### PR TITLE
CS-194 Chore/Eureka client 의존성 제거

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,6 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 
 	// MSA
-	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 
 	// Kafka
 	implementation 'org.springframework.kafka:spring-kafka'


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
Eureka Server를 사용하지 않는 관계로, eureka client 의존성을 제거했습니다.
---

## 🔗 관련 이슈
- closes #9 

---

## 💡 추가 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 더 이상 사용되지 않는 `spring-cloud-starter-netflix-eureka-client` 의존성이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->