### PR TITLE
CS-217 refactor/에러 발생 시 ErrorResponse 클래스 통해 반환하도록 리팩토링

### DIFF
--- a/.github/ISSUE_TEMPLATE/chore-issue-form.yml
+++ b/.github/ISSUE_TEMPLATE/chore-issue-form.yml
@@ -16,7 +16,7 @@ body:
     id : parentKey
     attributes:
       label: '상위 작업 (Epic, 보라색 번개) Ticket Number'
-      description: '상위 직업 (Epic, 보라색 아이콘) 의 Ticket Number를 기입해주세요, 노션에서도 확인 가능'
+      description: '상위 작업 (Epic, 보라색 아이콘) 의 Ticket Number를 기입해주세요, 노션에서도 확인 가능'
       value: CS-00
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feat-issue-form.yml
+++ b/.github/ISSUE_TEMPLATE/feat-issue-form.yml
@@ -12,11 +12,11 @@ body:
         제목은 반드시 `Feat/ ~` 형식으로 작성해주세요.  
         예: `Feat/A 기능 구현`
 
-  - type : input
-    id : parentKey
+  - type: input
+    id: parentKey
     attributes:
-      label: '상위 직업 (Epic, 보라색 번개) Ticket Number'
-      description: '상위 직업 (Epic, 보라색 아이콘) 의 Ticket Number 기입해주세요, 노션에서도 확인 가능'
+      label: '상위 작업 (Epic, 보라색 번개) Ticket Number'
+      description: '상위 작업 (Epic, 보라색 아이콘) 의 Ticket Number를 기입해주세요, 노션에서도 확인 가능'
       value: CS-00
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/fix-issue-form.yml
+++ b/.github/ISSUE_TEMPLATE/fix-issue-form.yml
@@ -12,11 +12,11 @@ body:
         제목은 반드시 `Fix/ ~` 형식으로 작성해주세요.  
         예: `Fix/A 기능 중 B 에러`
 
-  - type : input
-    id : parentKey
+  - type: input
+    id: parentKey
     attributes:
-      label: '상위 작업 (Story, 초록색 책갈피) Ticket Number'
-      description: '상위 직업 (Story, 초록색 아이콘) 의 Ticket Number를 기입해주세요, 노션에서도 확인 가능'
+      label: '상위 작업 (Epic, 보라색 번개) Ticket Number'
+      description: '상위 작업 (Epic, 보라색 아이콘) 의 Ticket Number를 기입해주세요, 노션에서도 확인 가능'
       value: CS-00
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/performance-issue-form.yml
+++ b/.github/ISSUE_TEMPLATE/performance-issue-form.yml
@@ -12,11 +12,11 @@ body:
         제목은 반드시 `Performance/ ~` 형식으로 작성해주세요.  
         예: `Performance/A 기능 성능 개선`
 
-  - type : input
-    id : parentKey
+  - type: input
+    id: parentKey
     attributes:
-      label: '상위 작업 (Story, 초록색 책갈피) Ticket Number'
-      description: '상위 직업 (Story, 초록색 아이콘) 의 Ticket Number를 기입해주세요, 노션에서도 확인 가능'
+      label: '상위 작업 (Epic, 보라색 번개) Ticket Number'
+      description: '상위 작업 (Epic, 보라색 아이콘) 의 Ticket Number를 기입해주세요, 노션에서도 확인 가능'
       value: CS-00
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/refactor-issue-form.yml
+++ b/.github/ISSUE_TEMPLATE/refactor-issue-form.yml
@@ -12,11 +12,11 @@ body:
         제목은 반드시 `Refactor/ ~` 형식으로 작성해주세요.  
         예: `Refactor/A 기능 리팩토링`
 
-  - type : input
-    id : parentKey
+  - type: input
+    id: parentKey
     attributes:
-      label: '상위 작업 (Story, 초록색 책갈피) Ticket Number'
-      description: '상위 직업 (Story, 초록색 아이콘) 의 Ticket Number를 기입해주세요, 노션에서도 확인 가능'
+      label: '상위 작업 (Epic, 보라색 번개) Ticket Number'
+      description: '상위 작업 (Epic, 보라색 아이콘) 의 Ticket Number를 기입해주세요, 노션에서도 확인 가능'
       value: CS-00
     validations:
       required: true

--- a/src/main/java/com/playus/twpservice/global/GlobalControllerAdvice.java
+++ b/src/main/java/com/playus/twpservice/global/GlobalControllerAdvice.java
@@ -4,9 +4,9 @@ import com.playus.twpservice.domain.party.controller.PartyController;
 import com.playus.twpservice.domain.party.exception.enums.PartyAgeGroupExceptionGroup;
 import com.playus.twpservice.domain.party.exception.enums.PartyGenderExceptionGroup;
 import com.playus.twpservice.domain.party.exception.enums.PartyJoinMethodExceptionGroup;
