### PR TITLE
CS-234 feat/직관팟 생성 API 수정 및 Party Entity 필드 추가

### DIFF
--- a/src/main/java/com/playus/twpservice/domain/chat/repository/ChatPartRepository.java
+++ b/src/main/java/com/playus/twpservice/domain/chat/repository/ChatPartRepository.java
@@ -1,0 +1,7 @@
+package com.playus.twpservice.domain.chat.repository;
+
+import com.playus.twpservice.domain.chat.entity.ChatPart;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface ChatPartRepository extends MongoRepository<ChatPart, String> {
+}

--- a/src/main/java/com/playus/twpservice/domain/party/document/PartyDocument.java
+++ b/src/main/java/com/playus/twpservice/domain/party/document/PartyDocument.java
@@ -26,7 +26,11 @@ public class PartyDocument extends BaseTimeEntity {
     private String title;
 
     @NotNull
-    private String text;
+    private PartyJoinMethod partyJoinMethod;
+
+    @NotNull
+    @Field(name = "party_gender")
+    private PartyGender partyGender;
 
     @NotNull
     @Field(name = "minimum_participants")
@@ -37,19 +41,26 @@ public class PartyDocument extends BaseTimeEntity {
     private Long maximumParticipants;
 
     @NotNull
+    @Field(name = "match_id")
+    private Long matchId;
+
+    @NotNull
+    @Field(name = "chatroom_id")
+    private String chatRoomId;
+
+    @NotNull
+    private String text;
+
+    @NotNull
     @Field(name = "thumbnail_url")
     @Size(min = 1, max = 255)
     private String thumbnailUrl;
 
-    @NotNull
-    @Field(name = "party_gender")
-    private PartyGender partyGender;
 
-    @NotNull
-    private PartyJoinMethod partyJoinMethod;
 
     @Builder
-    private PartyDocument(Long id, String title, String text, Long minimumParticipants, Long maximumParticipants, String thumbnailUrl, PartyGender partyGender, PartyJoinMethod partyJoinMethod) {
+    private PartyDocument(Long id, String title, String text, Long minimumParticipants, Long maximumParticipants,
+                          String thumbnailUrl, PartyGender partyGender, PartyJoinMethod partyJoinMethod, Long matchId, String chatRoomId) {
         this.id = id;
         this.title = title;
         this.text = text;
@@ -58,9 +69,13 @@ public class PartyDocument extends BaseTimeEntity {
         this.thumbnailUrl = thumbnailUrl;
         this.partyGender = partyGender;
         this.partyJoinMethod = partyJoinMethod;
+        this.matchId = matchId;
+        this.chatRoomId = chatRoomId;
     }
 
-    public static PartyDocument createForOnlyTest(Long id, String title, String text, Long minimumParticipants, Long maximumParticipants, String thumbnailUrl, PartyGender partyGender, PartyJoinMethod partyJoinMethod) {
+    public static PartyDocument createForOnlyTest(Long id, String title, String text, Long minimumParticipants,
+                                                  Long maximumParticipants, String thumbnailUrl, PartyGender partyGender, PartyJoinMethod partyJoinMethod,
+                                                  Long matchId, String chatRoomId) {
         return PartyDocument.builder()
                 .id(id)
                 .title(title)
@@ -70,6 +85,8 @@ public class PartyDocument extends BaseTimeEntity {
                 .thumbnailUrl(thumbnailUrl)
                 .partyGender(partyGender)
                 .partyJoinMethod(partyJoinMethod)
+                .matchId(matchId)
+                .chatRoomId(chatRoomId)
                 .build();
     }
 }

--- a/src/main/java/com/playus/twpservice/domain/party/dto/party_create/PartyCreateRequest.java
+++ b/src/main/java/com/playus/twpservice/domain/party/dto/party_create/PartyCreateRequest.java
@@ -46,6 +46,10 @@ public record PartyCreateRequest(
                         String>
                 thumbnailUrl,
 
+        @NotNull(message = "경기 ID는 필수입니다!")
+        @Min(value = 1, message = "경기 ID는 1 이상이어야 합니다!")
+        Long matchId,
+
         @NotBlank(message = "직관팟 소개 문구가 비어 있습니다!")
         @Size(max = 100, message = "직관팟 소개 문구의 길이를 1~100자 이내로 작성해 주세요!")
         String message
@@ -54,7 +58,7 @@ public record PartyCreateRequest(
 
     public static PartyCreateRequest of(String title, String method, String gender, List<String> ageGroup,
                                         Long minimumParticipants, Long maximumParticipants,
-                                        List<String> thumbnailUrl, String message) {
+                                        List<String> thumbnailUrl, Long matchId, String message) {
 
         return PartyCreateRequest.builder()
                 .title(title)
@@ -64,6 +68,7 @@ public record PartyCreateRequest(
                 .minimumParticipants(minimumParticipants)
                 .maximumParticipants(maximumParticipants)
                 .thumbnailUrl(thumbnailUrl)
+                .matchId(matchId)
                 .message(message)
                 .build();
     }

--- a/src/main/java/com/playus/twpservice/domain/party/dto/party_create/PartyCreateRequest.java
+++ b/src/main/java/com/playus/twpservice/domain/party/dto/party_create/PartyCreateRequest.java
@@ -22,10 +22,10 @@ public record PartyCreateRequest(
         String title,
 
         @ValidEnum(enumClass = PartyJoinMethod.class, emptyValueMessage = "신청 방식이 비어 있습니다!", invalidValueMessage = "잘못된 신청 방식입니다!")
-        String method,
+        String partyJoinMethod,
 
         @ValidEnum(enumClass = PartyGender.class, emptyValueMessage = "참여 원하는 성별이 비어 있습니다!", invalidValueMessage = "잘못된 성별 형식입니다!")
-        String gender,
+        String partyGender,
 
         @ValidEnumList(enumClass = PartyAgeGroup.class, emptyValueMessage = "참여자 나이가 비어 있습니다!",
                        invalidValueMessage = "잘못된 참여자 나이입니다!", overValueMessage = "참여자 나이는 최대 6개까지 가능합니다!")
@@ -62,8 +62,8 @@ public record PartyCreateRequest(
 
         return PartyCreateRequest.builder()
                 .title(title)
-                .method(method)
-                .gender(gender)
+                .partyJoinMethod(method)
+                .partyGender(gender)
                 .ageGroup(ageGroup)
                 .minimumParticipants(minimumParticipants)
                 .maximumParticipants(maximumParticipants)
@@ -74,7 +74,7 @@ public record PartyCreateRequest(
     }
 
     public Party toParty() {
-        return Party.create(title, message, minimumParticipants, maximumParticipants, PartyGender.toEnumValue(gender), PartyJoinMethod.toEnumValue(method));
+        return Party.create(title, message, minimumParticipants, maximumParticipants, PartyGender.toEnumValue(partyGender), PartyJoinMethod.toEnumValue(partyJoinMethod));
     }
 
 }

--- a/src/main/java/com/playus/twpservice/domain/party/dto/party_create/PartyCreateRequest.java
+++ b/src/main/java/com/playus/twpservice/domain/party/dto/party_create/PartyCreateRequest.java
@@ -74,7 +74,6 @@ public record PartyCreateRequest(
     }
 
     public Party toParty() {
-        return Party.create(title, message, minimumParticipants, maximumParticipants, PartyGender.toEnumValue(partyGender), PartyJoinMethod.toEnumValue(partyJoinMethod));
+        return Party.create(title, message, minimumParticipants, maximumParticipants, PartyGender.toEnumValue(partyGender), PartyJoinMethod.toEnumValue(partyJoinMethod), matchId);
     }
-
 }

--- a/src/main/java/com/playus/twpservice/domain/party/dto/party_create/PartyCreateResponse.java
+++ b/src/main/java/com/playus/twpservice/domain/party/dto/party_create/PartyCreateResponse.java
@@ -5,13 +5,13 @@ import lombok.Builder;
 @Builder
 public record PartyCreateResponse (
       Long partyId,
-      Boolean success
+      String chatRoomId
 ) {
 
-    public static PartyCreateResponse of(Long partyId, Boolean success) {
+    public static PartyCreateResponse of(Long partyId, String chatRoomId) {
         return PartyCreateResponse.builder()
                 .partyId(partyId)
-                .success(success)
+                .chatRoomId(chatRoomId)
                 .build();
     }
 }

--- a/src/main/java/com/playus/twpservice/domain/party/entity/Party.java
+++ b/src/main/java/com/playus/twpservice/domain/party/entity/Party.java
@@ -22,8 +22,13 @@ public class Party extends BaseTimeEntity {
     @Column(nullable = false, length = 225)
     private String title;
 
-    @Column(nullable = false, columnDefinition = "TEXT")
-    private String text;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PartyJoinMethod partyJoinMethod;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, name = "party_gender")
+    private PartyGender partyGender;
 
     @Column(nullable = false,name = "minimum_participants")
     private Long minimumParticipants;
@@ -31,25 +36,24 @@ public class Party extends BaseTimeEntity {
     @Column(nullable = false, name = "maximum_participants")
     private Long maximumParticipants;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false, name = "party_gender")
-    private PartyGender partyGender;
+    @Column(nullable = false, name = "match_id")
+    private Long matchId;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private PartyJoinMethod partyJoinMethod;
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String text;
 
     @Builder
-    private Party(String title, String text, Long minimumParticipants, Long maximumParticipants, PartyGender partyGender, PartyJoinMethod partyJoinMethod){
+    private Party(String title, String text, Long minimumParticipants, Long maximumParticipants, PartyGender partyGender, PartyJoinMethod partyJoinMethod, Long matchId){
         this.title = title;
         this.text = text;
         this.minimumParticipants = minimumParticipants;
         this.maximumParticipants = maximumParticipants;
         this.partyGender = partyGender;
         this.partyJoinMethod = partyJoinMethod;
+        this.matchId = matchId;
     }
 
-    public static Party create(String title, String text, Long minimumParticipants, Long maximumParticipants, PartyGender partyGender, PartyJoinMethod partyJoinMethod){
+    public static Party create(String title, String text, Long minimumParticipants, Long maximumParticipants, PartyGender partyGender, PartyJoinMethod partyJoinMethod, Long matchId){
         return Party.builder()
                 .title(title)
                 .text(text)
@@ -57,6 +61,7 @@ public class Party extends BaseTimeEntity {
                 .maximumParticipants(maximumParticipants)
                 .partyGender(partyGender)
                 .partyJoinMethod(partyJoinMethod)
+                .matchId(matchId)
                 .build();
     }
 

--- a/src/main/java/com/playus/twpservice/domain/party/entity/Party.java
+++ b/src/main/java/com/playus/twpservice/domain/party/entity/Party.java
@@ -39,6 +39,9 @@ public class Party extends BaseTimeEntity {
     @Column(nullable = false, name = "match_id")
     private Long matchId;
 
+    @Column(nullable = false, name = "chatroom_id")
+    private String chatRoomId;
+
     @Column(nullable = false, columnDefinition = "TEXT")
     private String text;
 
@@ -65,4 +68,8 @@ public class Party extends BaseTimeEntity {
                 .build();
     }
 
+    public Party assignChatRoom(String chatRoomId) {
+        this.chatRoomId = chatRoomId;
+        return this;
+    }
 }

--- a/src/main/java/com/playus/twpservice/domain/party/service/PartyService.java
+++ b/src/main/java/com/playus/twpservice/domain/party/service/PartyService.java
@@ -1,5 +1,9 @@
 package com.playus.twpservice.domain.party.service;
 
+import com.playus.twpservice.domain.chat.entity.ChatPart;
+import com.playus.twpservice.domain.chat.entity.ChatRoom;
+import com.playus.twpservice.domain.chat.repository.ChatPartRepository;
+import com.playus.twpservice.domain.chat.repository.ChatRoomRepository;
 import com.playus.twpservice.domain.party.dto.party_create.PartyCreateRequest;
 import com.playus.twpservice.domain.party.dto.party_create.PartyCreateResponse;
 import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageRequest;
@@ -27,15 +31,21 @@ import java.util.Objects;
 @RequiredArgsConstructor
 public class PartyService {
 
-    private final S3PresignedUrlGenerator s3PresignedUrlGenerator;
     private final PartyRepository partyRepository;
     private final PartyJoinRepository partyJoinRepository;
     private final PartyAgeRepository partyAgeRepository;
     private final PartyThumbnailUrlRepository partyThumbnailUrlRepository;
 
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatPartRepository chatPartRepository;
+
+    private final S3PresignedUrlGenerator s3PresignedUrlGenerator;
+
     public PartyCreateResponse createParty(Long userId, PartyCreateRequest request) {
 
-        Party party = partyRepository.save(request.toParty());
+        ChatRoom chatRoom = initializeChatRoomAsWriter(userId, request);
+
+        Party party = partyRepository.save(request.toParty().assignChatRoom(chatRoom.getId()));
 
         partyJoinRepository.save(PartyJoin.create(userId, party, Status.ACCEPT, null));
 
@@ -44,15 +54,18 @@ public class PartyService {
 
         saveThumbnailUrlIfPresent(request, party);
 
-        return PartyCreateResponse.of(party.getId(), Boolean.TRUE);
+        return PartyCreateResponse.of(party.getId(), chatRoom.getId());
+    }
+
+    private ChatRoom initializeChatRoomAsWriter(Long userId, PartyCreateRequest request) {
+        ChatRoom chatRoom = chatRoomRepository.save(ChatRoom.create(request.title()));
+        chatPartRepository.save(ChatPart.create(userId, chatRoom));
+        return chatRoom;
     }
 
     public PresignedUrlForSaveImageResponse generatePresignedUrlForSaveImage(PresignedUrlForSaveImageRequest request) {
         return new PresignedUrlForSaveImageResponse(s3PresignedUrlGenerator.generatePresignedUrl(request.imageFileName()));
     }
-
-
-
 
     private void saveThumbnailUrlIfPresent(PartyCreateRequest request, Party party) {
         if (thumbnailUrlExistsIn(request)) {
@@ -76,6 +89,4 @@ public class PartyService {
                 .map(age -> PartyAge.create(party, PartyAgeGroup.getAgeByDescription(age)))
                 .toList();
     }
-
-
 }

--- a/src/main/java/com/playus/twpservice/domain/party/specification/PartyControllerSpecification.java
+++ b/src/main/java/com/playus/twpservice/domain/party/specification/PartyControllerSpecification.java
@@ -38,6 +38,7 @@ public interface PartyControllerSpecification {
                       "minimumParticipants": 3,
                       "maximumParticipants": 5,
                       "thumbnailUrl": "https://image.example.com/party.jpg",
+                      "matchId" : "1",
                       "message": "재밌게 응원할 분 구해요!"
                     }
                     """
@@ -55,7 +56,7 @@ public interface PartyControllerSpecification {
                                     value = """
                     {
                       "partyId": 1,
-                      "success": true
+                      "chatRoomId": "chatRoomId"
                     }
                     """
                             )

--- a/src/main/java/com/playus/twpservice/domain/party/specification/PartyControllerSpecification.java
+++ b/src/main/java/com/playus/twpservice/domain/party/specification/PartyControllerSpecification.java
@@ -32,8 +32,8 @@ public interface PartyControllerSpecification {
                                     value = """
                     {
                       "title": "롯데 vs LG 직관 같이 가요!",
-                      "method": "선착순",
-                      "gender": "남자만",
+                      "partyJoinMethod": "선착순",
+                      "partyGender": "남자만",
                       "ageGroup": ["10대", "20대"],
                       "minimumParticipants": 3,
                       "maximumParticipants": 5,

--- a/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
@@ -30,11 +30,12 @@ class PartyControllerTest extends ControllerTestSupport {
     List<String> thumbnailUrl = List.of("http://image.com");
     UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(userId, null, List.of(new SimpleGrantedAuthority("USER")));
 
+    //  직관팟 생성 happy case
     @DisplayName("직관팟을 생성할 수 있다.")
     @Test
     void createParty() throws Exception {
         // given
-        PartyCreateRequest request = PartyCreateRequest.of("title", "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
+        PartyCreateRequest request = PartyCreateRequest.of("title", "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, 1L, "message");
         PartyCreateResponse response = PartyCreateResponse.of(1L, true);
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(response);
 
@@ -49,12 +50,13 @@ class PartyControllerTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.success").value("true"));
     }
 
+    //  직관팟 생성 title 이슈
     @DisplayName("직관팟 생성 중 제목은 필수이다.")
     @NullAndEmptySource
     @ParameterizedTest(name = "title = {0}")
     void createParty_EMPTY_TITLE(String emptyTitle) throws Exception {
         // given
-        PartyCreateRequest request = PartyCreateRequest.of(emptyTitle, "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
+        PartyCreateRequest request = PartyCreateRequest.of(emptyTitle, "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, 1L, "message");
         PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
@@ -66,7 +68,7 @@ class PartyControllerTest extends ControllerTestSupport {
     @Test
     void createParty_EXCEED_TITLE() throws Exception {
         String exceedTitle = "a".repeat(226);
-        PartyCreateRequest request = PartyCreateRequest.of(exceedTitle, "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
+        PartyCreateRequest request = PartyCreateRequest.of(exceedTitle, "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, 1L, "message");
         PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
@@ -74,12 +76,13 @@ class PartyControllerTest extends ControllerTestSupport {
         assertBadRequestOfPartyCreateRequest(request, "/party", "제목의 길이를 1~225자 이내로 작성해 주세요!");
     }
 
+    //  직관팟 생성 method 이슈
     @DisplayName("직관팟 생성 중 신청 방식은 필수이다.")
     @NullAndEmptySource
     @ParameterizedTest(name = "method = {0}")
     void createParty_EMPTY_METHOD(String emptyMethod) throws Exception {
         // given
-        PartyCreateRequest request = PartyCreateRequest.of("제목", emptyMethod, "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
+        PartyCreateRequest request = PartyCreateRequest.of("제목", emptyMethod, "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, 1L, "message");
         PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
@@ -92,7 +95,7 @@ class PartyControllerTest extends ControllerTestSupport {
     @ParameterizedTest(name = "method = {0}")
     void createParty_INVALID_METHOD(String invalidMethod) throws Exception {
         // given
-        PartyCreateRequest request = PartyCreateRequest.of("제목", invalidMethod, "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
+        PartyCreateRequest request = PartyCreateRequest.of("제목", invalidMethod, "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, 1L, "message");
         PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
@@ -100,12 +103,13 @@ class PartyControllerTest extends ControllerTestSupport {
         assertBadRequestOfPartyCreateRequest(request, "/party", "잘못된 신청 방식입니다!");
     }
 
+    //  직관팟 생성 gender 이슈
     @DisplayName("직관팟 생성 중 참여 원하는 성별은 필수이다.")
     @NullAndEmptySource
     @ParameterizedTest(name = "gender = {0}")
     void createParty_EMPTY_GENDER(String emptyGender) throws Exception {
         // given
-        PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", emptyGender, List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
+        PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", emptyGender, List.of("10대", "20대"), 1L, 10L, thumbnailUrl, 1L, "message");
         PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
@@ -118,7 +122,7 @@ class PartyControllerTest extends ControllerTestSupport {
     @ParameterizedTest(name = "gender = {0}")
     void createParty_INVALID_GENDER(String invalidGender) throws Exception {
         // given
-        PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", invalidGender, List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
+        PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", invalidGender, List.of("10대", "20대"), 1L, 10L, thumbnailUrl, 1L, "message");
         PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
@@ -131,7 +135,7 @@ class PartyControllerTest extends ControllerTestSupport {
     @ParameterizedTest(name = "gender = {0}")
     void createParty_VALID_GENDER(String gender) throws Exception {
         // given
-        PartyCreateRequest request = PartyCreateRequest.of("title", "선착순", gender, List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
+        PartyCreateRequest request = PartyCreateRequest.of("title", "선착순", gender, List.of("10대", "20대"), 1L, 10L, thumbnailUrl, 1L, "message");
         PartyCreateResponse response = PartyCreateResponse.of(1L, true);
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(response);
 
@@ -146,13 +150,14 @@ class PartyControllerTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.success").value("true"));
     }
 
+    //  직관팟 생성 ageGroup 이슈
     @DisplayName("직관팟 생성 중 참여자 나이는 필수이다.")
     @NullAndEmptySource
     @ParameterizedTest(name = "age = {0}")
     void createParty_EMPTY_AGE(List<String> emptyAgeList) throws Exception {
 
         // given
-        PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", emptyAgeList, 1L, 10L, thumbnailUrl, "message");
+        PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", emptyAgeList, 1L, 10L, thumbnailUrl, 1L, "message");
         PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
@@ -166,7 +171,7 @@ class PartyControllerTest extends ControllerTestSupport {
     void createParty_INVALID_AGE(List<String> emptyAgeList) throws Exception {
 
         // given
-        PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", emptyAgeList, 1L, 10L, thumbnailUrl, "message");
+        PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", emptyAgeList, 1L, 10L, thumbnailUrl, 1L, "message");
         PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
@@ -191,7 +196,7 @@ class PartyControllerTest extends ControllerTestSupport {
 
         // given
         List<String> tooManyAgeList = List.of("10대", "20대", "30대", "40대", "50대", "60대 이상", "70대", "80대", "90대");
-        PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", tooManyAgeList, 1L, 10L, thumbnailUrl, "message");
+        PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", tooManyAgeList, 1L, 10L, thumbnailUrl, 1L, "message");
         PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
@@ -199,10 +204,11 @@ class PartyControllerTest extends ControllerTestSupport {
         assertBadRequestOfPartyCreateRequest(request, "/party", "참여자 나이는 최대 6개까지 가능합니다!");
     }
 
+    //  직관팟 생성 minimumParticipants 이슈
     @DisplayName("직관팟 최소 인원은 필수이다.")
     @Test
     void createParty_EMPTY_MINIMUM() throws Exception {
-        PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), null, 10L, thumbnailUrl, "message");
+        PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), null, 10L, thumbnailUrl, 1L, "message");
         PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
@@ -213,7 +219,7 @@ class PartyControllerTest extends ControllerTestSupport {
     @DisplayName("직관팟 최소 인원은 1 이상이여야 한다.")
     @Test
     void createParty_INVALID_MINIMUM() throws Exception {
-        PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), 0L, 10L, thumbnailUrl, "message");
+        PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), 0L, 10L, thumbnailUrl, 1L, "message");
         PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
@@ -221,10 +227,11 @@ class PartyControllerTest extends ControllerTestSupport {
         assertBadRequestOfPartyCreateRequest(request, "/party", "최소 참여 인원은 1명 이상이여야 합니다!");
     }
 
+    //  직관팟 생성 maximumParticipants 이슈
     @DisplayName("직관팟 최대 인원은 필수이다.")
     @Test
     void createParty_EMPTY_MAXIMUM() throws Exception {
-        PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), 1L, null, thumbnailUrl, "message");
+        PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), 1L, null, thumbnailUrl, 1L, "message");
         PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
@@ -235,7 +242,7 @@ class PartyControllerTest extends ControllerTestSupport {
     @DisplayName("직관팟 최소 인원은 최대 인원보다 클 수 없다.")
     @Test
     void createParty_MINIMUM_MAXIMUM() throws Exception {
-        PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), 10L, 9L, thumbnailUrl, "message");
+        PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), 10L, 9L, thumbnailUrl, 1L, "message");
         PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
@@ -243,12 +250,13 @@ class PartyControllerTest extends ControllerTestSupport {
         assertBadRequestOfPartyCreateRequest(request, "/party", "최소 참여 인원은 최대 참여 인원보다 클 수 없습니다!");
     }
 
+    //  직관팟 생성 thumbnailUrl 이슈
     @DisplayName("직관팟 생성 중 사진 url은 비어 있거나, http/https/ftp로 시작해야 한다.")
     @MethodSource("validUrlGroupProvider")
     @ParameterizedTest(name = "url = {0}")
     void createParty_VALID_IMAGE_URL(List<String> validUrl) throws Exception {
         // given
-        PartyCreateRequest request = PartyCreateRequest.of("title", "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, validUrl, "message");
+        PartyCreateRequest request = PartyCreateRequest.of("title", "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, validUrl, 1L, "message");
         PartyCreateResponse response = PartyCreateResponse.of(1L, true);
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(response);
 
@@ -281,7 +289,7 @@ class PartyControllerTest extends ControllerTestSupport {
                 "https://image.com", "ftp://image.com", "ftp://image.com", "http://image.com",
                 "https://image.com", "ftp://image.com", "http://image.com");
         PartyCreateRequest request = PartyCreateRequest.of("title", "선착순", "남자만", List.of("10대", "20대"),
-                1L, 10L, tooManyUrlList, "message");
+                1L, 10L, tooManyUrlList, 1L, "message");
         PartyCreateResponse response = PartyCreateResponse.of(1L, true);
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(response);
 
@@ -294,7 +302,7 @@ class PartyControllerTest extends ControllerTestSupport {
     @ParameterizedTest(name = "url = {0}")
     void createParty_INVALID_IMAGE_URL(List<String> invalidUrl) throws Exception {
         // given
-        PartyCreateRequest request = PartyCreateRequest.of("title", "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, invalidUrl, "message");
+        PartyCreateRequest request = PartyCreateRequest.of("title", "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, invalidUrl, 1L, "message");
         PartyCreateResponse response = PartyCreateResponse.of(1L, true);
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(response);
 
@@ -311,12 +319,40 @@ class PartyControllerTest extends ControllerTestSupport {
         );
     }
 
+    //  직관팟 생성 matchId 이슈
+    @DisplayName("직관팟 생성 시 경기 ID는 필수이다.")
+    @Test
+    void createParty_EMPTY_MATCH_ID() throws Exception {
+        PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"),
+                1L, 10L, thumbnailUrl, null, "message");
+        PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
+        given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
+
+        // when // then
+        assertBadRequestOfPartyCreateRequest(request, "/party", "경기 ID는 필수입니다!");
+    }
+
+    @DisplayName("직관팟 생성 시 경기 ID는 1 이상이여야 한다.")
+    @CsvSource(value = {"0", "-1", "-100", "-1000", "-10000"})
+    @ParameterizedTest(name = "invalidMatchId = {0}")
+    void createParty_INVALID_MATCH_ID(String invalidMatchIdStr) throws Exception {
+        Long invalidMatchId = Long.valueOf(invalidMatchIdStr);
+        PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"),
+                1L, 10L, thumbnailUrl, invalidMatchId, "message");
+        PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
+        given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
+
+        // when // then
+        assertBadRequestOfPartyCreateRequest(request, "/party", "경기 ID는 1 이상이어야 합니다!");
+    }
+
+    //  직관팟 생성 message 이슈
     @DisplayName("직관팟 생성 중 소개 문구는 필수이다.")
     @NullAndEmptySource
     @ParameterizedTest(name = "message = {0}")
     void createParty_EMPTY_MESSAGE(String emptyMessage) throws Exception {
         // given
-        PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, emptyMessage);
+        PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, 1L, emptyMessage);
         PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
@@ -329,7 +365,7 @@ class PartyControllerTest extends ControllerTestSupport {
     void createParty_EXCEED_MESSAGE() throws Exception {
         // given
         String exceedMessage = "a".repeat(101);
-        PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, exceedMessage);
+        PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, 1L, exceedMessage);
         PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
@@ -359,10 +395,10 @@ class PartyControllerTest extends ControllerTestSupport {
     @NullAndEmptySource
     @ParameterizedTest(name = "url = {0}")
     void generatePresignedUrlForSaveImage_BLANK_IMAGE_NAME(String blankImageFileName) throws Exception {
-      // given
+        // given
         PresignedUrlForSaveImageRequest request = new PresignedUrlForSaveImageRequest(blankImageFileName);
 
-      // when // then
+        // when // then
         mockMvc.perform(post("/party/presigned-url")
                         .content(objectMapper.writeValueAsString(request))
                         .contentType(APPLICATION_JSON)

--- a/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
@@ -36,7 +36,7 @@ class PartyControllerTest extends ControllerTestSupport {
     void createParty() throws Exception {
         // given
         PartyCreateRequest request = PartyCreateRequest.of("title", "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, 1L, "message");
-        PartyCreateResponse response = PartyCreateResponse.of(1L, true);
+        PartyCreateResponse response = PartyCreateResponse.of(1L, "id");
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(response);
 
         // when // then
@@ -47,7 +47,7 @@ class PartyControllerTest extends ControllerTestSupport {
                 .andDo(print())
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.partyId").value("1"))
-                .andExpect(jsonPath("$.success").value("true"));
+                .andExpect(jsonPath("$.chatRoomId").value("id"));
     }
 
     //  직관팟 생성 title 이슈
@@ -57,7 +57,7 @@ class PartyControllerTest extends ControllerTestSupport {
     void createParty_EMPTY_TITLE(String emptyTitle) throws Exception {
         // given
         PartyCreateRequest request = PartyCreateRequest.of(emptyTitle, "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, 1L, "message");
-        PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
+        PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, "id");
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
         // when // then
@@ -69,7 +69,7 @@ class PartyControllerTest extends ControllerTestSupport {
     void createParty_EXCEED_TITLE() throws Exception {
         String exceedTitle = "a".repeat(226);
         PartyCreateRequest request = PartyCreateRequest.of(exceedTitle, "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, 1L, "message");
-        PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
+        PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, "id");
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
         // when // then
@@ -83,7 +83,7 @@ class PartyControllerTest extends ControllerTestSupport {
     void createParty_EMPTY_METHOD(String emptyMethod) throws Exception {
         // given
         PartyCreateRequest request = PartyCreateRequest.of("제목", emptyMethod, "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, 1L, "message");
-        PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
+        PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, "id");
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
         // when // then
@@ -96,7 +96,7 @@ class PartyControllerTest extends ControllerTestSupport {
     void createParty_INVALID_METHOD(String invalidMethod) throws Exception {
         // given
         PartyCreateRequest request = PartyCreateRequest.of("제목", invalidMethod, "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, 1L, "message");
-        PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
+        PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, "id");
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
         // when // then
@@ -110,7 +110,7 @@ class PartyControllerTest extends ControllerTestSupport {
     void createParty_EMPTY_GENDER(String emptyGender) throws Exception {
         // given
         PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", emptyGender, List.of("10대", "20대"), 1L, 10L, thumbnailUrl, 1L, "message");
-        PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
+        PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, "id");
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
         // when // then
@@ -123,7 +123,7 @@ class PartyControllerTest extends ControllerTestSupport {
     void createParty_INVALID_GENDER(String invalidGender) throws Exception {
         // given
         PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", invalidGender, List.of("10대", "20대"), 1L, 10L, thumbnailUrl, 1L, "message");
-        PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
+        PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, "id");
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
         // when // then
@@ -136,7 +136,7 @@ class PartyControllerTest extends ControllerTestSupport {
     void createParty_VALID_GENDER(String gender) throws Exception {
         // given
         PartyCreateRequest request = PartyCreateRequest.of("title", "선착순", gender, List.of("10대", "20대"), 1L, 10L, thumbnailUrl, 1L, "message");
-        PartyCreateResponse response = PartyCreateResponse.of(1L, true);
+        PartyCreateResponse response = PartyCreateResponse.of(1L, "id");
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(response);
 
         // when // then
@@ -147,7 +147,7 @@ class PartyControllerTest extends ControllerTestSupport {
                 .andDo(print())
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.partyId").value("1"))
-                .andExpect(jsonPath("$.success").value("true"));
+                .andExpect(jsonPath("$.chatRoomId").value("id"));
     }
 
     //  직관팟 생성 ageGroup 이슈
@@ -158,7 +158,7 @@ class PartyControllerTest extends ControllerTestSupport {
 
         // given
         PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", emptyAgeList, 1L, 10L, thumbnailUrl, 1L, "message");
-        PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
+        PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, "id");
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
         // when // then
@@ -172,7 +172,7 @@ class PartyControllerTest extends ControllerTestSupport {
 
         // given
         PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", emptyAgeList, 1L, 10L, thumbnailUrl, 1L, "message");
-        PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
+        PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, "id");
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
         // when // then
@@ -197,7 +197,7 @@ class PartyControllerTest extends ControllerTestSupport {
         // given
         List<String> tooManyAgeList = List.of("10대", "20대", "30대", "40대", "50대", "60대 이상", "70대", "80대", "90대");
         PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", tooManyAgeList, 1L, 10L, thumbnailUrl, 1L, "message");
-        PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
+        PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, "id");
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
         // when // then
@@ -209,7 +209,7 @@ class PartyControllerTest extends ControllerTestSupport {
     @Test
     void createParty_EMPTY_MINIMUM() throws Exception {
         PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), null, 10L, thumbnailUrl, 1L, "message");
-        PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
+        PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, "id");
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
         // when // then
@@ -220,7 +220,7 @@ class PartyControllerTest extends ControllerTestSupport {
     @Test
     void createParty_INVALID_MINIMUM() throws Exception {
         PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), 0L, 10L, thumbnailUrl, 1L, "message");
-        PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
+        PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, "id");
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
         // when // then
@@ -232,7 +232,7 @@ class PartyControllerTest extends ControllerTestSupport {
     @Test
     void createParty_EMPTY_MAXIMUM() throws Exception {
         PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), 1L, null, thumbnailUrl, 1L, "message");
-        PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
+        PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, "id");
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
         // when // then
@@ -243,7 +243,7 @@ class PartyControllerTest extends ControllerTestSupport {
     @Test
     void createParty_MINIMUM_MAXIMUM() throws Exception {
         PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), 10L, 9L, thumbnailUrl, 1L, "message");
-        PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
+        PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, "id");
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
         // when // then
@@ -257,7 +257,7 @@ class PartyControllerTest extends ControllerTestSupport {
     void createParty_VALID_IMAGE_URL(List<String> validUrl) throws Exception {
         // given
         PartyCreateRequest request = PartyCreateRequest.of("title", "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, validUrl, 1L, "message");
-        PartyCreateResponse response = PartyCreateResponse.of(1L, true);
+        PartyCreateResponse response = PartyCreateResponse.of(1L, "id");
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(response);
 
         // when // then
@@ -268,7 +268,7 @@ class PartyControllerTest extends ControllerTestSupport {
                 .andDo(print())
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.partyId").value("1"))
-                .andExpect(jsonPath("$.success").value("true"));
+                .andExpect(jsonPath("$.chatRoomId").value("id"));
     }
 
     static Stream<Arguments> validUrlGroupProvider() {
@@ -290,7 +290,7 @@ class PartyControllerTest extends ControllerTestSupport {
                 "https://image.com", "ftp://image.com", "http://image.com");
         PartyCreateRequest request = PartyCreateRequest.of("title", "선착순", "남자만", List.of("10대", "20대"),
                 1L, 10L, tooManyUrlList, 1L, "message");
-        PartyCreateResponse response = PartyCreateResponse.of(1L, true);
+        PartyCreateResponse response = PartyCreateResponse.of(1L, "id");
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(response);
 
         // when // then
@@ -303,7 +303,7 @@ class PartyControllerTest extends ControllerTestSupport {
     void createParty_INVALID_IMAGE_URL(List<String> invalidUrl) throws Exception {
         // given
         PartyCreateRequest request = PartyCreateRequest.of("title", "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, invalidUrl, 1L, "message");
-        PartyCreateResponse response = PartyCreateResponse.of(1L, true);
+        PartyCreateResponse response = PartyCreateResponse.of(1L, "id");
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(response);
 
         // when // then
@@ -325,7 +325,7 @@ class PartyControllerTest extends ControllerTestSupport {
     void createParty_EMPTY_MATCH_ID() throws Exception {
         PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"),
                 1L, 10L, thumbnailUrl, null, "message");
-        PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
+        PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, "id");
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
         // when // then
@@ -339,7 +339,7 @@ class PartyControllerTest extends ControllerTestSupport {
         Long invalidMatchId = Long.valueOf(invalidMatchIdStr);
         PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"),
                 1L, 10L, thumbnailUrl, invalidMatchId, "message");
-        PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
+        PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, "id");
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
         // when // then
@@ -353,7 +353,7 @@ class PartyControllerTest extends ControllerTestSupport {
     void createParty_EMPTY_MESSAGE(String emptyMessage) throws Exception {
         // given
         PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, 1L, emptyMessage);
-        PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
+        PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, "id");
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
         // when // then
@@ -366,7 +366,7 @@ class PartyControllerTest extends ControllerTestSupport {
         // given
         String exceedMessage = "a".repeat(101);
         PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, 1L, exceedMessage);
-        PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, true);
+        PartyCreateResponse mockResponse = PartyCreateResponse.of(1L, "id");
         given(partyService.createParty(any(Long.class), any(PartyCreateRequest.class))).willReturn(mockResponse);
 
         // when // then

--- a/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
@@ -76,10 +76,10 @@ class PartyControllerTest extends ControllerTestSupport {
         assertBadRequestOfPartyCreateRequest(request, "/party", "제목의 길이를 1~225자 이내로 작성해 주세요!");
     }
 
-    //  직관팟 생성 method 이슈
+    //  직관팟 생성 partyJoinMethod 이슈
     @DisplayName("직관팟 생성 중 신청 방식은 필수이다.")
     @NullAndEmptySource
-    @ParameterizedTest(name = "method = {0}")
+    @ParameterizedTest(name = "partyJoinMethod = {0}")
     void createParty_EMPTY_METHOD(String emptyMethod) throws Exception {
         // given
         PartyCreateRequest request = PartyCreateRequest.of("제목", emptyMethod, "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, 1L, "message");
@@ -92,7 +92,7 @@ class PartyControllerTest extends ControllerTestSupport {
 
     @DisplayName("직관팟 생성 중 신청 방식은 정해진 양식대로 입력해야 한다.")
     @CsvSource(value = {"FIRST_COME", "RESERVATION", "ABCDEFG", "ㄱㄴㄷㄹㅁㅂㅅㅇ", "!@#$%^&", "123456789"})
-    @ParameterizedTest(name = "method = {0}")
+    @ParameterizedTest(name = "partyJoinMethod = {0}")
     void createParty_INVALID_METHOD(String invalidMethod) throws Exception {
         // given
         PartyCreateRequest request = PartyCreateRequest.of("제목", invalidMethod, "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, 1L, "message");
@@ -103,10 +103,10 @@ class PartyControllerTest extends ControllerTestSupport {
         assertBadRequestOfPartyCreateRequest(request, "/party", "잘못된 신청 방식입니다!");
     }
 
-    //  직관팟 생성 gender 이슈
+    //  직관팟 생성 partyGender 이슈
     @DisplayName("직관팟 생성 중 참여 원하는 성별은 필수이다.")
     @NullAndEmptySource
-    @ParameterizedTest(name = "gender = {0}")
+    @ParameterizedTest(name = "partyGender = {0}")
     void createParty_EMPTY_GENDER(String emptyGender) throws Exception {
         // given
         PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", emptyGender, List.of("10대", "20대"), 1L, 10L, thumbnailUrl, 1L, "message");
@@ -119,7 +119,7 @@ class PartyControllerTest extends ControllerTestSupport {
 
     @DisplayName("직관팟 생성 중 성별은 정해진 양식대로 입력해야 한다.")
     @CsvSource(value = {"MALE", "FEMALE", "NO_MATTER", "ㄱㄴㄷㄹㅁㅂㅅㅇ", "!@#$%^&", "123456789"})
-    @ParameterizedTest(name = "gender = {0}")
+    @ParameterizedTest(name = "partyGender = {0}")
     void createParty_INVALID_GENDER(String invalidGender) throws Exception {
         // given
         PartyCreateRequest request = PartyCreateRequest.of("제목", "선착순", invalidGender, List.of("10대", "20대"), 1L, 10L, thumbnailUrl, 1L, "message");
@@ -132,7 +132,7 @@ class PartyControllerTest extends ControllerTestSupport {
 
     @DisplayName("직관팟 생성 중 성별은 남자만, 여자만, 상관없음 중 하나만 입력해아 한다.")
     @CsvSource(value = {"남자만", "여자만", "상관없음"})
-    @ParameterizedTest(name = "gender = {0}")
+    @ParameterizedTest(name = "partyGender = {0}")
     void createParty_VALID_GENDER(String gender) throws Exception {
         // given
         PartyCreateRequest request = PartyCreateRequest.of("title", "선착순", gender, List.of("10대", "20대"), 1L, 10L, thumbnailUrl, 1L, "message");

--- a/src/test/java/com/playus/twpservice/domain/party/service/PartyServiceTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/service/PartyServiceTest.java
@@ -1,6 +1,10 @@
 package com.playus.twpservice.domain.party.service;
 
 import com.playus.twpservice.IntegrationTestSupport;
+import com.playus.twpservice.domain.chat.entity.ChatPart;
+import com.playus.twpservice.domain.chat.entity.ChatRoom;
+import com.playus.twpservice.domain.chat.repository.ChatPartRepository;
+import com.playus.twpservice.domain.chat.repository.ChatRoomRepository;
 import com.playus.twpservice.domain.party.dto.party_create.PartyCreateRequest;
 import com.playus.twpservice.domain.party.dto.party_create.PartyCreateResponse;
 import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageRequest;
@@ -48,12 +52,21 @@ class PartyServiceTest extends IntegrationTestSupport {
     @Autowired
     private PartyThumbnailUrlRepository partyThumbnailUrlRepository;
 
+    @Autowired
+    private ChatRoomRepository chatRoomRepository;
+
+    @Autowired
+    private ChatPartRepository chatPartRepository;
+
     @AfterEach
     void tearDown() {
         partyThumbnailUrlRepository.deleteAllInBatch();
         partyAgeRepository.deleteAllInBatch();
         partyJoinRepository.deleteAllInBatch();
         partyRepository.deleteAllInBatch();
+
+        chatRoomRepository.deleteAll();
+        chatPartRepository.deleteAll();
     }
 
     @DisplayName("직관팟을 생성할 수 있다.")
@@ -71,6 +84,16 @@ class PartyServiceTest extends IntegrationTestSupport {
         assertThat(partyRepository.count()).isEqualTo(1);
         assertThat(partyJoinRepository.count()).isEqualTo(1);
         assertThat(partyThumbnailUrlRepository.count()).isEqualTo(2);
+        assertThat(chatRoomRepository.count()).isEqualTo(1);
+        assertThat(chatPartRepository.count()).isEqualTo(1);
+
+        ChatRoom savedChatRoom = chatRoomRepository.findAll().get(0);
+        assertThat(savedChatRoom.getId()).isEqualTo(result.chatRoomId());
+        assertThat(savedChatRoom.getRoomName()).isEqualTo("title");
+
+        ChatPart savedChatPart = chatPartRepository.findAll().get(0);
+        assertThat(savedChatPart.getUserId()).isEqualTo(userId);
+        assertThat(savedChatPart.getChatRoom().getId()).isEqualTo(savedChatRoom.getId());
 
         Party savedParty = partyRepository.findAll().get(0);
         assertThat(savedParty.getTitle()).isEqualTo("title");
@@ -78,6 +101,7 @@ class PartyServiceTest extends IntegrationTestSupport {
         assertThat(savedParty.getMaximumParticipants()).isEqualTo(10L);
         assertThat(savedParty.getPartyGender()).isEqualTo(PartyGender.MALE);
         assertThat(savedParty.getPartyJoinMethod()).isEqualTo(PartyJoinMethod.FIRST_COME);
+        assertThat(savedParty.getChatRoomId()).isEqualTo(savedChatRoom.getId());
 
         PartyJoin savedPartyJoin = partyJoinRepository.findAll().get(0);
         assertThat(savedPartyJoin.getUserId()).isEqualTo(userId);
@@ -95,12 +119,15 @@ class PartyServiceTest extends IntegrationTestSupport {
         assertThat(savedPartyAges)
                 .extracting("age")
                 .containsExactlyInAnyOrder(10, 20);
-        assertThat(result).extracting("success").isEqualTo(true);
 
         Long savedPartyId = savedParty.getId();
         assertThat(savedPartyJoin.getParty().getId()).isEqualTo(savedPartyId);
         assertThat(savedUrl).allMatch(url -> url.getParty().getId().equals(savedPartyId));
         assertThat(savedPartyAges).allMatch(age -> age.getParty().getId().equals(savedPartyId));
+
+        assertThat(result)
+                .extracting("partyId", "chatRoomId")
+                .containsExactly(savedPartyId, savedChatRoom.getId());
     }
 
     @DisplayName("썸네일 URL이 비어 있을 때에도 직관팟을 생성할 수 있다.")

--- a/src/test/java/com/playus/twpservice/domain/party/service/PartyServiceTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/service/PartyServiceTest.java
@@ -62,7 +62,7 @@ class PartyServiceTest extends IntegrationTestSupport {
         // given
         Long userId = 1L;
         PartyCreateRequest request = PartyCreateRequest.of("title", "선착순", "남자만", List.of("10대", "20대"),
-                1L, 10L, List.of("url", "url2"), "message");
+                1L, 10L, List.of("url", "url2"), 1L, "message");
 
         // when
         PartyCreateResponse result = partyService.createParty(userId, request);
@@ -109,7 +109,7 @@ class PartyServiceTest extends IntegrationTestSupport {
         // given
         Long userId = 1L;
         PartyCreateRequest request = PartyCreateRequest.of("title", "선착순", "남자만",
-                List.of("10대", "20대"), 1L, 10L, List.of(), "message");
+                List.of("10대", "20대"), 1L, 10L, List.of(), 1L,  "message");
 
         // when
         partyService.createParty(userId, request);
@@ -127,7 +127,7 @@ class PartyServiceTest extends IntegrationTestSupport {
         // given
         Long userId = 1L;
         PartyCreateRequest request = PartyCreateRequest.of("title", "선착순", "남자만",
-                List.of("10대", "20대"), 1L, 10L, null, "message");
+                List.of("10대", "20대"), 1L, 10L, null, 1L, "message");
 
         // when
         partyService.createParty(userId, request);


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 기존 기능 변경
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
직관팟 생성 API에 다음 변경사항이 적용됩니다. 
> Request에 `matchId` (Long) 가 추가됩니다.
> Response에 기존 `success` 대신 `chatRoomId` (String) 가 추가됩니다. 
> 직관팟 생성 시 request에 들어온 title와 같은 제목으로 `ChatRoom` 생성 및 `ChatPart` 생성함으로써 방장이 자동 참여되도록 했습니다
> `Party` 엔티티에 `match_id`, `chatroom_id` 가 추가됩니다


---

## 🔗 관련 이슈
- closes #22 

---

## 💡 추가 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 파티 생성 시 채팅방과 채팅 참여자가 자동으로 생성되고, 파티 응답에 채팅방 ID가 포함됩니다.

- **기능 개선**
    - 파티 생성 요청에 matchId 필드가 추가되어 필수 입력값으로 적용되었습니다.
    - 파티 생성 요청 및 응답 필드명이 일부 변경되었습니다(예: method → partyJoinMethod, gender → partyGender, success → chatRoomId).

- **버그 수정**
    - matchId 필드에 대한 유효성 검사가 추가되었습니다(필수, 1 이상).

- **문서화**
    - 파티 생성 API 예시에 matchId 및 chatRoomId 반영 등 최신 스펙으로 문서가 업데이트되었습니다.

- **테스트**
    - matchId 유효성 및 채팅방 생성 여부 등 신규 기능과 변경 사항에 대한 테스트가 추가 및 보강되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->