### PR TITLE
chore : 이슈 생성 타입 Story/Subtask 체계에서 Task만 만들어지도록 변경

### DIFF
--- a/.github/workflows/create-jira-chore-issue.yml
+++ b/.github/workflows/create-jira-chore-issue.yml
@@ -48,7 +48,7 @@ jobs:
         uses: atlassian/gajira-create@v3
         with:
           project: CS # JIRA KEY
-          issuetype: 스토리
+          issuetype: Task
           summary: "${{ github.event.issue.title }}"
           description: "${{ steps.md2jira.outputs.output-text }}"
           fields: |

--- a/.github/workflows/create-jira-feat-issue.yml
+++ b/.github/workflows/create-jira-feat-issue.yml
@@ -48,7 +48,7 @@ jobs:
         uses: atlassian/gajira-create@v3
         with:
           project: CS # JIRA KEY
-          issuetype: 스토리
+          issuetype: Task
           summary: "${{ github.event.issue.title }}"
           description: "${{ steps.md2jira.outputs.output-text }}"
           fields: |

--- a/.github/workflows/create-jira-fix-issue.yml
+++ b/.github/workflows/create-jira-fix-issue.yml
@@ -48,7 +48,7 @@ jobs:
         uses: atlassian/gajira-create@v3
         with:
           project: CS # JIRA KEY
-          issuetype: 하위 작업 # Task, Subtask 아님!
+          issuetype: Task
           summary: "${{ github.event.issue.title }}"
           description: "${{ steps.md2jira.outputs.output-text }}"
           fields: |

--- a/.github/workflows/create-jira-performance-issue.yml
+++ b/.github/workflows/create-jira-performance-issue.yml
@@ -48,7 +48,7 @@ jobs:
         uses: atlassian/gajira-create@v3
         with:
           project: CS # JIRA KEY
-          issuetype: 하위 작업 # Task, Subtask 아님!
+          issuetype: Task
           summary: "${{ github.event.issue.title }}"
           description: "${{ steps.md2jira.outputs.output-text }}"
           fields: |

--- a/.github/workflows/create-jira-refactor-issue.yml
+++ b/.github/workflows/create-jira-refactor-issue.yml
@@ -48,7 +48,7 @@ jobs:
         uses: atlassian/gajira-create@v3
         with:
           project: CS # JIRA KEY
-          issuetype: 하위 작업 # Task, Subtask 아님!
+          issuetype: Task
           summary: "${{ github.event.issue.title }}"
           description: "${{ steps.md2jira.outputs.output-text }}"
           fields: |


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
이슈 타입 관계없이 Jira에서 전부 Task만 만들어지도록 수정햇습니다!

---

## 🔗 관련 이슈
- closes #14 

---

## 💡 추가 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
    - Jira 이슈 생성 시 사용되는 이슈 유형이 기존의 비영어(한국어) 라벨에서 영어 "Task"로 변경되었습니다. 이제 모든 워크플로우에서 Jira 이슈가 "Task" 유형으로 생성됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->