+import com.playus.twpservice.global.response.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -21,10 +21,10 @@ public class GlobalControllerAdvice {
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(BindException.class)
-    public ResponseEntity<String> bindExceptionHandler(BindException e) {
+    public ErrorResponse bindExceptionHandler(BindException e) {
         String errorMessage = e.getAllErrors().get(0).getDefaultMessage();
         log.warn("Validation Error: {}", errorMessage);
-        return ResponseEntity.badRequest().body(errorMessage);
+        return ErrorResponse.badRequestError(errorMessage);
     }
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)
@@ -33,25 +33,25 @@ public class GlobalControllerAdvice {
             PartyJoinMethodExceptionGroup.InvalidDescriptionException.class,
             PartyAgeGroupExceptionGroup.InvalidDescriptionException.class
     })
-    public ResponseEntity<String> invalidDescriptionExceptionHandler(Exception e) {
+    public ErrorResponse invalidDescriptionExceptionHandler(Exception e) {
         String errorMessage = e.getMessage();
         log.warn("Validation Error: {}", errorMessage);
-        return ResponseEntity.badRequest().body(errorMessage);
+        return ErrorResponse.badRequestError(errorMessage);
     }
 
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(SdkException.class)
-    public ResponseEntity<String> sdkExceptionHandler(Exception e) {
+    public ErrorResponse sdkExceptionHandler(Exception e) {
         String errorMessage = e.getMessage();
         log.error("Object Storage Error: {}", errorMessage);
-        return ResponseEntity.internalServerError().body("서버 에러가 발생했습니다! 관리자에게 문의해 주세요!");
+        return ErrorResponse.internalServerError("서버 에러가 발생했습니다! 관리자에게 문의해 주세요!");
     }
 
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<String> otherExceptionHandler(Exception e) {
+    public ErrorResponse otherExceptionHandler(Exception e) {
         String errorMessage = e.getMessage();
         log.error("Unexpected Error: {}", errorMessage);
-        return ResponseEntity.internalServerError().body("서버 에러가 발생했습니다! 관리자에게 문의해 주세요!");
+        return ErrorResponse.internalServerError("서버 에러가 발생했습니다! 관리자에게 문의해 주세요!");
     }
 }

--- a/src/main/java/com/playus/twpservice/global/response/ErrorResponse.java
+++ b/src/main/java/com/playus/twpservice/global/response/ErrorResponse.java
@@ -34,11 +34,11 @@ public record ErrorResponse(
 
 
 
-    private static ErrorResponse createErrorResponse(HttpStatus badRequest, String message) {
+    private static ErrorResponse createErrorResponse(HttpStatus errorStatus, String errorMessage) {
         return ErrorResponse.builder()
-                .code(badRequest.value())
-                .status(badRequest)
-                .message(message)
+                .code(errorStatus.value())
+                .status(errorStatus)
+                .message(errorMessage)
                 .build();
     }
 }

--- a/src/main/java/com/playus/twpservice/global/response/ErrorResponse.java
+++ b/src/main/java/com/playus/twpservice/global/response/ErrorResponse.java
@@ -1,0 +1,48 @@
+package com.playus.twpservice.global.response;
+
+import lombok.Builder;
+import org.springframework.http.HttpStatus;
+
+@Builder
+public record ErrorResponse(
+   int code,
+   HttpStatus status,
+   String message
+) {
+
+    public static ErrorResponse badRequestError (String message) {
+        return ErrorResponse.builder()
+                .status(HttpStatus.BAD_REQUEST)
+                .message(message)
+                .build();
+    }
+
+    public static ErrorResponse unauthorizedError (String message) {
+        return ErrorResponse.builder()
+                .status(HttpStatus.UNAUTHORIZED)
+                .message(message)
+                .build();
+    }
+
+    public static ErrorResponse forbiddenError (String message) {
+        return ErrorResponse.builder()
+                .status(HttpStatus.FORBIDDEN)
+                .message(message)
+                .build();
+    }
+
+    public static ErrorResponse notFoundError(String errorMessage) {
+        return ErrorResponse.builder()
+                .status(HttpStatus.NOT_FOUND)
+                .message(errorMessage)
+                .build();
+    }
+
+
+    public static ErrorResponse internalServerError (String message) {
+        return ErrorResponse.builder()
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .message(message)
+                .build();
+    }
+}

--- a/src/main/java/com/playus/twpservice/global/response/ErrorResponse.java
+++ b/src/main/java/com/playus/twpservice/global/response/ErrorResponse.java
@@ -26,6 +26,8 @@ public record ErrorResponse(
         return createErrorResponse(HttpStatus.NOT_FOUND, errorMessage);
     }
 
+
+
     public static ErrorResponse internalServerError (String errorMessage) {
         return createErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, errorMessage);
     }

--- a/src/main/java/com/playus/twpservice/global/response/ErrorResponse.java
+++ b/src/main/java/com/playus/twpservice/global/response/ErrorResponse.java
@@ -26,13 +26,9 @@ public record ErrorResponse(
         return createErrorResponse(HttpStatus.NOT_FOUND, errorMessage);
     }
 
-
-
     public static ErrorResponse internalServerError (String errorMessage) {
         return createErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, errorMessage);
     }
-
-
 
     private static ErrorResponse createErrorResponse(HttpStatus errorStatus, String errorMessage) {
         return ErrorResponse.builder()

--- a/src/main/java/com/playus/twpservice/global/response/ErrorResponse.java
+++ b/src/main/java/com/playus/twpservice/global/response/ErrorResponse.java
@@ -10,38 +10,32 @@ public record ErrorResponse(
    String message
 ) {
 
-    public static ErrorResponse badRequestError (String message) {
-        return ErrorResponse.builder()
-                .status(HttpStatus.BAD_REQUEST)
-                .message(message)
-                .build();
+    public static ErrorResponse badRequestError (String errorMessage) {
+        return createErrorResponse(HttpStatus.BAD_REQUEST, errorMessage);
     }
 
-    public static ErrorResponse unauthorizedError (String message) {
-        return ErrorResponse.builder()
-                .status(HttpStatus.UNAUTHORIZED)
-                .message(message)
-                .build();
+    public static ErrorResponse unauthorizedError (String errorMessage) {
+        return createErrorResponse(HttpStatus.UNAUTHORIZED, errorMessage);
     }
 
-    public static ErrorResponse forbiddenError (String message) {
-        return ErrorResponse.builder()
-                .status(HttpStatus.FORBIDDEN)
-                .message(message)
-                .build();
+    public static ErrorResponse forbiddenError (String errorMessage) {
+        return createErrorResponse(HttpStatus.FORBIDDEN, errorMessage);
     }
 
     public static ErrorResponse notFoundError(String errorMessage) {
-        return ErrorResponse.builder()
-                .status(HttpStatus.NOT_FOUND)
-                .message(errorMessage)
-                .build();
+        return createErrorResponse(HttpStatus.NOT_FOUND, errorMessage);
+    }
+
+    public static ErrorResponse internalServerError (String errorMessage) {
+        return createErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, errorMessage);
     }
 
 
-    public static ErrorResponse internalServerError (String message) {
+
+    private static ErrorResponse createErrorResponse(HttpStatus badRequest, String message) {
         return ErrorResponse.builder()
-                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .code(badRequest.value())
+                .status(badRequest)
                 .message(message)
                 .build();
     }

--- a/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
@@ -49,7 +49,6 @@ class PartyControllerTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.success").value("true"));
     }
 
-
     @DisplayName("직관팟 생성 중 제목은 필수이다.")
     @NullAndEmptySource
     @ParameterizedTest(name = "title = {0}")
@@ -74,7 +73,6 @@ class PartyControllerTest extends ControllerTestSupport {
         // when // then
         assertBadRequestOfPartyCreateRequest(request, "/party", "제목의 길이를 1~225자 이내로 작성해 주세요!");
     }
-
 
     @DisplayName("직관팟 생성 중 신청 방식은 필수이다.")
     @NullAndEmptySource
@@ -101,7 +99,6 @@ class PartyControllerTest extends ControllerTestSupport {
         // when // then
         assertBadRequestOfPartyCreateRequest(request, "/party", "잘못된 신청 방식입니다!");
     }
-
 
     @DisplayName("직관팟 생성 중 참여 원하는 성별은 필수이다.")
     @NullAndEmptySource
@@ -148,7 +145,6 @@ class PartyControllerTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.partyId").value("1"))
                 .andExpect(jsonPath("$.success").value("true"));
     }
-
 
     @DisplayName("직관팟 생성 중 참여자 나이는 필수이다.")
     @NullAndEmptySource
@@ -203,7 +199,6 @@ class PartyControllerTest extends ControllerTestSupport {
         assertBadRequestOfPartyCreateRequest(request, "/party", "참여자 나이는 최대 6개까지 가능합니다!");
     }
 
-
     @DisplayName("직관팟 최소 인원은 필수이다.")
     @Test
     void createParty_EMPTY_MINIMUM() throws Exception {
@@ -226,7 +221,6 @@ class PartyControllerTest extends ControllerTestSupport {
         assertBadRequestOfPartyCreateRequest(request, "/party", "최소 참여 인원은 1명 이상이여야 합니다!");
     }
 
-
     @DisplayName("직관팟 최대 인원은 필수이다.")
     @Test
     void createParty_EMPTY_MAXIMUM() throws Exception {
@@ -248,7 +242,6 @@ class PartyControllerTest extends ControllerTestSupport {
         // when // then
         assertBadRequestOfPartyCreateRequest(request, "/party", "최소 참여 인원은 최대 참여 인원보다 클 수 없습니다!");
     }
-
 
     @DisplayName("직관팟 생성 중 사진 url은 비어 있거나, http/https/ftp로 시작해야 한다.")
     @MethodSource("validUrlGroupProvider")
@@ -318,7 +311,6 @@ class PartyControllerTest extends ControllerTestSupport {
         );
     }
 
-
     @DisplayName("직관팟 생성 중 소개 문구는 필수이다.")
     @NullAndEmptySource
     @ParameterizedTest(name = "message = {0}")
@@ -344,7 +336,6 @@ class PartyControllerTest extends ControllerTestSupport {
         // when // then
         assertBadRequestOfPartyCreateRequest(request, "/party", "직관팟 소개 문구의 길이를 1~100자 이내로 작성해 주세요!");
     }
-
 
     @DisplayName("이미지 저장을 위한 Presigned URL을 발급해줄 수 있다.")
     @Test
@@ -382,7 +373,6 @@ class PartyControllerTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
                 .andExpect(jsonPath("$.message").value("이미지 파일명은 필수입니다!"));
     }
-
 
     private void assertBadRequestOfPartyCreateRequest(PartyCreateRequest request, String requestUri, String expectedResult) throws Exception {
         mockMvc.perform(post(requestUri)

--- a/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
@@ -16,7 +16,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.*;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
@@ -379,21 +378,21 @@ class PartyControllerTest extends ControllerTestSupport {
                         .with(authentication(token)))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
-                .andExpect(content().string("이미지 파일명은 필수입니다!"));
-
+                .andExpect(jsonPath("$.code").value("400"))
+                .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+                .andExpect(jsonPath("$.message").value("이미지 파일명은 필수입니다!"));
     }
 
 
     private void assertBadRequestOfPartyCreateRequest(PartyCreateRequest request, String requestUri, String expectedResult) throws Exception {
-        String responseBody = mockMvc.perform(post(requestUri)
+        mockMvc.perform(post(requestUri)
                         .content(objectMapper.writeValueAsString(request))
                         .contentType(APPLICATION_JSON)
                         .with(authentication(token)))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
-                .andReturn()
-                .getResponse()
-                .getContentAsString();
-        assertThat(responseBody).isEqualTo(expectedResult);
+                .andExpect(jsonPath("$.code").value("400"))
+                .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+                .andExpect(jsonPath("$.message").value(expectedResult));
     }
 }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용

`ErrorResponse` 를 도입해 4xx, 5xx 에러 발생 시 보다 정형화된 response가 프론트에게 전달될 수 있도록 했습니다!
사용은 아래처럼 하시면 됩니다! 일단은 제가 평소에 쓰는 `ErrorResponse` 작성해서 적용시켰는데, 혹시 추가하거나 빼면 좋겟다 싶은 거 잇으면 말씀해주세요~
```
    @ResponseStatus(HttpStatus.BAD_REQUEST)
    @ExceptionHandler(BindException.class)
    public ErrorResponse bindExceptionHandler(BindException e) {
        String errorMessage = e.getAllErrors().get(0).getDefaultMessage();
        log.warn("Validation Error: {}", errorMessage);
        return ErrorResponse.badRequestError(errorMessage);
    }
```

```
{
   "code":400,
   "status":"BAD_REQUEST",
   "message":"잘못된 신청 방식입니다!"
}
```

---

## 🔗 관련 이슈
- closes #16 

---

## 💡 추가 사항
아까 이슈 템플릿 이 쪽에서는 깜빡하고 수정을 안 해서 수정햇어요~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **문서화**
  - 이슈 템플릿에서 "상위 직업"을 "상위 작업"으로 수정하고, Epic(보라색 번개 아이콘) 기준으로 라벨 및 설명을 일관성 있게 변경했습니다.
  - YAML 포맷의 공백 및 표기 방식을 통일했습니다.

- **신규 기능**
  - 일관된 에러 응답 구조를 제공하는 `ErrorResponse`가 추가되었습니다.

- **리팩터**
  - 예외 처리 시 에러 메시지 응답 방식을 표준화하여, 기존 문자열 대신 구조화된 에러 응답을 반환하도록 개선했습니다.

- **테스트**
  - 컨트롤러 테스트에서 에러 응답 검증을 구조화된 JSON 형태로 변경했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->