### PR TITLE
CS-233 Chore/dev.yaml 환경변수 이름 변경

### DIFF
--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -3,18 +3,17 @@ spring:
     name: twp-service
 
   datasource:
-    url: ${DB_URL}
-    username: ${DB_USER}
-    password: ${DB_PASSWORD}
+    url: ${SPRING_DATASOURCE_URL}
+    username: ${SPRING_DATASOURCE_USERNAME}
+    password: ${SPRING_DATASOURCE_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   data:
     mongodb:
       read:
-        uri: ${MONGO_READ_URI}
-
+        uri: ${SPRING_DATA_MONGODB_READ_URI}
       chat:
-        uri: ${MONGO_CHAT_URI}
+        uri: ${SPRING_DATA_MONGODB_CHAT_URI}
 
     redis:
       host: ${REDIS_HOST}
@@ -38,8 +37,8 @@ spring:
 cloud:
   aws:
     credentials:
-      access-key: ${STORAGE_ACCESS_KEY}
-      secret-key: ${STORAGE_SECRET_KEY}
+      access-key: ${AWS_S3_ACCESS_KEY}
+      secret-key: ${AWS_S3_SECRET_KEY}
     s3:
-      bucket : ${BUCKET_NAME}
-      endpoint : ${BUCKET_ENDPOINT}
+      bucket : ${AWS_S3_BUCKET_NAME}
+      endpoint : ${AWS_S3_ENDPOINT}


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
application-dev.yaml의 환경변수 네이밍을 Spring 공식 패턴 + 일관성 있게 변경했습니다
MySQL: DB_URL -> SPRING_DATASOURCE_URL

MongoDB(Read): MONGO_READ_URI -> SPRING_DATA_MONGODB_READ_URI
MongoDB(Chat): MONGO_CHAT_URI -> SPRING_DATA_MONGODB_CHAT_URI

S3 관련:
STORAGE_ACCESS_KEY -> AWS_S3_ACCESS_KEY
STORAGE_SECRET_KEY -> AWS_S3_SECRET_KEY
BUCKET_NAME -> AWS_S3_BUCKET_NAME
BUCKET_ENDPOINT -> AWS_S3_ENDPOINT

---

## 🔗 관련 이슈
- closes #20 

---

## 💡 추가 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 환경 변수 명칭이 더 명확하고 표준화된 이름으로 변경되었습니다. (예: 데이터베이스, MongoDB, AWS S3 관련 변수)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->