### PR TITLE
CS-207 feat/이미지 저장 위한 presigned url 생성 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 
+	// Object Storage
+	implementation 'software.amazon.awssdk:s3:2.20.45'
+
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -67,9 +67,6 @@ dependencies {
 	testImplementation "org.testcontainers:mysql:1.20.1"
 	testImplementation 'org.testcontainers:junit-jupiter'
 
-	//H2 Database for Test
-	testImplementation("com.h2database:h2:2.3.232")
-
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 

--- a/src/main/java/com/playus/twpservice/domain/party/controller/PartyController.java
+++ b/src/main/java/com/playus/twpservice/domain/party/controller/PartyController.java
@@ -2,6 +2,8 @@ package com.playus.twpservice.domain.party.controller;
 
 import com.playus.twpservice.domain.party.dto.party_create.PartyCreateRequest;
 import com.playus.twpservice.domain.party.dto.party_create.PartyCreateResponse;
+import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageRequest;
+import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageResponse;
 import com.playus.twpservice.domain.party.service.PartyService;
 import com.playus.twpservice.domain.party.specification.PartyControllerSpecification;
 import jakarta.validation.Valid;
@@ -9,10 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/party")
@@ -24,5 +23,10 @@ public class PartyController implements PartyControllerSpecification {
     @PostMapping
     public ResponseEntity<PartyCreateResponse> createParty(@AuthenticationPrincipal Long userId, @Valid @RequestBody PartyCreateRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(partyService.createParty(userId, request));
+    }
+
+    @PostMapping("/presigned-url")
+    public PresignedUrlForSaveImageResponse generatePresignedUrlForSaveImage(@Valid @RequestBody PresignedUrlForSaveImageRequest request) {
+        return partyService.generatePresignedUrlForSaveImage(request);
     }
 }

--- a/src/main/java/com/playus/twpservice/domain/party/dto/presigned/PresignedUrlForSaveImageRequest.java
+++ b/src/main/java/com/playus/twpservice/domain/party/dto/presigned/PresignedUrlForSaveImageRequest.java
@@ -1,0 +1,11 @@
+package com.playus.twpservice.domain.party.dto.presigned;
+
+import jakarta.validation.constraints.NotBlank;
+
+
+public record PresignedUrlForSaveImageRequest (
+        @NotBlank(message = "이미지 파일명은 필수입니다!")
+        String imageFileName
+) {
+
+}

--- a/src/main/java/com/playus/twpservice/domain/party/dto/presigned/PresignedUrlForSaveImageResponse.java
+++ b/src/main/java/com/playus/twpservice/domain/party/dto/presigned/PresignedUrlForSaveImageResponse.java
@@ -1,15 +1,8 @@
 package com.playus.twpservice.domain.party.dto.presigned;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor
-public class PresignedUrlForSaveImageResponse {
+public record PresignedUrlForSaveImageResponse(
+        String presignedUrl
+) {
 
-    private String presignedUrl;
-
-    public PresignedUrlForSaveImageResponse(String presignedUrl) {
-        this.presignedUrl = presignedUrl;
-    }
 }

--- a/src/main/java/com/playus/twpservice/domain/party/dto/presigned/PresignedUrlForSaveImageResponse.java
+++ b/src/main/java/com/playus/twpservice/domain/party/dto/presigned/PresignedUrlForSaveImageResponse.java
@@ -1,0 +1,15 @@
+package com.playus.twpservice.domain.party.dto.presigned;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PresignedUrlForSaveImageResponse {
+
+    private String presignedUrl;
+
+    public PresignedUrlForSaveImageResponse(String presignedUrl) {
+        this.presignedUrl = presignedUrl;
+    }
+}

--- a/src/main/java/com/playus/twpservice/domain/party/service/PartyService.java
+++ b/src/main/java/com/playus/twpservice/domain/party/service/PartyService.java
@@ -2,6 +2,8 @@ package com.playus.twpservice.domain.party.service;
 
 import com.playus.twpservice.domain.party.dto.party_create.PartyCreateRequest;
 import com.playus.twpservice.domain.party.dto.party_create.PartyCreateResponse;
+import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageRequest;
+import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageResponse;
 import com.playus.twpservice.domain.party.entity.Party;
 import com.playus.twpservice.domain.party.entity.PartyAge;
 import com.playus.twpservice.domain.party.entity.PartyJoin;
@@ -44,6 +46,13 @@ public class PartyService {
         return PartyCreateResponse.of(party.getId(), Boolean.TRUE);
     }
 
+    public PresignedUrlForSaveImageResponse generatePresignedUrlForSaveImage(PresignedUrlForSaveImageRequest request) {
+        return null;
+    }
+
+
+
+
     private void saveThumbnailUrlIfPresent(PartyCreateRequest request, Party party) {
         if (thumbnailUrlExistsIn(request)) {
             List<PartyThumbnailUrl> partyThumbnailUrlList = toPartyThumbnailUrlEntity(request, party);
@@ -66,4 +75,6 @@ public class PartyService {
                 .map(age -> PartyAge.create(party, PartyAgeGroup.getAgeByDescription(age)))
                 .toList();
     }
+
+
 }

--- a/src/main/java/com/playus/twpservice/domain/party/service/PartyService.java
+++ b/src/main/java/com/playus/twpservice/domain/party/service/PartyService.java
@@ -14,6 +14,7 @@ import com.playus.twpservice.domain.party.repository.write.PartyAgeRepository;
 import com.playus.twpservice.domain.party.repository.write.PartyJoinRepository;
 import com.playus.twpservice.domain.party.repository.write.PartyRepository;
 import com.playus.twpservice.domain.party.repository.write.PartyThumbnailUrlRepository;
+import com.playus.twpservice.global.s3.S3PresignedUrlGenerator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,7 +27,7 @@ import java.util.Objects;
 @RequiredArgsConstructor
 public class PartyService {
 
-
+    private final S3PresignedUrlGenerator s3PresignedUrlGenerator;
     private final PartyRepository partyRepository;
     private final PartyJoinRepository partyJoinRepository;
     private final PartyAgeRepository partyAgeRepository;
@@ -47,7 +48,7 @@ public class PartyService {
     }
 
     public PresignedUrlForSaveImageResponse generatePresignedUrlForSaveImage(PresignedUrlForSaveImageRequest request) {
-        return null;
+        return new PresignedUrlForSaveImageResponse(s3PresignedUrlGenerator.generatePresignedUrl(request.imageFileName()));
     }
 
 

--- a/src/main/java/com/playus/twpservice/domain/party/specification/PartyControllerSpecification.java
+++ b/src/main/java/com/playus/twpservice/domain/party/specification/PartyControllerSpecification.java
@@ -2,6 +2,8 @@ package com.playus.twpservice.domain.party.specification;
 
 import com.playus.twpservice.domain.party.dto.party_create.PartyCreateRequest;
 import com.playus.twpservice.domain.party.dto.party_create.PartyCreateResponse;
+import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageRequest;
+import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -61,4 +63,41 @@ public interface PartyControllerSpecification {
             )
     })
     ResponseEntity<PartyCreateResponse> createParty(Long userId, PartyCreateRequest request);
+
+    @Tag(name = "Post", description = "Presigned URL 발급 API")
+    @Operation(
+            summary = "Presigned URL 발급",
+            description = "프론트에서 이미지를 직접 저장하기 위한 Presigned URL을 생성 및 반환합니다. (버킷에 저장할 때는 PUT으로)",
+            requestBody = @RequestBody(
+                    required = true,
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    name = "Presigned URL 발급 요청 예시",
+                                    value = """
+                    {
+                      "imageFileName": "party_thumbnail.jpg"
+                    }
+                    """
+                            )
+                    )
+            )
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "발급 성공",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    name = "Presigned URL 발급 응답 예시",
+                                    value = """
+                    {
+                      "presignedUrl": "http://presigned-url.com"
+                    }
+                    """
+                            )
+                    )
+            )
+    })
+    PresignedUrlForSaveImageResponse generatePresignedUrlForSaveImage(PresignedUrlForSaveImageRequest request);
 }

--- a/src/main/java/com/playus/twpservice/global/GlobalControllerAdvice.java
+++ b/src/main/java/com/playus/twpservice/global/GlobalControllerAdvice.java
@@ -11,6 +11,7 @@ import org.springframework.validation.BindException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import software.amazon.awssdk.core.exception.SdkException;
 
 @Slf4j
 @RestControllerAdvice(assignableTypes = {
@@ -36,6 +37,14 @@ public class GlobalControllerAdvice {
         String errorMessage = e.getMessage();
         log.warn("Validation Error: {}", errorMessage);
         return ResponseEntity.badRequest().body(errorMessage);
+    }
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(SdkException.class)
+    public ResponseEntity<String> sdkExceptionHandler(Exception e) {
+        String errorMessage = e.getMessage();
+        log.error("Object Storage Error: {}", errorMessage);
+        return ResponseEntity.internalServerError().body("서버 에러가 발생했습니다! 관리자에게 문의해 주세요!");
     }
 
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/main/java/com/playus/twpservice/global/s3/S3Config.java
+++ b/src/main/java/com/playus/twpservice/global/s3/S3Config.java
@@ -1,0 +1,37 @@
+package com.playus.twpservice.global.s3;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+import java.net.URI;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.s3.endpoint}")
+    private String endpoint;
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        return S3Presigner.builder()
+                .endpointOverride(URI.create(endpoint))
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(accessKey, secretKey)
+                        )
+                )
+                .region(Region.US_EAST_1)
+                .build();
+    }
+}

--- a/src/main/java/com/playus/twpservice/global/s3/S3Config.java
+++ b/src/main/java/com/playus/twpservice/global/s3/S3Config.java
@@ -3,6 +3,7 @@ package com.playus.twpservice.global.s3;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
@@ -10,6 +11,7 @@ import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 import java.net.URI;
 
+@Profile("!test")
 @Configuration
 public class S3Config {
 

--- a/src/main/java/com/playus/twpservice/global/s3/S3PresignedUrlGenerator.java
+++ b/src/main/java/com/playus/twpservice/global/s3/S3PresignedUrlGenerator.java
@@ -1,0 +1,36 @@
+package com.playus.twpservice.global.s3;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.time.Duration;
+
+@Component
+@RequiredArgsConstructor
+public class S3PresignedUrlGenerator {
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    private final S3Presigner s3Presigner;
+
+
+    public String generatePresignedUrl(String imageFileName) {
+
+        PutObjectRequest objectRequest = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(imageFileName)
+                .build();
+
+        PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofMinutes(10))
+                .putObjectRequest(objectRequest)
+                .build();
+
+        return s3Presigner.presignPutObject(presignRequest).url().toString();
+    }
+}

--- a/src/main/java/com/playus/twpservice/global/s3/S3PresignedUrlGenerator.java
+++ b/src/main/java/com/playus/twpservice/global/s3/S3PresignedUrlGenerator.java
@@ -21,16 +21,23 @@ public class S3PresignedUrlGenerator {
 
     public String generatePresignedUrl(String imageFileName) {
 
-        PutObjectRequest objectRequest = PutObjectRequest.builder()
+        PutObjectRequest objectRequest = createPutObjectRequest(imageFileName);
+        PutObjectPresignRequest presignRequest = createPresignedRequest(objectRequest, 10);
+
+        return s3Presigner.presignPutObject(presignRequest).url().toString();
+    }
+
+    private PutObjectRequest createPutObjectRequest(String imageFileName) {
+        return PutObjectRequest.builder()
                 .bucket(bucketName)
                 .key(imageFileName)
                 .build();
+    }
 
-        PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
-                .signatureDuration(Duration.ofMinutes(10))
+    private static PutObjectPresignRequest createPresignedRequest(PutObjectRequest objectRequest, int minutes) {
+        return PutObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofMinutes(minutes))
                 .putObjectRequest(objectRequest)
                 .build();
-
-        return s3Presigner.presignPutObject(presignRequest).url().toString();
     }
 }

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -34,3 +34,12 @@ spring:
         jdbc:
           time_zone: Asia/Seoul
         show_sql: true
+
+cloud:
+  aws:
+    credentials:
+      access-key: ${STORAGE_ACCESS_KEY}
+      secret-key: ${STORAGE_SECRET_KEY}
+    s3:
+      bucket : ${BUCKET_NAME}
+      endpoint : ${BUCKET_ENDPOINT}

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -33,6 +33,20 @@ spring:
         show_sql: true
 
   jwt:
-    secret: "secretkeysecretkeysecretkeysecretkeysecretkeysecretkeysecretkey"
+    secret: secretsecretsecretesecretesecretesecret
+
+cloud:
+  aws:
+    credentials:
+      access-key: ${STORAGE_ACCESS_KEY}
+      secret-key: ${STORAGE_SECRET_KEY}
+    s3:
+      bucket : ${BUCKET_NAME}
+      endpoint : ${BUCKET_ENDPOINT}
+
+
+
+
+
 
 

--- a/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
@@ -3,6 +3,8 @@ package com.playus.twpservice.domain.party.controller;
 import com.playus.twpservice.ControllerTestSupport;
 import com.playus.twpservice.domain.party.dto.party_create.PartyCreateRequest;
 import com.playus.twpservice.domain.party.dto.party_create.PartyCreateResponse;
+import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageRequest;
+import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -21,8 +23,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 class PartyControllerTest extends ControllerTestSupport {
 
@@ -50,13 +51,12 @@ class PartyControllerTest extends ControllerTestSupport {
     }
 
 
-
     @DisplayName("직관팟 생성 중 제목은 필수이다.")
     @NullAndEmptySource
     @ParameterizedTest(name = "title = {0}")
     void createParty_EMPTY_TITLE(String emptyTitle) throws Exception {
         // given
-        PartyCreateRequest request = PartyCreateRequest.of(emptyTitle, "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl,"message");
+        PartyCreateRequest request = PartyCreateRequest.of(emptyTitle, "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
         PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
@@ -68,7 +68,7 @@ class PartyControllerTest extends ControllerTestSupport {
     @Test
     void createParty_EXCEED_TITLE() throws Exception {
         String exceedTitle = "a".repeat(226);
-        PartyCreateRequest request = PartyCreateRequest.of(exceedTitle, "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl,"message");
+        PartyCreateRequest request = PartyCreateRequest.of(exceedTitle, "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
         PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
@@ -77,14 +77,12 @@ class PartyControllerTest extends ControllerTestSupport {
     }
 
 
-
-
     @DisplayName("직관팟 생성 중 신청 방식은 필수이다.")
     @NullAndEmptySource
     @ParameterizedTest(name = "method = {0}")
     void createParty_EMPTY_METHOD(String emptyMethod) throws Exception {
         // given
-        PartyCreateRequest request = PartyCreateRequest.of("제목", emptyMethod, "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl,"message");
+        PartyCreateRequest request = PartyCreateRequest.of("제목", emptyMethod, "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
         PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
@@ -97,7 +95,7 @@ class PartyControllerTest extends ControllerTestSupport {
     @ParameterizedTest(name = "method = {0}")
     void createParty_INVALID_METHOD(String invalidMethod) throws Exception {
         // given
-        PartyCreateRequest request = PartyCreateRequest.of("제목", invalidMethod, "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl,"message");
+        PartyCreateRequest request = PartyCreateRequest.of("제목", invalidMethod, "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
         PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
@@ -106,16 +104,12 @@ class PartyControllerTest extends ControllerTestSupport {
     }
 
 
-
-
-
-
     @DisplayName("직관팟 생성 중 참여 원하는 성별은 필수이다.")
     @NullAndEmptySource
     @ParameterizedTest(name = "gender = {0}")
     void createParty_EMPTY_GENDER(String emptyGender) throws Exception {
         // given
-        PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", emptyGender, List.of("10대", "20대"), 1L, 10L, thumbnailUrl,"message");
+        PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", emptyGender, List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
         PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
@@ -128,7 +122,7 @@ class PartyControllerTest extends ControllerTestSupport {
     @ParameterizedTest(name = "gender = {0}")
     void createParty_INVALID_GENDER(String invalidGender) throws Exception {
         // given
-        PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", invalidGender, List.of("10대", "20대"), 1L, 10L, thumbnailUrl,"message");
+        PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", invalidGender, List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
         PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
@@ -157,15 +151,13 @@ class PartyControllerTest extends ControllerTestSupport {
     }
 
 
-
-
     @DisplayName("직관팟 생성 중 참여자 나이는 필수이다.")
     @NullAndEmptySource
     @ParameterizedTest(name = "age = {0}")
     void createParty_EMPTY_AGE(List<String> emptyAgeList) throws Exception {
 
         // given
-        PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", emptyAgeList, 1L, 10L, thumbnailUrl,"message");
+        PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", emptyAgeList, 1L, 10L, thumbnailUrl, "message");
         PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
@@ -179,7 +171,7 @@ class PartyControllerTest extends ControllerTestSupport {
     void createParty_INVALID_AGE(List<String> emptyAgeList) throws Exception {
 
         // given
-        PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", emptyAgeList, 1L, 10L, thumbnailUrl,"message");
+        PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", emptyAgeList, 1L, 10L, thumbnailUrl, "message");
         PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
@@ -204,7 +196,7 @@ class PartyControllerTest extends ControllerTestSupport {
 
         // given
         List<String> tooManyAgeList = List.of("10대", "20대", "30대", "40대", "50대", "60대 이상", "70대", "80대", "90대");
-        PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", tooManyAgeList, 1L, 10L, thumbnailUrl,"message");
+        PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", tooManyAgeList, 1L, 10L, thumbnailUrl, "message");
         PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
@@ -213,11 +205,10 @@ class PartyControllerTest extends ControllerTestSupport {
     }
 
 
-
     @DisplayName("직관팟 최소 인원은 필수이다.")
     @Test
     void createParty_EMPTY_MINIMUM() throws Exception {
-        PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), null, 10L, thumbnailUrl,"message");
+        PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), null, 10L, thumbnailUrl, "message");
         PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
@@ -228,7 +219,7 @@ class PartyControllerTest extends ControllerTestSupport {
     @DisplayName("직관팟 최소 인원은 1 이상이여야 한다.")
     @Test
     void createParty_INVALID_MINIMUM() throws Exception {
-        PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), 0L, 10L, thumbnailUrl,"message");
+        PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), 0L, 10L, thumbnailUrl, "message");
         PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
@@ -237,11 +228,10 @@ class PartyControllerTest extends ControllerTestSupport {
     }
 
 
-
     @DisplayName("직관팟 최대 인원은 필수이다.")
     @Test
     void createParty_EMPTY_MAXIMUM() throws Exception {
-        PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), 1L, null, thumbnailUrl,"message");
+        PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), 1L, null, thumbnailUrl, "message");
         PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
@@ -252,15 +242,13 @@ class PartyControllerTest extends ControllerTestSupport {
     @DisplayName("직관팟 최소 인원은 최대 인원보다 클 수 없다.")
     @Test
     void createParty_MINIMUM_MAXIMUM() throws Exception {
-        PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), 10L, 9L, thumbnailUrl,"message");
+        PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), 10L, 9L, thumbnailUrl, "message");
         PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
         // when // then
         assertBadRequestOfPartyCreateRequest(request, "/party", "최소 참여 인원은 최대 참여 인원보다 클 수 없습니다!");
     }
-
-
 
 
     @DisplayName("직관팟 생성 중 사진 url은 비어 있거나, http/https/ftp로 시작해야 한다.")
@@ -290,7 +278,7 @@ class PartyControllerTest extends ControllerTestSupport {
                 Arguments.of(List.of("https://image.com")),
                 Arguments.of(Arrays.asList("http://image.com", "https://image.com")),
                 Arguments.of(Arrays.asList("http://image.co.kr", "https://image.com", "ftp://image.com"))
-                );
+        );
     }
 
     @DisplayName("직관팟 생성 중 사진 url은 최대 10개까지만 담을 수 있다.")
@@ -298,8 +286,8 @@ class PartyControllerTest extends ControllerTestSupport {
     void createParty_NULL_IMAGE_URL() throws Exception {
         // given
         List<String> tooManyUrlList = List.of("http://image.com", "https://image.com", "ftp://image.com", "http://image.com",
-                                                        "https://image.com", "ftp://image.com", "ftp://image.com", "http://image.com",
-                                                        "https://image.com", "ftp://image.com", "http://image.com");
+                "https://image.com", "ftp://image.com", "ftp://image.com", "http://image.com",
+                "https://image.com", "ftp://image.com", "http://image.com");
         PartyCreateRequest request = PartyCreateRequest.of("title", "선착순", "남자만", List.of("10대", "20대"),
                 1L, 10L, tooManyUrlList, "message");
         PartyCreateResponse response = PartyCreateResponse.of(1L, true);
@@ -328,12 +316,8 @@ class PartyControllerTest extends ControllerTestSupport {
                 Arguments.of(List.of("!@#$%%", "#$%^&%$#", "#(*##$#$")),
                 Arguments.of(Arrays.asList("사진 URL", "IMAGE URL")),
                 Arguments.of(Arrays.asList("abc@123.com", "www.abc.com"))
-                );
+        );
     }
-
-
-
-
 
 
     @DisplayName("직관팟 생성 중 소개 문구는 필수이다.")
@@ -341,7 +325,7 @@ class PartyControllerTest extends ControllerTestSupport {
     @ParameterizedTest(name = "message = {0}")
     void createParty_EMPTY_MESSAGE(String emptyMessage) throws Exception {
         // given
-        PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl,emptyMessage);
+        PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, emptyMessage);
         PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
@@ -361,6 +345,44 @@ class PartyControllerTest extends ControllerTestSupport {
         // when // then
         assertBadRequestOfPartyCreateRequest(request, "/party", "직관팟 소개 문구의 길이를 1~100자 이내로 작성해 주세요!");
     }
+
+
+    @DisplayName("이미지 저장을 위한 Presigned URL을 발급해줄 수 있다.")
+    @Test
+    void generatePresignedUrlForSaveImage() throws Exception {
+        // given
+        PresignedUrlForSaveImageRequest request = new PresignedUrlForSaveImageRequest("image.jpg");
+        given(partyService.generatePresignedUrlForSaveImage(any(PresignedUrlForSaveImageRequest.class)))
+                .willReturn(new PresignedUrlForSaveImageResponse("https://presigned-url.com"));
+
+        // when // then
+        mockMvc.perform(post("/party/presigned-url")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(APPLICATION_JSON)
+                        .with(authentication(token)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.presignedUrl").value("https://presigned-url.com"));
+    }
+
+    @DisplayName("URL 발급을 위해서 이미지 파일명은 필수이다.")
+    @NullAndEmptySource
+    @ParameterizedTest(name = "url = {0}")
+    void generatePresignedUrlForSaveImage_BLANK_IMAGE_NAME(String blankImageFileName) throws Exception {
+      // given
+        PresignedUrlForSaveImageRequest request = new PresignedUrlForSaveImageRequest(blankImageFileName);
+
+      // when // then
+        mockMvc.perform(post("/party/presigned-url")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(APPLICATION_JSON)
+                        .with(authentication(token)))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string("이미지 파일명은 필수입니다!"));
+
+    }
+
 
     private void assertBadRequestOfPartyCreateRequest(PartyCreateRequest request, String requestUri, String expectedResult) throws Exception {
         String responseBody = mockMvc.perform(post(requestUri)

--- a/src/test/java/com/playus/twpservice/domain/party/service/PartyServiceTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/service/PartyServiceTest.java
@@ -61,7 +61,8 @@ class PartyServiceTest extends IntegrationTestSupport {
     void createParty() {
         // given
         Long userId = 1L;
-        PartyCreateRequest request = PartyCreateRequest.of("title", "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, List.of("url"), "message");
+        PartyCreateRequest request = PartyCreateRequest.of("title", "선착순", "남자만", List.of("10대", "20대"),
+                1L, 10L, List.of("url", "url2"), "message");
 
         // when
         PartyCreateResponse result = partyService.createParty(userId, request);
@@ -69,7 +70,7 @@ class PartyServiceTest extends IntegrationTestSupport {
         // then
         assertThat(partyRepository.count()).isEqualTo(1);
         assertThat(partyJoinRepository.count()).isEqualTo(1);
-        assertThat(partyThumbnailUrlRepository.count()).isEqualTo(1);
+        assertThat(partyThumbnailUrlRepository.count()).isEqualTo(2);
 
         Party savedParty = partyRepository.findAll().get(0);
         assertThat(savedParty.getTitle()).isEqualTo("title");
@@ -83,8 +84,11 @@ class PartyServiceTest extends IntegrationTestSupport {
         assertThat(savedPartyJoin.getStatus()).isEqualTo(Status.ACCEPT);
         assertThat(savedPartyJoin.getRequireMessage()).isNull();
 
-        PartyThumbnailUrl savedPartyUrl = partyThumbnailUrlRepository.findAll().get(0);
-        assertThat(savedPartyUrl.getThumbnailUrl()).isEqualTo("url");
+        List<PartyThumbnailUrl> savedUrl = partyThumbnailUrlRepository.findAll();
+        assertThat(savedUrl).hasSize(2);
+        assertThat(savedUrl)
+                .extracting("thumbnailUrl")
+                .containsExactlyInAnyOrder("url", "url2");
 
         List<PartyAge> savedPartyAges = partyAgeRepository.findAll();
         assertThat(savedPartyAges).hasSize(2);
@@ -95,7 +99,7 @@ class PartyServiceTest extends IntegrationTestSupport {
 
         Long savedPartyId = savedParty.getId();
         assertThat(savedPartyJoin.getParty().getId()).isEqualTo(savedPartyId);
-        assertThat(savedPartyUrl.getParty().getId()).isEqualTo(savedPartyId);
+        assertThat(savedUrl).allMatch(url -> url.getParty().getId().equals(savedPartyId));
         assertThat(savedPartyAges).allMatch(age -> age.getParty().getId().equals(savedPartyId));
     }
 

--- a/src/test/java/com/playus/twpservice/domain/party/service/PartyServiceTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/service/PartyServiceTest.java
@@ -14,10 +14,12 @@ import com.playus.twpservice.domain.party.repository.write.PartyAgeRepository;
 import com.playus.twpservice.domain.party.repository.write.PartyJoinRepository;
 import com.playus.twpservice.domain.party.repository.write.PartyRepository;
 import com.playus.twpservice.domain.party.repository.write.PartyThumbnailUrlRepository;
+import com.playus.twpservice.global.s3.S3PresignedUrlGenerator;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.util.List;
 
@@ -27,6 +29,9 @@ class PartyServiceTest extends IntegrationTestSupport {
 
     @Autowired
     private PartyService partyService;
+
+    @MockitoBean
+    private S3PresignedUrlGenerator s3PresignedUrlGenerator;
 
     @Autowired
     private PartyRepository partyRepository;

--- a/src/test/java/com/playus/twpservice/domain/party/service/PartyServiceTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/service/PartyServiceTest.java
@@ -147,7 +147,7 @@ class PartyServiceTest extends IntegrationTestSupport {
         PresignedUrlForSaveImageResponse result = partyService.generatePresignedUrlForSaveImage(request);
 
         // then
-        assertThat(result.getPresignedUrl()).isEqualTo(responseUrl);
+        assertThat(result.presignedUrl()).isEqualTo(responseUrl);
     }
 
 }

--- a/src/test/java/com/playus/twpservice/domain/party/service/PartyServiceTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/service/PartyServiceTest.java
@@ -3,6 +3,8 @@ package com.playus.twpservice.domain.party.service;
 import com.playus.twpservice.IntegrationTestSupport;
 import com.playus.twpservice.domain.party.dto.party_create.PartyCreateRequest;
 import com.playus.twpservice.domain.party.dto.party_create.PartyCreateResponse;
+import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageRequest;
+import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageResponse;
 import com.playus.twpservice.domain.party.entity.Party;
 import com.playus.twpservice.domain.party.entity.PartyAge;
 import com.playus.twpservice.domain.party.entity.PartyJoin;
@@ -24,6 +26,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.*;
 
 class PartyServiceTest extends IntegrationTestSupport {
 
@@ -132,5 +135,19 @@ class PartyServiceTest extends IntegrationTestSupport {
         assertThat(partyThumbnailUrlRepository.count()).isZero();
     }
 
+    @DisplayName("이미지 저장 위한 Presigned URL 을 발급받을 수 있다.")
+    @Test
+    void generatePresignedUrlForSaveImage() {
+        // given
+        String responseUrl = "http://presigned-url.com";
+        PresignedUrlForSaveImageRequest request = new PresignedUrlForSaveImageRequest("image.jpg");
+        given(s3PresignedUrlGenerator.generatePresignedUrl(request.imageFileName())).willReturn(responseUrl);
+
+        // when
+        PresignedUrlForSaveImageResponse result = partyService.generatePresignedUrlForSaveImage(request);
+
+        // then
+        assertThat(result.getPresignedUrl()).isEqualTo(responseUrl);
+    }
 
 }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
프론트에서 bucket으로 이미지를 저장하기 위한 Presigned URL 발급 기능을 구현했습니다. 이는 MultipartFile이나 base64로 인코딩된 이미지를 서버에 보내고, 서버에서 이를 S3에 저장하는 방식은 서버 과부하가 예상되므로 프론트가 서버에서 발급받은 Presigned URL을 PUT 으로 직접 저장을 요청하는 방식으로 이뤄집니다.  (카카오 클라우드의 Object Storage에서 Presigned URL 발급이 되는지 확실하지 않아, 이미지 저장 방식은 추후 바뀔 수 있습니다!)

(https://velog.io/@jjeongdong/AWS-PresignedURL-%EC%82%AC%EC%9A%A9%ED%95%98%EC%97%AC-S3%EC%97%90-%EC%9D%B4%EB%AF%B8%EC%A7%80-%EC%97%85%EB%A1%9C%EB%93%9C)

AWS API를 이용했기에 기존 JUnit5, Mockito 등으로 테스트를 하는 건 제대로 URL 발급이 되는지 확인하는 건 어려울 거 같아서, Postman 으로 Presigned URL이 발급되는 지 테스트했습니다. 
(Mockito를 통해 Controller 테스트와 Service 단에서 Response 생성하는 테스트 케이스는 작성했습니다!) 

하지만 Postman으로 이미지를 저장하려 시도할 때, jpg와 png 파일 모두 첨부가 되지 않아서 관련해서는 QA 기간에 프론트와 테스트를 진행하겠습니다. 

첫 CI에서의 Test 실패는 application-test.yaml 에서 s3 관련 설정을 하지 않아 `S3PresignedUrlGenerator` 이 제대로 만들어지지 않았기에 발생했습니다. 따라서 아래처럼 `@Profile("!test")` 와 `@MockitoBean` 을 통해 해결했습니다!


```
@Profile("!test")
@Configuration
public class S3Config {

    @Value("${cloud.aws.credentials.access-key}")
    private String accessKey;

    @Value("${cloud.aws.credentials.secret-key}")
    private String secretKey;

    @Value("${cloud.aws.s3.endpoint}")
    private String endpoint;

    @Bean
    public S3Presigner s3Presigner() {
        return S3Presigner.builder()
                .endpointOverride(URI.create(endpoint))
                .credentialsProvider(
                        StaticCredentialsProvider.create(
                                AwsBasicCredentials.create(accessKey, secretKey)
                        )
                )
                .region(Region.US_EAST_1)
                .build();
    }
}
```

```
class PartyServiceTest extends IntegrationTestSupport {

    @Autowired
    private PartyService partyService;

    @MockitoBean
    private S3PresignedUrlGenerator s3PresignedUrlGenerator;

    @Autowired
    private PartyRepository partyRepository;

    @Autowired
    private PartyJoinRepository partyJoinRepository;

    @Autowired
    private PartyAgeRepository partyAgeRepository;

    @Autowired
    private PartyThumbnailUrlRepository partyThumbnailUrlRepository;
```
<br/>

dev.yaml에 변화가 있어서 공유합니다. 하단에 aws 관련 요소가 추가되었습니다.

```
spring:
  application:
    name: twp-service

  datasource:
    url: ${DB_URL}
    username: ${DB_USER}
    password: ${DB_PASSWORD}
    driver-class-name: com.mysql.cj.jdbc.Driver

  data:
    mongodb:
      read:
        uri: ${MONGO_READ_URI}

      chat:
        uri: ${MONGO_CHAT_URI}

    redis:
      host: ${REDIS_HOST}
      port: ${REDIS_PORT}

  jwt:
    secret: ${JWT_SECRET}

  jpa:
    show-sql: true
    hibernate:
      ddl-auto: update
    database: mysql
    properties:
      hibernate:
        format_sql: true
        jdbc:
          time_zone: Asia/Seoul
        show_sql: true

cloud:
  aws:
    credentials:
      access-key: ${STORAGE_ACCESS_KEY}
      secret-key: ${STORAGE_SECRET_KEY}
    s3:
      bucket : ${BUCKET_NAME}
      endpoint : ${BUCKET_ENDPOINT}
```  

---

## 🔗 관련 이슈
- closes #12 

---

## 💡 추가 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **신규 기능**
    - 이미지 저장을 위한 S3 Presigned URL 발급용 POST 엔드포인트가 추가되었습니다.
- **설정**
    - AWS S3 연동을 위한 SDK 의존성 및 관련 설정이 추가되었습니다.
    - 개발 및 로컬 환경 설정에 AWS 자격증명 및 S3 버킷 정보 환경변수가 포함되었습니다.
- **테스트**
    - Presigned URL 발급 기능에 대한 정상 동작 및 유효성 검증 테스트가 추가되었습니다.
- **기타**
    - AWS SDK 관련 예외 처리 핸들러가 추가되어 오류 발생 시 사용자에게 안내 메시지를 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->