### PR TITLE
CS-237 feat/직관팟 조회

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,8 @@ dependencies {
 	testImplementation "org.testcontainers:mysql:1.20.1"
 	testImplementation 'org.testcontainers:junit-jupiter'
 
+	testImplementation 'org.springframework.cloud:spring-cloud-contract-wiremock'
+
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,6 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0' // for StringUtils
 
-
 	// DB
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'mysql:mysql-connector-java:8.0.33'
@@ -43,6 +42,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 
 	// MSA
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+	implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'
 
 	// Kafka
 	implementation 'org.springframework.kafka:spring-kafka'

--- a/build.gradle
+++ b/build.gradle
@@ -96,3 +96,8 @@ dependencyManagement {
 tasks.named('test') {
 	useJUnitPlatform()
 }
+
+test {
+	systemProperty 'user.language', 'ko'
+	systemProperty 'user.country', 'KR'
+}

--- a/src/main/java/com/playus/twpservice/TwpServiceApplication.java
+++ b/src/main/java/com/playus/twpservice/TwpServiceApplication.java
@@ -2,7 +2,9 @@ package com.playus.twpservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
+@EnableFeignClients
 @SpringBootApplication
 public class TwpServiceApplication {
 

--- a/src/main/java/com/playus/twpservice/domain/party/controller/PartyController.java
+++ b/src/main/java/com/playus/twpservice/domain/party/controller/PartyController.java
@@ -40,6 +40,6 @@ public class PartyController implements PartyControllerSpecification {
     @GetMapping
     public List<PartiesByMatchResponse> getPartiesByMatchId(@AuthenticationPrincipal Long userId,
                                                             @Valid PartiesByMatchRequest request) {
-        return partyReadOnlyService.getPartiesBy(request.matchId(), userId);
+        return partyReadOnlyService.getPartiesBy(request.matchId());
     }
 }

--- a/src/main/java/com/playus/twpservice/domain/party/controller/PartyController.java
+++ b/src/main/java/com/playus/twpservice/domain/party/controller/PartyController.java
@@ -1,9 +1,12 @@
 package com.playus.twpservice.domain.party.controller;
 
+import com.playus.twpservice.domain.party.dto.partyByMatch.PartiesByMatchRequest;
+import com.playus.twpservice.domain.party.dto.partyByMatch.PartiesByMatchResponse;
 import com.playus.twpservice.domain.party.dto.party_create.PartyCreateRequest;
 import com.playus.twpservice.domain.party.dto.party_create.PartyCreateResponse;
 import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageRequest;
 import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageResponse;
+import com.playus.twpservice.domain.party.service.PartyReadOnlyService;
 import com.playus.twpservice.domain.party.service.PartyService;
 import com.playus.twpservice.domain.party.specification.PartyControllerSpecification;
 import jakarta.validation.Valid;
@@ -13,12 +16,14 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+
 @RestController
 @RequestMapping("/party")
 @RequiredArgsConstructor
 public class PartyController implements PartyControllerSpecification {
 
     private final PartyService partyService;
+    private final PartyReadOnlyService partyReadOnlyService;
 
     @PostMapping
     public ResponseEntity<PartyCreateResponse> createParty(@AuthenticationPrincipal Long userId, @Valid @RequestBody PartyCreateRequest request) {
@@ -28,5 +33,11 @@ public class PartyController implements PartyControllerSpecification {
     @PostMapping("/presigned-url")
     public PresignedUrlForSaveImageResponse generatePresignedUrlForSaveImage(@Valid @RequestBody PresignedUrlForSaveImageRequest request) {
         return partyService.generatePresignedUrlForSaveImage(request);
+    }
+
+    @GetMapping
+    public PartiesByMatchResponse getPartiesByMatchId(@AuthenticationPrincipal Long userId,
+                                                      @Valid PartiesByMatchRequest request) {
+        return partyReadOnlyService.getPartiesBy(request.matchId(), userId);
     }
 }

--- a/src/main/java/com/playus/twpservice/domain/party/controller/PartyController.java
+++ b/src/main/java/com/playus/twpservice/domain/party/controller/PartyController.java
@@ -1,7 +1,7 @@
 package com.playus.twpservice.domain.party.controller;
 
-import com.playus.twpservice.domain.party.dto.partyByMatch.PartiesByMatchRequest;
-import com.playus.twpservice.domain.party.dto.partyByMatch.PartiesByMatchResponse;
+import com.playus.twpservice.domain.party.dto.partybymatch.PartiesByMatchRequest;
+import com.playus.twpservice.domain.party.dto.partybymatch.PartiesByMatchResponse;
 import com.playus.twpservice.domain.party.dto.party_create.PartyCreateRequest;
 import com.playus.twpservice.domain.party.dto.party_create.PartyCreateResponse;
 import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageRequest;

--- a/src/main/java/com/playus/twpservice/domain/party/controller/PartyController.java
+++ b/src/main/java/com/playus/twpservice/domain/party/controller/PartyController.java
@@ -38,8 +38,7 @@ public class PartyController implements PartyControllerSpecification {
     }
 
     @GetMapping
-    public List<PartiesByMatchResponse> getPartiesByMatchId(@AuthenticationPrincipal Long userId,
-                                                            @Valid PartiesByMatchRequest request) {
+    public List<PartiesByMatchResponse> getPartiesByMatchId(@Valid PartiesByMatchRequest request) {
         return partyReadOnlyService.getPartiesBy(request.matchId());
     }
 }

--- a/src/main/java/com/playus/twpservice/domain/party/controller/PartyController.java
+++ b/src/main/java/com/playus/twpservice/domain/party/controller/PartyController.java
@@ -16,6 +16,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 
 @RestController
 @RequestMapping("/party")
@@ -36,8 +38,8 @@ public class PartyController implements PartyControllerSpecification {
     }
 
     @GetMapping
-    public PartiesByMatchResponse getPartiesByMatchId(@AuthenticationPrincipal Long userId,
-                                                      @Valid PartiesByMatchRequest request) {
+    public List<PartiesByMatchResponse> getPartiesByMatchId(@AuthenticationPrincipal Long userId,
+                                                            @Valid PartiesByMatchRequest request) {
         return partyReadOnlyService.getPartiesBy(request.matchId(), userId);
     }
 }

--- a/src/main/java/com/playus/twpservice/domain/party/document/PartyAgeDocument.java
+++ b/src/main/java/com/playus/twpservice/domain/party/document/PartyAgeDocument.java
@@ -1,13 +1,13 @@
 package com.playus.twpservice.domain.party.document;
 
-import org.springframework.data.annotation.Id;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.mongodb.core.mapping.DBRef;
+import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.DocumentReference;
 import org.springframework.data.mongodb.core.mapping.Field;
 
 @Getter
@@ -19,7 +19,7 @@ public class PartyAgeDocument {
     private Long id;
 
     @NotNull
-    @DBRef(lazy = true)
+    @DocumentReference(lazy = true)
     @Field(name = "party_id")
     private PartyDocument party;
 

--- a/src/main/java/com/playus/twpservice/domain/party/document/PartyAgeDocument.java
+++ b/src/main/java/com/playus/twpservice/domain/party/document/PartyAgeDocument.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.DocumentReference;
 import org.springframework.data.mongodb.core.mapping.Field;
@@ -19,6 +20,7 @@ public class PartyAgeDocument {
     private Long id;
 
     @NotNull
+    @Indexed
     @DocumentReference(lazy = true)
     @Field(name = "party_id")
     private PartyDocument party;

--- a/src/main/java/com/playus/twpservice/domain/party/document/PartyDocument.java
+++ b/src/main/java/com/playus/twpservice/domain/party/document/PartyDocument.java
@@ -62,25 +62,6 @@ public class PartyDocument extends BaseTimeEntity {
     @Size(min = 1, max = 255)
     private String thumbnailUrl;
 
-    public PartyDocument(Long id, String title, PartyJoinMethod partyJoinMethod, PartyGender partyGender, Long minimumParticipants, Long maximumParticipants, Long writerId, Long matchId, String chatRoomId, String text, String thumbnailUrl) {
-        this.id = id;
-        this.title = title;
-        this.partyJoinMethod = partyJoinMethod;
-        this.partyGender = partyGender;
-        this.minimumParticipants = minimumParticipants;
-        this.maximumParticipants = maximumParticipants;
-        this.writerId = writerId;
-        this.matchId = matchId;
-        this.chatRoomId = chatRoomId;
-        this.text = text;
-        this.thumbnailUrl = thumbnailUrl;
-    }
-
-    public PartyDocument(String title, PartyJoinMethod partyJoinMethod) {
-        this.title = title;
-        this.partyJoinMethod = partyJoinMethod;
-    }
-
     @Builder
     private PartyDocument(Long id, String title, String text, Long minimumParticipants, Long maximumParticipants,
                           String thumbnailUrl, PartyGender partyGender, PartyJoinMethod partyJoinMethod, Long writerId, Long matchId, String chatRoomId) {

--- a/src/main/java/com/playus/twpservice/domain/party/document/PartyDocument.java
+++ b/src/main/java/com/playus/twpservice/domain/party/document/PartyDocument.java
@@ -41,6 +41,10 @@ public class PartyDocument extends BaseTimeEntity {
     private Long maximumParticipants;
 
     @NotNull
+    @Field(name = "writer_id")
+    private Long writerId;
+
+    @NotNull
     @Field(name = "match_id")
     private Long matchId;
 
@@ -56,11 +60,28 @@ public class PartyDocument extends BaseTimeEntity {
     @Size(min = 1, max = 255)
     private String thumbnailUrl;
 
+    public PartyDocument(Long id, String title, PartyJoinMethod partyJoinMethod, PartyGender partyGender, Long minimumParticipants, Long maximumParticipants, Long writerId, Long matchId, String chatRoomId, String text, String thumbnailUrl) {
+        this.id = id;
+        this.title = title;
+        this.partyJoinMethod = partyJoinMethod;
+        this.partyGender = partyGender;
+        this.minimumParticipants = minimumParticipants;
+        this.maximumParticipants = maximumParticipants;
+        this.writerId = writerId;
+        this.matchId = matchId;
+        this.chatRoomId = chatRoomId;
+        this.text = text;
+        this.thumbnailUrl = thumbnailUrl;
+    }
 
+    public PartyDocument(String title, PartyJoinMethod partyJoinMethod) {
+        this.title = title;
+        this.partyJoinMethod = partyJoinMethod;
+    }
 
     @Builder
     private PartyDocument(Long id, String title, String text, Long minimumParticipants, Long maximumParticipants,
-                          String thumbnailUrl, PartyGender partyGender, PartyJoinMethod partyJoinMethod, Long matchId, String chatRoomId) {
+                          String thumbnailUrl, PartyGender partyGender, PartyJoinMethod partyJoinMethod, Long writerId, Long matchId, String chatRoomId) {
         this.id = id;
         this.title = title;
         this.text = text;
@@ -71,11 +92,12 @@ public class PartyDocument extends BaseTimeEntity {
         this.partyJoinMethod = partyJoinMethod;
         this.matchId = matchId;
         this.chatRoomId = chatRoomId;
+        this.writerId = writerId;
     }
 
     public static PartyDocument createForOnlyTest(Long id, String title, String text, Long minimumParticipants,
                                                   Long maximumParticipants, String thumbnailUrl, PartyGender partyGender, PartyJoinMethod partyJoinMethod,
-                                                  Long matchId, String chatRoomId) {
+                                                  Long writerId, Long matchId, String chatRoomId) {
         return PartyDocument.builder()
                 .id(id)
                 .title(title)
@@ -85,6 +107,7 @@ public class PartyDocument extends BaseTimeEntity {
                 .thumbnailUrl(thumbnailUrl)
                 .partyGender(partyGender)
                 .partyJoinMethod(partyJoinMethod)
+                .writerId(writerId)
                 .matchId(matchId)
                 .chatRoomId(chatRoomId)
                 .build();

--- a/src/main/java/com/playus/twpservice/domain/party/document/PartyDocument.java
+++ b/src/main/java/com/playus/twpservice/domain/party/document/PartyDocument.java
@@ -10,6 +10,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 
@@ -45,6 +46,7 @@ public class PartyDocument extends BaseTimeEntity {
     private Long writerId;
 
     @NotNull
+    @Indexed
     @Field(name = "match_id")
     private Long matchId;
 

--- a/src/main/java/com/playus/twpservice/domain/party/document/PartyJoinDocument.java
+++ b/src/main/java/com/playus/twpservice/domain/party/document/PartyJoinDocument.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.DocumentReference;
 import org.springframework.data.mongodb.core.mapping.Field;
@@ -25,6 +26,7 @@ public class PartyJoinDocument {
     private Long userId;
 
     @NotNull
+    @Indexed
     @DocumentReference(lazy = true)
     @Field(name = "party_id")
     private PartyDocument party;

--- a/src/main/java/com/playus/twpservice/domain/party/document/PartyJoinDocument.java
+++ b/src/main/java/com/playus/twpservice/domain/party/document/PartyJoinDocument.java
@@ -1,15 +1,15 @@
 package com.playus.twpservice.domain.party.document;
 
 import com.playus.twpservice.domain.party.enums.PartyJoinRequestStatus;
-import org.springframework.data.annotation.Id;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.mongodb.core.mapping.DBRef;
+import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.DocumentReference;
 import org.springframework.data.mongodb.core.mapping.Field;
 
 @Getter
@@ -25,7 +25,7 @@ public class PartyJoinDocument {
     private Long userId;
 
     @NotNull
-    @DBRef(lazy = true)
+    @DocumentReference(lazy = true)
     @Field(name = "party_id")
     private PartyDocument party;
 

--- a/src/main/java/com/playus/twpservice/domain/party/document/PartyJoinDocument.java
+++ b/src/main/java/com/playus/twpservice/domain/party/document/PartyJoinDocument.java
@@ -33,31 +33,26 @@ public class PartyJoinDocument {
     private PartyJoinRequestStatus partyJoinRequestStatus;
 
     @NotNull
-    @Field(name = "is_writer")
-    private Boolean isWriter;
-
-    @NotNull
     @Field(name = "require_message")
     @Size(min = 1, max = 100)
     private String requireMessage;
 
     @Builder
-    private PartyJoinDocument(Long id, Long userId, PartyDocument party, PartyJoinRequestStatus partyJoinRequestStatus, Boolean isWriter, String requireMessage) {
+    private PartyJoinDocument(Long id, Long userId, PartyDocument party, PartyJoinRequestStatus partyJoinRequestStatus, String requireMessage) {
         this.id = id;
         this.userId = userId;
         this.party = party;
         this.partyJoinRequestStatus = partyJoinRequestStatus;
-        this.isWriter = isWriter;
         this.requireMessage = requireMessage;
     }
 
-    public static PartyJoinDocument createForOnlyTest(Long id, Long userId, PartyDocument party, PartyJoinRequestStatus partyJoinRequestStatus, String requireMessage) {
+    public static PartyJoinDocument createForOnlyTest(Long id, Long userId, PartyDocument party,
+                                                      PartyJoinRequestStatus partyJoinRequestStatus, String requireMessage) {
         return PartyJoinDocument.builder()
                 .id(id)
                 .userId(userId)
                 .party(party)
                 .partyJoinRequestStatus(partyJoinRequestStatus)
-                .isWriter(true)
                 .requireMessage(requireMessage)
                 .build();
     }

--- a/src/main/java/com/playus/twpservice/domain/party/document/PartyJoinDocument.java
+++ b/src/main/java/com/playus/twpservice/domain/party/document/PartyJoinDocument.java
@@ -34,9 +34,8 @@ public class PartyJoinDocument {
     @NotNull
     private PartyJoinRequestStatus partyJoinRequestStatus;
 
-    @NotNull
     @Field(name = "require_message")
-    @Size(min = 1, max = 100)
+    @Size(max = 100)
     private String requireMessage;
 
     @Builder

--- a/src/main/java/com/playus/twpservice/domain/party/document/PartyJoinDocument.java
+++ b/src/main/java/com/playus/twpservice/domain/party/document/PartyJoinDocument.java
@@ -1,6 +1,6 @@
 package com.playus.twpservice.domain.party.document;
 
-import com.playus.twpservice.domain.party.enums.Status;
+import com.playus.twpservice.domain.party.enums.PartyJoinRequestStatus;
 import org.springframework.data.annotation.Id;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -30,7 +30,7 @@ public class PartyJoinDocument {
     private PartyDocument party;
 
     @NotNull
-    private Status status;
+    private PartyJoinRequestStatus partyJoinRequestStatus;
 
     @NotNull
     @Field(name = "is_writer")
@@ -42,21 +42,21 @@ public class PartyJoinDocument {
     private String requireMessage;
 
     @Builder
-    private PartyJoinDocument(Long id, Long userId, PartyDocument party, Status status, Boolean isWriter, String requireMessage) {
+    private PartyJoinDocument(Long id, Long userId, PartyDocument party, PartyJoinRequestStatus partyJoinRequestStatus, Boolean isWriter, String requireMessage) {
         this.id = id;
         this.userId = userId;
         this.party = party;
-        this.status = status;
+        this.partyJoinRequestStatus = partyJoinRequestStatus;
         this.isWriter = isWriter;
         this.requireMessage = requireMessage;
     }
 
-    public static PartyJoinDocument createForOnlyTest(Long id, Long userId, PartyDocument party, Status status, String requireMessage) {
+    public static PartyJoinDocument createForOnlyTest(Long id, Long userId, PartyDocument party, PartyJoinRequestStatus partyJoinRequestStatus, String requireMessage) {
         return PartyJoinDocument.builder()
                 .id(id)
                 .userId(userId)
                 .party(party)
-                .status(status)
+                .partyJoinRequestStatus(partyJoinRequestStatus)
                 .isWriter(true)
                 .requireMessage(requireMessage)
                 .build();

--- a/src/main/java/com/playus/twpservice/domain/party/document/PartyThumbnailUrlDocument.java
+++ b/src/main/java/com/playus/twpservice/domain/party/document/PartyThumbnailUrlDocument.java
@@ -32,7 +32,7 @@ public class PartyThumbnailUrlDocument {
         this.thumbnailUrl = thumbnailUrl;
     }
 
-    public static PartyThumbnailUrlDocument create(PartyDocument party, String thumbnailUrl) {
+    public static PartyThumbnailUrlDocument createForOnlyTest(PartyDocument party, String thumbnailUrl) {
         return PartyThumbnailUrlDocument.builder()
                 .party(party)
                 .thumbnailUrl(thumbnailUrl)

--- a/src/main/java/com/playus/twpservice/domain/party/document/PartyThumbnailUrlDocument.java
+++ b/src/main/java/com/playus/twpservice/domain/party/document/PartyThumbnailUrlDocument.java
@@ -6,8 +6,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
-import org.springframework.data.mongodb.core.mapping.DBRef;
 import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.DocumentReference;
 import org.springframework.data.mongodb.core.mapping.Field;
 
 @Getter
@@ -19,7 +19,7 @@ public class PartyThumbnailUrlDocument {
     private Long id;
 
     @NotNull
-    @DBRef(lazy = true)
+    @DocumentReference(lazy = true)
     @Field(name = "party_id")
     private PartyDocument party;
 
@@ -27,13 +27,15 @@ public class PartyThumbnailUrlDocument {
     private String thumbnailUrl;
 
     @Builder
-    private PartyThumbnailUrlDocument(PartyDocument party, String thumbnailUrl) {
+    private PartyThumbnailUrlDocument(Long id, PartyDocument party, String thumbnailUrl) {
+        this.id = id;
         this.party = party;
         this.thumbnailUrl = thumbnailUrl;
     }
 
-    public static PartyThumbnailUrlDocument createForOnlyTest(PartyDocument party, String thumbnailUrl) {
+    public static PartyThumbnailUrlDocument createForOnlyTest(Long id, PartyDocument party, String thumbnailUrl) {
         return PartyThumbnailUrlDocument.builder()
+                .id(id)
                 .party(party)
                 .thumbnailUrl(thumbnailUrl)
                 .build();

--- a/src/main/java/com/playus/twpservice/domain/party/document/PartyThumbnailUrlDocument.java
+++ b/src/main/java/com/playus/twpservice/domain/party/document/PartyThumbnailUrlDocument.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.DocumentReference;
 import org.springframework.data.mongodb.core.mapping.Field;
@@ -19,6 +20,7 @@ public class PartyThumbnailUrlDocument {
     private Long id;
 
     @NotNull
+    @Indexed
     @DocumentReference(lazy = true)
     @Field(name = "party_id")
     private PartyDocument party;

--- a/src/main/java/com/playus/twpservice/domain/party/dto/party_create/PartyCreateRequest.java
+++ b/src/main/java/com/playus/twpservice/domain/party/dto/party_create/PartyCreateRequest.java
@@ -73,7 +73,7 @@ public record PartyCreateRequest(
                 .build();
     }
 
-    public Party toParty() {
-        return Party.create(title, message, minimumParticipants, maximumParticipants, PartyGender.toEnumValue(partyGender), PartyJoinMethod.toEnumValue(partyJoinMethod), matchId);
+    public Party toPartyWith(Long userId) {
+        return Party.create(title, message, minimumParticipants, maximumParticipants, PartyGender.toEnumValue(partyGender), PartyJoinMethod.toEnumValue(partyJoinMethod), userId, matchId);
     }
 }

--- a/src/main/java/com/playus/twpservice/domain/party/dto/partybymatch/PartiesByMatchRequest.java
+++ b/src/main/java/com/playus/twpservice/domain/party/dto/partybymatch/PartiesByMatchRequest.java
@@ -1,0 +1,11 @@
+package com.playus.twpservice.domain.party.dto.partybymatch;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record PartiesByMatchRequest (
+        @NotNull(message = "경기 ID는 필수입니다!")
+        @Min(value = 1, message = "ID는 1 이상이여아 합니다!")
+        Long matchId
+) {
+}

--- a/src/main/java/com/playus/twpservice/domain/party/dto/partybymatch/PartiesByMatchResponse.java
+++ b/src/main/java/com/playus/twpservice/domain/party/dto/partybymatch/PartiesByMatchResponse.java
@@ -1,0 +1,55 @@
+package com.playus.twpservice.domain.party.dto.partybymatch;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+public record PartiesByMatchResponse(
+        String title,
+        String partyJoinMethod,
+        List<String> partyAges,
+        String availableGender,
+        String authorName,
+        String authorGender,
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "M.d(E) a h:mm", timezone = "Asia/Seoul")
+        LocalDateTime matchDate, // BE 기준 match entity에서 LocalDateTime 으로 저장
+
+        Long currentParticipantsCount,
+        Long maximumParticipantsCount,
+        List<String> partyThumbnailUrls,
+        List<String> userThumbnailUrls
+) {
+
+
+    public static PartiesByMatchResponse of(
+            String title,
+            String partyJoinMethod,
+            List<String> partyAges,
+            String availableGender,
+            String authorName,
+            String authorGender,
+            LocalDateTime matchDate,
+            Long currentParticipantsCount,
+            Long maximumParticipantsCount,
+            List<String> partyThumbnailUrls,
+            List<String> userThumbnailUrls
+    ) {
+        return PartiesByMatchResponse.builder()
+                .title(title)
+                .partyJoinMethod(partyJoinMethod)
+                .partyAges(partyAges)
+                .availableGender(availableGender)
+                .authorName(authorName)
+                .authorGender(authorGender)
+                .matchDate(matchDate)
+                .currentParticipantsCount(currentParticipantsCount)
+                .maximumParticipantsCount(maximumParticipantsCount)
+                .partyThumbnailUrls(partyThumbnailUrls)
+                .userThumbnailUrls(userThumbnailUrls)
+                .build();
+    }
+}

--- a/src/main/java/com/playus/twpservice/domain/party/dto/partybymatch/PartiesByMatchResponse.java
+++ b/src/main/java/com/playus/twpservice/domain/party/dto/partybymatch/PartiesByMatchResponse.java
@@ -1,6 +1,9 @@
 package com.playus.twpservice.domain.party.dto.partybymatch;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.playus.twpservice.domain.party.enums.PartyAgeGroup;
+import com.playus.twpservice.domain.party.enums.PartyGender;
+import com.playus.twpservice.domain.party.enums.PartyJoinMethod;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
@@ -27,9 +30,9 @@ public record PartiesByMatchResponse(
 
     public static PartiesByMatchResponse of(
             String title,
-            String partyJoinMethod,
-            List<String> partyAges,
-            String availableGender,
+            PartyJoinMethod partyJoinMethod,
+            List<PartyAgeGroup> partyAges,
+            PartyGender availableGender,
             String authorName,
             String authorGender,
             LocalDateTime matchDate,
@@ -40,9 +43,9 @@ public record PartiesByMatchResponse(
     ) {
         return PartiesByMatchResponse.builder()
                 .title(title)
-                .partyJoinMethod(partyJoinMethod)
-                .partyAges(partyAges)
-                .availableGender(availableGender)
+                .partyJoinMethod(partyJoinMethod.getDescription())
+                .partyAges(partyAges.stream().map(PartyAgeGroup::getDescription).toList())
+                .availableGender(availableGender.getDescription())
                 .authorName(authorName)
                 .authorGender(authorGender)
                 .matchDate(matchDate)

--- a/src/main/java/com/playus/twpservice/domain/party/dto/partybymatch/PartiesByMatchResponse.java
+++ b/src/main/java/com/playus/twpservice/domain/party/dto/partybymatch/PartiesByMatchResponse.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 @Builder
 public record PartiesByMatchResponse(
+        Long partyId,
         String title,
         String partyJoinMethod,
         List<String> partyAges,
@@ -29,6 +30,7 @@ public record PartiesByMatchResponse(
 
 
     public static PartiesByMatchResponse of(
+            Long partyId,
             String title,
             PartyJoinMethod partyJoinMethod,
             List<PartyAgeGroup> partyAges,
@@ -42,6 +44,7 @@ public record PartiesByMatchResponse(
             List<String> userThumbnailUrls
     ) {
         return PartiesByMatchResponse.builder()
+                .partyId(partyId)
                 .title(title)
                 .partyJoinMethod(partyJoinMethod.getDescription())
                 .partyAges(partyAges.stream().map(PartyAgeGroup::getDescription).toList())

--- a/src/main/java/com/playus/twpservice/domain/party/entity/Party.java
+++ b/src/main/java/com/playus/twpservice/domain/party/entity/Party.java
@@ -36,6 +36,9 @@ public class Party extends BaseTimeEntity {
     @Column(nullable = false, name = "maximum_participants")
     private Long maximumParticipants;
 
+    @Column(nullable = false, name = "writer_id")
+    private Long writerId;
+
     @Column(nullable = false, name = "match_id")
     private Long matchId;
 
@@ -46,17 +49,19 @@ public class Party extends BaseTimeEntity {
     private String text;
 
     @Builder
-    private Party(String title, String text, Long minimumParticipants, Long maximumParticipants, PartyGender partyGender, PartyJoinMethod partyJoinMethod, Long matchId){
+    private Party(String title, String text, Long minimumParticipants, Long maximumParticipants, PartyGender partyGender, PartyJoinMethod partyJoinMethod, Long writerId, Long matchId){
         this.title = title;
         this.text = text;
         this.minimumParticipants = minimumParticipants;
         this.maximumParticipants = maximumParticipants;
         this.partyGender = partyGender;
         this.partyJoinMethod = partyJoinMethod;
+        this.writerId = writerId;
         this.matchId = matchId;
     }
 
-    public static Party create(String title, String text, Long minimumParticipants, Long maximumParticipants, PartyGender partyGender, PartyJoinMethod partyJoinMethod, Long matchId){
+    public static Party create(String title, String text, Long minimumParticipants, Long maximumParticipants,
+                               PartyGender partyGender, PartyJoinMethod partyJoinMethod, Long writerId, Long matchId){
         return Party.builder()
                 .title(title)
                 .text(text)
@@ -64,6 +69,7 @@ public class Party extends BaseTimeEntity {
                 .maximumParticipants(maximumParticipants)
                 .partyGender(partyGender)
                 .partyJoinMethod(partyJoinMethod)
+                .writerId(writerId)
                 .matchId(matchId)
                 .build();
     }

--- a/src/main/java/com/playus/twpservice/domain/party/entity/PartyJoin.java
+++ b/src/main/java/com/playus/twpservice/domain/party/entity/PartyJoin.java
@@ -28,18 +28,14 @@ public class PartyJoin {
     @Column(nullable = false)
     private PartyJoinRequestStatus partyJoinRequestStatus;
 
-    @Column(nullable = false, name = "is_writer")
-    private Boolean isWriter;
-
     @Column(name = "require_message", length = 100)
     private String requireMessage;
 
     @Builder
-    private PartyJoin(Long userId, Party party, PartyJoinRequestStatus partyJoinRequestStatus, boolean isWriter, String requireMessage) {
+    private PartyJoin(Long userId, Party party, PartyJoinRequestStatus partyJoinRequestStatus, String requireMessage) {
         this.userId = userId;
         this.party = party;
         this.partyJoinRequestStatus = partyJoinRequestStatus;
-        this.isWriter = isWriter;
         this.requireMessage = requireMessage;
     }
 
@@ -48,7 +44,6 @@ public class PartyJoin {
                 .userId(userId)
                 .party(party)
                 .partyJoinRequestStatus(partyJoinRequestStatus)
-                .isWriter(true)
                 .requireMessage(requireMessage)
                 .build();
     }

--- a/src/main/java/com/playus/twpservice/domain/party/entity/PartyJoin.java
+++ b/src/main/java/com/playus/twpservice/domain/party/entity/PartyJoin.java
@@ -1,6 +1,6 @@
 package com.playus.twpservice.domain.party.entity;
 
-import com.playus.twpservice.domain.party.enums.Status;
+import com.playus.twpservice.domain.party.enums.PartyJoinRequestStatus;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -26,7 +26,7 @@ public class PartyJoin {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private Status status;
+    private PartyJoinRequestStatus partyJoinRequestStatus;
 
     @Column(nullable = false, name = "is_writer")
     private Boolean isWriter;
@@ -35,19 +35,19 @@ public class PartyJoin {
     private String requireMessage;
 
     @Builder
-    private PartyJoin(Long userId, Party party, Status status, boolean isWriter, String requireMessage) {
+    private PartyJoin(Long userId, Party party, PartyJoinRequestStatus partyJoinRequestStatus, boolean isWriter, String requireMessage) {
         this.userId = userId;
         this.party = party;
-        this.status = status;
+        this.partyJoinRequestStatus = partyJoinRequestStatus;
         this.isWriter = isWriter;
         this.requireMessage = requireMessage;
     }
 
-    public static PartyJoin create (Long userId, Party party, Status status,String requireMessage) {
+    public static PartyJoin create (Long userId, Party party, PartyJoinRequestStatus partyJoinRequestStatus, String requireMessage) {
         return PartyJoin.builder()
                 .userId(userId)
                 .party(party)
-                .status(status)
+                .partyJoinRequestStatus(partyJoinRequestStatus)
                 .isWriter(true)
                 .requireMessage(requireMessage)
                 .build();

--- a/src/main/java/com/playus/twpservice/domain/party/enums/PartyAgeGroup.java
+++ b/src/main/java/com/playus/twpservice/domain/party/enums/PartyAgeGroup.java
@@ -5,6 +5,8 @@ import com.playus.twpservice.domain.party.exception.enums.PartyAgeGroupException
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import static com.playus.twpservice.domain.party.exception.enums.PartyAgeGroupExceptionGroup.*;
+
 
 @Getter
 @NoArgsConstructor
@@ -30,6 +32,15 @@ public enum PartyAgeGroup implements Describable {
                 return group.getAge();
             }
         }
-        throw new PartyAgeGroupExceptionGroup.InvalidDescriptionException("Invalid description: " + description);
+        throw new InvalidDescriptionException("Invalid description: " + description);
+    }
+
+    public static PartyAgeGroup getAgeGroupByAge(int age) {
+        for (PartyAgeGroup group : PartyAgeGroup.values()) {
+            if (group.getAge() == age) {
+                return group;
+            }
+        }
+        throw new InvalidAgeException("Invalid age: " + age);
     }
 }

--- a/src/main/java/com/playus/twpservice/domain/party/enums/PartyJoinRequestStatus.java
+++ b/src/main/java/com/playus/twpservice/domain/party/enums/PartyJoinRequestStatus.java
@@ -1,5 +1,5 @@
 package com.playus.twpservice.domain.party.enums;
 
-public enum Status {
+public enum PartyJoinRequestStatus {
     WAIT, REFUSE, ACCEPT
 }

--- a/src/main/java/com/playus/twpservice/domain/party/exception/enums/PartyAgeGroupExceptionGroup.java
+++ b/src/main/java/com/playus/twpservice/domain/party/exception/enums/PartyAgeGroupExceptionGroup.java
@@ -24,4 +24,16 @@ public class PartyAgeGroupExceptionGroup {
             super(message);
         }
     }
+
+    public static class InvalidAgeException extends RuntimeException {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
+
+        public InvalidAgeException(String message) {
+            super(message);
+        }
+    }
+
+
 }

--- a/src/main/java/com/playus/twpservice/domain/party/feign/client/MatchFeignClient.java
+++ b/src/main/java/com/playus/twpservice/domain/party/feign/client/MatchFeignClient.java
@@ -12,6 +12,6 @@ import java.time.LocalDateTime;
 @CircuitBreaker(name = "circuit")
 public interface MatchFeignClient {
 
-    @GetMapping("/api/match")
+    @GetMapping("/match/api/date")
     LocalDateTime getMatchDate(@RequestParam Long matchId);
 }

--- a/src/main/java/com/playus/twpservice/domain/party/feign/client/MatchFeignClient.java
+++ b/src/main/java/com/playus/twpservice/domain/party/feign/client/MatchFeignClient.java
@@ -8,10 +8,10 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 import java.time.LocalDateTime;
 
-@FeignClient(name = "matchFeignClient", url = "${feign.match.url}", fallback = MatchFeignFallback.class)
+@FeignClient(name = "matchFeignClient", url = "${feign.match.url}", path = "/match/api", fallback = MatchFeignFallback.class)
 @CircuitBreaker(name = "circuit")
 public interface MatchFeignClient {
 
-    @GetMapping("/match/api/date")
+    @GetMapping("/date")
     LocalDateTime getMatchDate(@RequestParam Long matchId);
 }

--- a/src/main/java/com/playus/twpservice/domain/party/feign/client/MatchFeignClient.java
+++ b/src/main/java/com/playus/twpservice/domain/party/feign/client/MatchFeignClient.java
@@ -1,16 +1,17 @@
 package com.playus.twpservice.domain.party.feign.client;
 
+import com.playus.twpservice.domain.party.feign.fallback.MatchFeignFallback;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import org.springframework.cloud.openfeign.FeignClient;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
-// match-service, /match/api 예상 중
-@FeignClient(name = "${feign.match.domain}", url = "${feign.match.url}", fallback = MatchFeignClient.class)
+@FeignClient(name = "matchFeignClient", url = "${feign.match.url}", fallback = MatchFeignFallback.class)
 @CircuitBreaker(name = "circuit")
 public interface MatchFeignClient {
 
-    List<LocalDateTime> getMatchDate(@RequestBody List<Long> matchIdList);
+    @GetMapping("/api/match")
+    LocalDateTime getMatchDate(@RequestParam Long matchId);
 }

--- a/src/main/java/com/playus/twpservice/domain/party/feign/client/MatchFeignClient.java
+++ b/src/main/java/com/playus/twpservice/domain/party/feign/client/MatchFeignClient.java
@@ -1,0 +1,16 @@
+package com.playus.twpservice.domain.party.feign.client;
+
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+// match-service, /match/api 예상 중
+@FeignClient(name = "${feign.match.domain}", url = "${feign.match.url}", fallback = MatchFeignClient.class)
+@CircuitBreaker(name = "circuit")
+public interface MatchFeignClient {
+
+    List<LocalDateTime> getMatchDate(@RequestBody List<Long> matchIdList);
+}

--- a/src/main/java/com/playus/twpservice/domain/party/feign/client/UserFeignClient.java
+++ b/src/main/java/com/playus/twpservice/domain/party/feign/client/UserFeignClient.java
@@ -1,6 +1,7 @@
 package com.playus.twpservice.domain.party.feign.client;
 
 import com.playus.twpservice.domain.party.feign.fallback.UserFeignFallback;
+import com.playus.twpservice.domain.party.feign.response.PartyUserThumbnailUrlListResponse;
 import com.playus.twpservice.domain.party.feign.response.PartyWriterInfoFeignResponse;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import org.springframework.cloud.openfeign.FeignClient;
@@ -20,5 +21,5 @@ public interface UserFeignClient {
      List<PartyWriterInfoFeignResponse> getWriterInfo(@RequestBody List<Long> writerIdList);
 
 
-     List<String> getPartyUserThumbnailUrls(@RequestBody List<Long> userIdList);
+     PartyUserThumbnailUrlListResponse getPartyUserThumbnailUrls(@RequestBody List<Long> userIdList);
 }

--- a/src/main/java/com/playus/twpservice/domain/party/feign/client/UserFeignClient.java
+++ b/src/main/java/com/playus/twpservice/domain/party/feign/client/UserFeignClient.java
@@ -10,14 +10,13 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 import java.util.List;
 
-@FeignClient(name = "userFeignClient", url = "${feign.user.url}",
-             fallback = UserFeignFallback.class)
+@FeignClient(name = "userFeignClient", url = "${feign.user.url}", path = "/user/api", fallback = UserFeignFallback.class)
 @CircuitBreaker(name = "circuit")
 public interface UserFeignClient {
 
-     @PostMapping("/user/api/thumbnails")
+     @PostMapping("/thumbnails")
      PartyUserThumbnailUrlListResponse getPartyUserThumbnailUrls(@RequestBody List<Long> userIdList);
 
-     @PostMapping("/user/api/writers")
+     @PostMapping("/writers")
      List<PartyWriterInfoFeignResponse> getWriterInfo(@RequestBody List<Long> writerIdList);
 }

--- a/src/main/java/com/playus/twpservice/domain/party/feign/client/UserFeignClient.java
+++ b/src/main/java/com/playus/twpservice/domain/party/feign/client/UserFeignClient.java
@@ -1,0 +1,24 @@
+package com.playus.twpservice.domain.party.feign.client;
+
+import com.playus.twpservice.domain.party.feign.fallback.UserFeignFallback;
+import com.playus.twpservice.domain.party.feign.response.PartyWriterInfoFeignResponse;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
+
+// user-service, /user/api 예상 중
+@FeignClient(name = "${feign.user.domain}",
+             url = "${feign.author-info.url}",
+             fallback = UserFeignFallback.class)
+@CircuitBreaker(name = "circuit")
+public interface UserFeignClient {
+
+     @PostMapping("/writers")
+     List<PartyWriterInfoFeignResponse> getWriterInfo(@RequestBody List<Long> writerIdList);
+
+
+     List<String> getPartyUserThumbnailUrls(@RequestBody List<Long> userIdList);
+}

--- a/src/main/java/com/playus/twpservice/domain/party/feign/client/UserFeignClient.java
+++ b/src/main/java/com/playus/twpservice/domain/party/feign/client/UserFeignClient.java
@@ -10,16 +10,14 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 import java.util.List;
 
-// user-service, /user/api 예상 중
-@FeignClient(name = "${feign.user.domain}",
-             url = "${feign.author-info.url}",
+@FeignClient(name = "userFeignClient", url = "${feign.user.url}",
              fallback = UserFeignFallback.class)
 @CircuitBreaker(name = "circuit")
 public interface UserFeignClient {
 
-     @PostMapping("/writers")
-     List<PartyWriterInfoFeignResponse> getWriterInfo(@RequestBody List<Long> writerIdList);
-
-
+     @PostMapping("/user/api/thumbnails")
      PartyUserThumbnailUrlListResponse getPartyUserThumbnailUrls(@RequestBody List<Long> userIdList);
+
+     @PostMapping("/user/api/writers")
+     List<PartyWriterInfoFeignResponse> getWriterInfo(@RequestBody List<Long> writerIdList);
 }

--- a/src/main/java/com/playus/twpservice/domain/party/feign/fallback/MatchFeignFallback.java
+++ b/src/main/java/com/playus/twpservice/domain/party/feign/fallback/MatchFeignFallback.java
@@ -1,0 +1,15 @@
+package com.playus.twpservice.domain.party.feign.fallback;
+
+import com.playus.twpservice.domain.party.feign.client.MatchFeignClient;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class MatchFeignFallback implements MatchFeignClient {
+
+    @Override
+    public List<LocalDateTime> getMatchDate(List<Long> matchIdList) {
+        return List.of();
+    }
+
+}

--- a/src/main/java/com/playus/twpservice/domain/party/feign/fallback/MatchFeignFallback.java
+++ b/src/main/java/com/playus/twpservice/domain/party/feign/fallback/MatchFeignFallback.java
@@ -1,15 +1,18 @@
 package com.playus.twpservice.domain.party.feign.fallback;
 
 import com.playus.twpservice.domain.party.feign.client.MatchFeignClient;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
 
+@Slf4j
 @Component
 public class MatchFeignFallback implements MatchFeignClient {
 
     @Override
     public LocalDateTime getMatchDate(Long matchId) {
+        log.error("503 happened in MatchFeignClient at fetching match date!!!");
         return LocalDateTime.of(2023, 10, 1, 0, 0);
     }
 }

--- a/src/main/java/com/playus/twpservice/domain/party/feign/fallback/MatchFeignFallback.java
+++ b/src/main/java/com/playus/twpservice/domain/party/feign/fallback/MatchFeignFallback.java
@@ -1,15 +1,15 @@
 package com.playus.twpservice.domain.party.feign.fallback;
 
 import com.playus.twpservice.domain.party.feign.client.MatchFeignClient;
+import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
+@Component
 public class MatchFeignFallback implements MatchFeignClient {
 
     @Override
-    public List<LocalDateTime> getMatchDate(List<Long> matchIdList) {
-        return List.of();
+    public LocalDateTime getMatchDate(Long matchId) {
+        return LocalDateTime.of(2023, 10, 1, 0, 0);
     }
-
 }

--- a/src/main/java/com/playus/twpservice/domain/party/feign/fallback/UserFeignFallback.java
+++ b/src/main/java/com/playus/twpservice/domain/party/feign/fallback/UserFeignFallback.java
@@ -1,0 +1,19 @@
+package com.playus.twpservice.domain.party.feign.fallback;
+
+import com.playus.twpservice.domain.party.feign.client.UserFeignClient;
+import com.playus.twpservice.domain.party.feign.response.PartyWriterInfoFeignResponse;
+
+import java.util.List;
+
+public class UserFeignFallback implements UserFeignClient {
+
+    @Override
+    public List<PartyWriterInfoFeignResponse> getWriterInfo(List<Long> writerIdList) {
+        return List.of();
+    }
+
+    @Override
+    public List<String> getPartyUserThumbnailUrls(List<Long> userIdList) {
+        return List.of();
+    }
+}

--- a/src/main/java/com/playus/twpservice/domain/party/feign/fallback/UserFeignFallback.java
+++ b/src/main/java/com/playus/twpservice/domain/party/feign/fallback/UserFeignFallback.java
@@ -1,19 +1,22 @@
 package com.playus.twpservice.domain.party.feign.fallback;
 
 import com.playus.twpservice.domain.party.feign.client.UserFeignClient;
+import com.playus.twpservice.domain.party.feign.response.PartyUserThumbnailUrlListResponse;
 import com.playus.twpservice.domain.party.feign.response.PartyWriterInfoFeignResponse;
+import org.springframework.stereotype.Component;
 
 import java.util.List;
 
+@Component
 public class UserFeignFallback implements UserFeignClient {
 
     @Override
     public List<PartyWriterInfoFeignResponse> getWriterInfo(List<Long> writerIdList) {
-        return List.of();
+        return List.of(PartyWriterInfoFeignResponse.withServiceUnavailable());
     }
 
     @Override
-    public List<String> getPartyUserThumbnailUrls(List<Long> userIdList) {
-        return List.of();
+    public PartyUserThumbnailUrlListResponse getPartyUserThumbnailUrls(List<Long> userIdList) {
+        return PartyUserThumbnailUrlListResponse.withServiceUnavailable();
     }
 }

--- a/src/main/java/com/playus/twpservice/domain/party/feign/fallback/UserFeignFallback.java
+++ b/src/main/java/com/playus/twpservice/domain/party/feign/fallback/UserFeignFallback.java
@@ -3,20 +3,24 @@ package com.playus.twpservice.domain.party.feign.fallback;
 import com.playus.twpservice.domain.party.feign.client.UserFeignClient;
 import com.playus.twpservice.domain.party.feign.response.PartyUserThumbnailUrlListResponse;
 import com.playus.twpservice.domain.party.feign.response.PartyWriterInfoFeignResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 
+@Slf4j
 @Component
 public class UserFeignFallback implements UserFeignClient {
 
     @Override
     public List<PartyWriterInfoFeignResponse> getWriterInfo(List<Long> writerIdList) {
+        log.error("503 happened in UserFeignClient at fetching writer data!!!");
         return List.of(PartyWriterInfoFeignResponse.withServiceUnavailable());
     }
 
     @Override
     public PartyUserThumbnailUrlListResponse getPartyUserThumbnailUrls(List<Long> userIdList) {
+        log.error("503 happened in UserFeignClient at fetching user thumbnail data!!!");
         return PartyUserThumbnailUrlListResponse.withServiceUnavailable();
     }
 }

--- a/src/main/java/com/playus/twpservice/domain/party/feign/response/PartyUserThumbnailUrlListResponse.java
+++ b/src/main/java/com/playus/twpservice/domain/party/feign/response/PartyUserThumbnailUrlListResponse.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 import java.util.List;
 
 @Builder
-public record PartyUserThumbnailUrlsResponse(
+public record PartyUserThumbnailUrlListResponse(
      List<String> thumbnailUrls
 ) {
 }

--- a/src/main/java/com/playus/twpservice/domain/party/feign/response/PartyUserThumbnailUrlListResponse.java
+++ b/src/main/java/com/playus/twpservice/domain/party/feign/response/PartyUserThumbnailUrlListResponse.java
@@ -8,4 +8,16 @@ import java.util.List;
 public record PartyUserThumbnailUrlListResponse(
      List<String> thumbnailUrls
 ) {
+
+    public static PartyUserThumbnailUrlListResponse of(List<String> thumbnailUrls) {
+        return PartyUserThumbnailUrlListResponse.builder()
+                .thumbnailUrls(thumbnailUrls)
+                .build();
+    }
+
+    public static PartyUserThumbnailUrlListResponse withServiceUnavailable() {
+        return PartyUserThumbnailUrlListResponse.builder()
+                .thumbnailUrls(List.of())
+                .build();
+    }
 }

--- a/src/main/java/com/playus/twpservice/domain/party/feign/response/PartyUserThumbnailUrlsResponse.java
+++ b/src/main/java/com/playus/twpservice/domain/party/feign/response/PartyUserThumbnailUrlsResponse.java
@@ -1,0 +1,11 @@
+package com.playus.twpservice.domain.party.feign.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record PartyUserThumbnailUrlsResponse(
+     List<String> thumbnailUrls
+) {
+}

--- a/src/main/java/com/playus/twpservice/domain/party/feign/response/PartyWriterInfoFeignResponse.java
+++ b/src/main/java/com/playus/twpservice/domain/party/feign/response/PartyWriterInfoFeignResponse.java
@@ -10,4 +10,22 @@ public record PartyWriterInfoFeignResponse(
         String writerThumbnailUrl
 ) {
 
+    public static PartyWriterInfoFeignResponse of (Long id, String writerName,
+                                                   String writerGender, String writerThumbnailUrl) {
+        return PartyWriterInfoFeignResponse.builder()
+                .id(id)
+                .writerName(writerName)
+                .writerGender(writerGender)
+                .writerThumbnailUrl(writerThumbnailUrl)
+                .build();
+    }
+
+    public static PartyWriterInfoFeignResponse withServiceUnavailable() {
+        return PartyWriterInfoFeignResponse.builder()
+                .id(null)
+                .writerName(null)
+                .writerGender(null)
+                .writerThumbnailUrl(null)
+                .build();
+    }
 }

--- a/src/main/java/com/playus/twpservice/domain/party/feign/response/PartyWriterInfoFeignResponse.java
+++ b/src/main/java/com/playus/twpservice/domain/party/feign/response/PartyWriterInfoFeignResponse.java
@@ -1,0 +1,13 @@
+package com.playus.twpservice.domain.party.feign.response;
+
+import lombok.Builder;
+
+@Builder
+public record PartyWriterInfoFeignResponse(
+        Long id,
+        String writerName,
+        String writerGender,
+        String writerThumbnailUrl
+) {
+
+}

--- a/src/main/java/com/playus/twpservice/domain/party/repository/read/PartyAgeReadOnlyRepository.java
+++ b/src/main/java/com/playus/twpservice/domain/party/repository/read/PartyAgeReadOnlyRepository.java
@@ -1,0 +1,7 @@
+package com.playus.twpservice.domain.party.repository.read;
+
+import com.playus.twpservice.domain.party.document.PartyAgeDocument;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface PartyAgeReadOnlyRepository extends MongoRepository<PartyAgeDocument, Long> {
+}

--- a/src/main/java/com/playus/twpservice/domain/party/repository/read/PartyJoinReadOnlyRepository.java
+++ b/src/main/java/com/playus/twpservice/domain/party/repository/read/PartyJoinReadOnlyRepository.java
@@ -1,0 +1,7 @@
+package com.playus.twpservice.domain.party.repository.read;
+
+import com.playus.twpservice.domain.party.document.PartyJoinDocument;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface PartyJoinReadOnlyRepository extends MongoRepository<PartyJoinDocument, Long> {
+}

--- a/src/main/java/com/playus/twpservice/domain/party/repository/read/PartyReadOnlyRepository.java
+++ b/src/main/java/com/playus/twpservice/domain/party/repository/read/PartyReadOnlyRepository.java
@@ -1,6 +1,7 @@
 package com.playus.twpservice.domain.party.repository.read;
 
 import com.playus.twpservice.domain.party.document.PartyDocument;
+import com.playus.twpservice.domain.party.repository.read.custom.PartyReadOnlyRepositoryCustom;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
 public interface PartyReadOnlyRepository extends MongoRepository<PartyDocument, Long>, PartyReadOnlyRepositoryCustom {

--- a/src/main/java/com/playus/twpservice/domain/party/repository/read/PartyReadOnlyRepository.java
+++ b/src/main/java/com/playus/twpservice/domain/party/repository/read/PartyReadOnlyRepository.java
@@ -3,5 +3,6 @@ package com.playus.twpservice.domain.party.repository.read;
 import com.playus.twpservice.domain.party.document.PartyDocument;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
-public interface PartyReadOnlyRepository extends MongoRepository<PartyDocument, Long> {
+public interface PartyReadOnlyRepository extends MongoRepository<PartyDocument, Long>, PartyReadOnlyRepositoryCustom {
+
 }

--- a/src/main/java/com/playus/twpservice/domain/party/repository/read/PartyReadOnlyRepositoryCustom.java
+++ b/src/main/java/com/playus/twpservice/domain/party/repository/read/PartyReadOnlyRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.playus.twpservice.domain.party.repository.read;
+
+import com.playus.twpservice.domain.party.vo.PartySummary;
+
+import java.util.List;
+
+public interface PartyReadOnlyRepositoryCustom {
+    List<PartySummary> findPartySummariesByMatchId(Long matchId);
+}

--- a/src/main/java/com/playus/twpservice/domain/party/repository/read/PartyReadOnlyRepositoryCustomImpl.java
+++ b/src/main/java/com/playus/twpservice/domain/party/repository/read/PartyReadOnlyRepositoryCustomImpl.java
@@ -1,0 +1,57 @@
+package com.playus.twpservice.domain.party.repository.read;
+
+import com.playus.twpservice.domain.party.vo.PartySummary;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.*;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+
+import static org.springframework.data.mongodb.core.aggregation.Aggregation.lookup;
+import static org.springframework.data.mongodb.core.aggregation.Aggregation.match;
+
+@RequiredArgsConstructor
+public class PartyReadOnlyRepositoryCustomImpl implements PartyReadOnlyRepositoryCustom {
+
+    private final MongoTemplate readMongoTemplate;
+
+    /**
+     *
+     * field는 class field 기준이 아닌, collection field 기준!
+     * @param matchId
+     * @return
+     */
+    @Override
+    public List<PartySummary> findPartySummariesByMatchId(Long matchId) {
+
+        MatchOperation matchOperation = match(new Criteria("match_id").is(matchId));
+
+        LookupOperation partyAgeLookupOperation = lookup("party_age", "_id", "party_id", "partyAge");
+        LookupOperation partyJoinLookupOperation = lookup("party_join", "_id", "party_id", "partyJoin");
+        LookupOperation partyThumbnailUrlLookupOperation = lookup("party_thumbnailurl", "_id", "party_id", "partyThumbnailUrl");
+
+        ProjectionOperation projectionOperation = Aggregation.project()
+                .and("_id").as("partyId")
+                .and("title").as("title")
+                .and("partyJoinMethod").as("partyJoinMethod")
+                .and("party_gender").as("partyGender")
+                .and("maximum_participants").as("maximumParticipants")
+                .and("partyAge.age").as("ages")
+                .and("partyJoin").size().as("currentParticipantsCount")
+                .and("partyThumbnailUrl.thumbnailUrl").as("thumbnailUrls");
+
+        Aggregation aggregation = Aggregation.newAggregation(
+                matchOperation,
+                partyAgeLookupOperation,
+                partyJoinLookupOperation,
+                partyThumbnailUrlLookupOperation,
+                projectionOperation
+        );
+
+        AggregationResults<PartySummary> results = readMongoTemplate.aggregate(aggregation, "party", PartySummary.class);
+
+        return results.getMappedResults();
+    }
+}
+

--- a/src/main/java/com/playus/twpservice/domain/party/repository/read/PartyThumbnailUrlReadOnlyRepository.java
+++ b/src/main/java/com/playus/twpservice/domain/party/repository/read/PartyThumbnailUrlReadOnlyRepository.java
@@ -1,0 +1,7 @@
+package com.playus.twpservice.domain.party.repository.read;
+
+import com.playus.twpservice.domain.party.document.PartyThumbnailUrlDocument;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface PartyThumbnailUrlReadOnlyRepository extends MongoRepository<PartyThumbnailUrlDocument, Long> {
+}

--- a/src/main/java/com/playus/twpservice/domain/party/repository/read/custom/PartyReadOnlyRepositoryCustom.java
+++ b/src/main/java/com/playus/twpservice/domain/party/repository/read/custom/PartyReadOnlyRepositoryCustom.java
@@ -1,4 +1,4 @@
-package com.playus.twpservice.domain.party.repository.read;
+package com.playus.twpservice.domain.party.repository.read.custom;
 
 import com.playus.twpservice.domain.party.vo.PartySummary;
 

--- a/src/main/java/com/playus/twpservice/domain/party/repository/read/custom/PartyReadOnlyRepositoryCustomImpl.java
+++ b/src/main/java/com/playus/twpservice/domain/party/repository/read/custom/PartyReadOnlyRepositoryCustomImpl.java
@@ -34,6 +34,7 @@ public class PartyReadOnlyRepositoryCustomImpl implements PartyReadOnlyRepositor
         ProjectionOperation projectionOperation = Aggregation.project()
                 .and("_id").as("partyId")
                 .and("title").as("title")
+                .and("writer_id").as("writerId")
                 .and("partyJoinMethod").as("partyJoinMethod")
                 .and("party_gender").as("partyGender")
                 .and("maximum_participants").as("maximumParticipants")

--- a/src/main/java/com/playus/twpservice/domain/party/repository/read/custom/PartyReadOnlyRepositoryCustomImpl.java
+++ b/src/main/java/com/playus/twpservice/domain/party/repository/read/custom/PartyReadOnlyRepositoryCustomImpl.java
@@ -35,6 +35,7 @@ public class PartyReadOnlyRepositoryCustomImpl implements PartyReadOnlyRepositor
                 .and("_id").as("partyId")
                 .and("title").as("title")
                 .and("writer_id").as("writerId")
+                .and("match_id").as("matchId")
                 .and("partyJoin.user_id").as("userIdList")
                 .and("partyJoinMethod").as("partyJoinMethod")
                 .and("party_gender").as("partyGender")
@@ -53,6 +54,7 @@ public class PartyReadOnlyRepositoryCustomImpl implements PartyReadOnlyRepositor
 
         AggregationResults<PartySummary> results = readMongoTemplate.aggregate(aggregation, "party", PartySummary.class);
 
+        // currentParticipantsCount에 1 추가해줘야! (response 생성 시 처리해줫음)
         return results.getMappedResults();
     }
 }

--- a/src/main/java/com/playus/twpservice/domain/party/repository/read/custom/PartyReadOnlyRepositoryCustomImpl.java
+++ b/src/main/java/com/playus/twpservice/domain/party/repository/read/custom/PartyReadOnlyRepositoryCustomImpl.java
@@ -1,4 +1,4 @@
-package com.playus.twpservice.domain.party.repository.read;
+package com.playus.twpservice.domain.party.repository.read.custom;
 
 import com.playus.twpservice.domain.party.vo.PartySummary;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/playus/twpservice/domain/party/repository/read/custom/PartyReadOnlyRepositoryCustomImpl.java
+++ b/src/main/java/com/playus/twpservice/domain/party/repository/read/custom/PartyReadOnlyRepositoryCustomImpl.java
@@ -35,6 +35,7 @@ public class PartyReadOnlyRepositoryCustomImpl implements PartyReadOnlyRepositor
                 .and("_id").as("partyId")
                 .and("title").as("title")
                 .and("writer_id").as("writerId")
+                .and("partyJoin.user_id").as("userIdList")
                 .and("partyJoinMethod").as("partyJoinMethod")
                 .and("party_gender").as("partyGender")
                 .and("maximum_participants").as("maximumParticipants")

--- a/src/main/java/com/playus/twpservice/domain/party/service/PartyReadOnlyService.java
+++ b/src/main/java/com/playus/twpservice/domain/party/service/PartyReadOnlyService.java
@@ -12,8 +12,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.IntStream;
 
 @Service
 @RequiredArgsConstructor
@@ -26,40 +26,38 @@ public class PartyReadOnlyService {
 
     public List<PartiesByMatchResponse> getPartiesBy(Long matchId) {
 
-        // 1. 직관팟 데이터 가져오기 (title, method, ages, gender, currentParticipantsCount,
-        //                         maximumParticipantsCount, thumbnailurls)
-
         List<PartySummary> partySummaries = partyRepository.findPartySummariesByMatchId(matchId);
 
-        // 2. 각 party 대한 user 데이터 가져오기 (thumbnailUrls)
-        for(int j=0;j< partySummaries.size();j++) {
-            PartySummary partySummary = partySummaries.get(j);
-            PartyUserThumbnailUrlListResponse userThumbnailUrls = userFeignClient.getPartyUserThumbnailUrls(partySummary.getUserIdList());
-            partySummary.updateUserThumbnailUrls(userThumbnailUrls.thumbnailUrls());
-        }
+        updateUserThumbnailUrls(partySummaries);
+        updateWriterInfo(partySummaries);
+        updateMatchDate(partySummaries, matchId);
 
-        // 3. author 데이터 가져오기 (writerName, writerGender, writerThumbnailUrl)
-        List<Long> writerIdList = partySummaries.stream()
+        return partySummaries.stream()
+                .map(PartySummary::toResponse)
+                .toList();
+    }
+
+    private void updateUserThumbnailUrls(List<PartySummary> summaries) {
+        summaries.forEach(party -> {
+            List<Long> userIds = party.getUserIdList();
+            PartyUserThumbnailUrlListResponse userThumbnails = userFeignClient.getPartyUserThumbnailUrls(userIds);
+            party.updateUserThumbnailUrls(userThumbnails.thumbnailUrls());
+        });
+    }
+
+    private void updateWriterInfo(List<PartySummary> summaries) {
+        List<Long> writerIds = summaries.stream()
                 .map(PartySummary::getWriterId)
                 .toList();
 
-        List<PartyWriterInfoFeignResponse> writerInfoList = userFeignClient.getWriterInfo(writerIdList);
-        for(int i=0;i < partySummaries.size();i++) {
-            partySummaries.get(i).updateWriterInfo(writerInfoList.get(i));
-        }
+        List<PartyWriterInfoFeignResponse> writerInfoList = userFeignClient.getWriterInfo(writerIds);
 
-        // 4. match 데이터 가져오기 (matchDate)
+        IntStream.range(0, summaries.size()).forEach(i ->
+                summaries.get(i).updateWriterInfo(writerInfoList.get(i)));
+    }
+
+    private void updateMatchDate(List<PartySummary> summaries, Long matchId) {
         LocalDateTime matchDate = matchFeignClient.getMatchDate(matchId);
-        for(int i=0;i<partySummaries.size();i++) {
-            partySummaries.get(i).updateMatchDate(matchDate);
-        }
-
-        // 5. 1, 2, 3, 4 정보 기반으로 response 생성
-        List<PartiesByMatchResponse> results = new ArrayList<>();
-        for (PartySummary partySummary : partySummaries) {
-            results.add(partySummary.toResponse());
-        }
-
-        return results;
+        summaries.forEach(party -> party.updateMatchDate(matchDate));
     }
 }

--- a/src/main/java/com/playus/twpservice/domain/party/service/PartyReadOnlyService.java
+++ b/src/main/java/com/playus/twpservice/domain/party/service/PartyReadOnlyService.java
@@ -1,13 +1,18 @@
 package com.playus.twpservice.domain.party.service;
 
 import com.playus.twpservice.domain.party.dto.partybymatch.PartiesByMatchResponse;
-import com.playus.twpservice.domain.party.repository.read.PartyAgeReadOnlyRepository;
-import com.playus.twpservice.domain.party.repository.read.PartyJoinReadOnlyRepository;
+import com.playus.twpservice.domain.party.feign.client.MatchFeignClient;
+import com.playus.twpservice.domain.party.feign.client.UserFeignClient;
+import com.playus.twpservice.domain.party.feign.response.PartyWriterInfoFeignResponse;
 import com.playus.twpservice.domain.party.repository.read.PartyReadOnlyRepository;
-import com.playus.twpservice.domain.party.repository.read.PartyThumbnailUrlReadOnlyRepository;
+import com.playus.twpservice.domain.party.vo.PartySummary;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -15,21 +20,48 @@ import org.springframework.transaction.annotation.Transactional;
 public class PartyReadOnlyService {
 
     private final PartyReadOnlyRepository partyRepository;
-    private final PartyAgeReadOnlyRepository partyAgeRepository;
-    private final PartyJoinReadOnlyRepository partyJoinRepository;
-    private final PartyThumbnailUrlReadOnlyRepository partyThumbnailUrlRepository;
+    private final UserFeignClient userFeignClient;
+    private final MatchFeignClient matchFeignClient;
 
-    public PartiesByMatchResponse getPartiesBy(Long matchId, Long userId) {
+    public List<PartiesByMatchResponse> getPartiesBy(Long matchId, Long userId) {
 
         // 1. 직관팟 데이터 가져오기 (title, method, ages, gender, currentParticipantsCount,
         //                         maximumParticipantsCount, thumbnailurls)
 
+        List<PartySummary> partySummaries = partyRepository.findPartySummariesByMatchId(matchId);
 
+        // 2. 각 party 대한 user 데이터 가져오기 (thumbnailUrls)
+        for(int j=0;j< partySummaries.size();j++) {
+            PartySummary partySummary = partySummaries.get(j);
+            List<String> userThumbnailUrls = userFeignClient.getPartyUserThumbnailUrls(partySummary.getUserIdList());
+            partySummary.updateUserThumbnailUrls(userThumbnailUrls);
+        }
 
-        // 2. user 데이터 가져오기 (authorName, authorGender, userThumbnailUrls)
+        // 3. author 데이터 가져오기 (writerName, writerGender, writerThumbnailUrl)
+        List<Long> writerIdList = partySummaries.stream()
+                .map(PartySummary::getWriterId)
+                .toList();
 
-        // 3. match 데이터 가져오기 (matchDate)
+        List<PartyWriterInfoFeignResponse> writerInfoList = userFeignClient.getWriterInfo(writerIdList);
+        for(int i=0;i < partySummaries.size();i++) {
+            partySummaries.get(i).updateWriterInfo(writerInfoList.get(i));
+        }
 
-        return null;
+        // 4. match 데이터 가져오기 (matchDate)
+        List<Long> matchIdList = partySummaries.stream()
+                .map(PartySummary::getMatchId)
+                .toList();
+        List<LocalDateTime> matchDateList = matchFeignClient.getMatchDate(matchIdList);
+        for(int i=0;i<partySummaries.size();i++) {
+            partySummaries.get(i).updateMatchDate(matchDateList.get(i));
+        }
+
+        // 5. 1, 2, 3, 4 정보 기반으로 response 생성
+        List<PartiesByMatchResponse> results = new ArrayList();
+        for (PartySummary partySummary : partySummaries) {
+            results.add(partySummary.toResponse());
+        }
+
+        return results;
     }
 }

--- a/src/main/java/com/playus/twpservice/domain/party/service/PartyReadOnlyService.java
+++ b/src/main/java/com/playus/twpservice/domain/party/service/PartyReadOnlyService.java
@@ -49,16 +49,13 @@ public class PartyReadOnlyService {
         }
 
         // 4. match 데이터 가져오기 (matchDate)
-        List<Long> matchIdList = partySummaries.stream()
-                .map(PartySummary::getMatchId)
-                .toList();
-        List<LocalDateTime> matchDateList = matchFeignClient.getMatchDate(matchIdList);
+        LocalDateTime matchDate = matchFeignClient.getMatchDate(matchId);
         for(int i=0;i<partySummaries.size();i++) {
-            partySummaries.get(i).updateMatchDate(matchDateList.get(i));
+            partySummaries.get(i).updateMatchDate(matchDate);
         }
 
         // 5. 1, 2, 3, 4 정보 기반으로 response 생성
-        List<PartiesByMatchResponse> results = new ArrayList();
+        List<PartiesByMatchResponse> results = new ArrayList<>();
         for (PartySummary partySummary : partySummaries) {
             results.add(partySummary.toResponse());
         }

--- a/src/main/java/com/playus/twpservice/domain/party/service/PartyReadOnlyService.java
+++ b/src/main/java/com/playus/twpservice/domain/party/service/PartyReadOnlyService.java
@@ -1,6 +1,10 @@
 package com.playus.twpservice.domain.party.service;
 
 import com.playus.twpservice.domain.party.dto.partybymatch.PartiesByMatchResponse;
+import com.playus.twpservice.domain.party.repository.read.PartyAgeReadOnlyRepository;
+import com.playus.twpservice.domain.party.repository.read.PartyJoinReadOnlyRepository;
+import com.playus.twpservice.domain.party.repository.read.PartyReadOnlyRepository;
+import com.playus.twpservice.domain.party.repository.read.PartyThumbnailUrlReadOnlyRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -10,7 +14,22 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class PartyReadOnlyService {
 
+    private final PartyReadOnlyRepository partyRepository;
+    private final PartyAgeReadOnlyRepository partyAgeRepository;
+    private final PartyJoinReadOnlyRepository partyJoinRepository;
+    private final PartyThumbnailUrlReadOnlyRepository partyThumbnailUrlRepository;
+
     public PartiesByMatchResponse getPartiesBy(Long matchId, Long userId) {
+
+        // 1. 직관팟 데이터 가져오기 (title, method, ages, gender, currentParticipantsCount,
+        //                         maximumParticipantsCount, thumbnailurls)
+
+
+
+        // 2. user 데이터 가져오기 (authorName, authorGender, userThumbnailUrls)
+
+        // 3. match 데이터 가져오기 (matchDate)
+
         return null;
     }
 }

--- a/src/main/java/com/playus/twpservice/domain/party/service/PartyReadOnlyService.java
+++ b/src/main/java/com/playus/twpservice/domain/party/service/PartyReadOnlyService.java
@@ -1,0 +1,16 @@
+package com.playus.twpservice.domain.party.service;
+
+import com.playus.twpservice.domain.party.dto.partybymatch.PartiesByMatchResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PartyReadOnlyService {
+
+    public PartiesByMatchResponse getPartiesBy(Long matchId, Long userId) {
+        return null;
+    }
+}

--- a/src/main/java/com/playus/twpservice/domain/party/service/PartyReadOnlyService.java
+++ b/src/main/java/com/playus/twpservice/domain/party/service/PartyReadOnlyService.java
@@ -3,6 +3,7 @@ package com.playus.twpservice.domain.party.service;
 import com.playus.twpservice.domain.party.dto.partybymatch.PartiesByMatchResponse;
 import com.playus.twpservice.domain.party.feign.client.MatchFeignClient;
 import com.playus.twpservice.domain.party.feign.client.UserFeignClient;
+import com.playus.twpservice.domain.party.feign.response.PartyUserThumbnailUrlListResponse;
 import com.playus.twpservice.domain.party.feign.response.PartyWriterInfoFeignResponse;
 import com.playus.twpservice.domain.party.repository.read.PartyReadOnlyRepository;
 import com.playus.twpservice.domain.party.vo.PartySummary;
@@ -23,7 +24,7 @@ public class PartyReadOnlyService {
     private final UserFeignClient userFeignClient;
     private final MatchFeignClient matchFeignClient;
 
-    public List<PartiesByMatchResponse> getPartiesBy(Long matchId, Long userId) {
+    public List<PartiesByMatchResponse> getPartiesBy(Long matchId) {
 
         // 1. 직관팟 데이터 가져오기 (title, method, ages, gender, currentParticipantsCount,
         //                         maximumParticipantsCount, thumbnailurls)
@@ -33,8 +34,8 @@ public class PartyReadOnlyService {
         // 2. 각 party 대한 user 데이터 가져오기 (thumbnailUrls)
         for(int j=0;j< partySummaries.size();j++) {
             PartySummary partySummary = partySummaries.get(j);
-            List<String> userThumbnailUrls = userFeignClient.getPartyUserThumbnailUrls(partySummary.getUserIdList());
-            partySummary.updateUserThumbnailUrls(userThumbnailUrls);
+            PartyUserThumbnailUrlListResponse userThumbnailUrls = userFeignClient.getPartyUserThumbnailUrls(partySummary.getUserIdList());
+            partySummary.updateUserThumbnailUrls(userThumbnailUrls.thumbnailUrls());
         }
 
         // 3. author 데이터 가져오기 (writerName, writerGender, writerThumbnailUrl)

--- a/src/main/java/com/playus/twpservice/domain/party/service/PartyService.java
+++ b/src/main/java/com/playus/twpservice/domain/party/service/PartyService.java
@@ -42,7 +42,6 @@ public class PartyService {
     private final S3PresignedUrlGenerator s3PresignedUrlGenerator;
 
     public PartyCreateResponse createParty(Long userId, PartyCreateRequest request) {
-
         ChatRoom chatRoom = initializeChatRoomAsWriter(userId, request);
 
         Party party = partyRepository.save(request.toParty().assignChatRoom(chatRoom.getId()));
@@ -57,14 +56,14 @@ public class PartyService {
         return PartyCreateResponse.of(party.getId(), chatRoom.getId());
     }
 
+    public PresignedUrlForSaveImageResponse generatePresignedUrlForSaveImage(PresignedUrlForSaveImageRequest request) {
+        return new PresignedUrlForSaveImageResponse(s3PresignedUrlGenerator.generatePresignedUrl(request.imageFileName()));
+    }
+
     private ChatRoom initializeChatRoomAsWriter(Long userId, PartyCreateRequest request) {
         ChatRoom chatRoom = chatRoomRepository.save(ChatRoom.create(request.title()));
         chatPartRepository.save(ChatPart.create(userId, chatRoom));
         return chatRoom;
-    }
-
-    public PresignedUrlForSaveImageResponse generatePresignedUrlForSaveImage(PresignedUrlForSaveImageRequest request) {
-        return new PresignedUrlForSaveImageResponse(s3PresignedUrlGenerator.generatePresignedUrl(request.imageFileName()));
     }
 
     private void saveThumbnailUrlIfPresent(PartyCreateRequest request, Party party) {

--- a/src/main/java/com/playus/twpservice/domain/party/service/PartyService.java
+++ b/src/main/java/com/playus/twpservice/domain/party/service/PartyService.java
@@ -10,10 +10,8 @@ import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImage
 import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageResponse;
 import com.playus.twpservice.domain.party.entity.Party;
 import com.playus.twpservice.domain.party.entity.PartyAge;
-import com.playus.twpservice.domain.party.entity.PartyJoin;
 import com.playus.twpservice.domain.party.entity.PartyThumbnailUrl;
 import com.playus.twpservice.domain.party.enums.PartyAgeGroup;
-import com.playus.twpservice.domain.party.enums.PartyJoinRequestStatus;
 import com.playus.twpservice.domain.party.repository.write.PartyAgeRepository;
 import com.playus.twpservice.domain.party.repository.write.PartyJoinRepository;
 import com.playus.twpservice.domain.party.repository.write.PartyRepository;
@@ -44,9 +42,7 @@ public class PartyService {
     public PartyCreateResponse createParty(Long userId, PartyCreateRequest request) {
         ChatRoom chatRoom = initializeChatRoomAsWriter(userId, request);
 
-        Party party = partyRepository.save(request.toParty().assignChatRoom(chatRoom.getId()));
-
-        partyJoinRepository.save(PartyJoin.create(userId, party, PartyJoinRequestStatus.ACCEPT, null));
+        Party party = partyRepository.save(request.toPartyWith(userId).assignChatRoom(chatRoom.getId()));
 
         List<PartyAge> partyAgeList = toPartyAgeEntity(request, party);
         partyAgeRepository.saveAll(partyAgeList);

--- a/src/main/java/com/playus/twpservice/domain/party/service/PartyService.java
+++ b/src/main/java/com/playus/twpservice/domain/party/service/PartyService.java
@@ -13,7 +13,7 @@ import com.playus.twpservice.domain.party.entity.PartyAge;
 import com.playus.twpservice.domain.party.entity.PartyJoin;
 import com.playus.twpservice.domain.party.entity.PartyThumbnailUrl;
 import com.playus.twpservice.domain.party.enums.PartyAgeGroup;
-import com.playus.twpservice.domain.party.enums.Status;
+import com.playus.twpservice.domain.party.enums.PartyJoinRequestStatus;
 import com.playus.twpservice.domain.party.repository.write.PartyAgeRepository;
 import com.playus.twpservice.domain.party.repository.write.PartyJoinRepository;
 import com.playus.twpservice.domain.party.repository.write.PartyRepository;
@@ -46,7 +46,7 @@ public class PartyService {
 
         Party party = partyRepository.save(request.toParty().assignChatRoom(chatRoom.getId()));
 
-        partyJoinRepository.save(PartyJoin.create(userId, party, Status.ACCEPT, null));
+        partyJoinRepository.save(PartyJoin.create(userId, party, PartyJoinRequestStatus.ACCEPT, null));
 
         List<PartyAge> partyAgeList = toPartyAgeEntity(request, party);
         partyAgeRepository.saveAll(partyAgeList);

--- a/src/main/java/com/playus/twpservice/domain/party/specification/PartyControllerSpecification.java
+++ b/src/main/java/com/playus/twpservice/domain/party/specification/PartyControllerSpecification.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
@@ -63,7 +64,7 @@ public interface PartyControllerSpecification {
                     )
             )
     })
-    ResponseEntity<PartyCreateResponse> createParty(Long userId, PartyCreateRequest request);
+    ResponseEntity<PartyCreateResponse> createParty(Long userId, @Valid PartyCreateRequest request);
 
     @Tag(name = "Post", description = "Presigned URL 발급 API")
     @Operation(
@@ -100,5 +101,5 @@ public interface PartyControllerSpecification {
                     )
             )
     })
-    PresignedUrlForSaveImageResponse generatePresignedUrlForSaveImage(PresignedUrlForSaveImageRequest request);
+    PresignedUrlForSaveImageResponse generatePresignedUrlForSaveImage(@Valid PresignedUrlForSaveImageRequest request);
 }

--- a/src/main/java/com/playus/twpservice/domain/party/specification/PartyControllerSpecification.java
+++ b/src/main/java/com/playus/twpservice/domain/party/specification/PartyControllerSpecification.java
@@ -2,9 +2,12 @@ package com.playus.twpservice.domain.party.specification;
 
 import com.playus.twpservice.domain.party.dto.party_create.PartyCreateRequest;
 import com.playus.twpservice.domain.party.dto.party_create.PartyCreateResponse;
+import com.playus.twpservice.domain.party.dto.partybymatch.PartiesByMatchRequest;
+import com.playus.twpservice.domain.party.dto.partybymatch.PartiesByMatchResponse;
 import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageRequest;
 import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
@@ -14,6 +17,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+
+import java.util.List;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
@@ -102,4 +107,73 @@ public interface PartyControllerSpecification {
             )
     })
     PresignedUrlForSaveImageResponse generatePresignedUrlForSaveImage(@Valid PresignedUrlForSaveImageRequest request);
+
+    @Tag(name = "Get", description = "직관팟 조회 API")
+    @Operation(
+            summary = "직관팟 조회 API",
+            description = "특정 경기에 대한 모든 직관팟을 조회합니다.",
+            parameters = {
+                    @Parameter(
+                            name = "matchId",
+                            description = "경기 ID",
+                            required = true,
+                            example = "1"
+                    )
+            }
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "조회 성공",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    name = "직관팟 조회 응답 예시",
+                                    value = """
+                                            [
+                                               {
+                                                 "partyId": 1,
+                                                 "title": "title",
+                                                 "partyJoinMethod": "승인제",
+                                                 "partyAges": ["10대", "20대"],
+                                                 "availableGender": "남자만",
+                                                 "authorName": "ZSJ",
+                                                 "authorGender": "남성",
+                                                 "matchDate": "3.22(토) 오후 2:00",
+                                                 "currentParticipantsCount": 10,
+                                                 "maximumParticipantsCount": 14,
+                                                 "partyThumbnailUrls": [
+                                                   "http://party-thumbnail",
+                                                   "http://party-thumbnail2"
+                                                 ],
+                                                 "userThumbnailUrls": [
+                                                   "http://user-thumbnailUrl",
+                                                   "http://user2-thumbnailUrl"
+                                                 ]
+                                               }, 
+                                               
+                                                  {
+                                                     "partyId": 2,
+                                                     "title": "title2",
+                                                     "partyJoinMethod": "선착순",
+                                                     "partyAges": ["30대"],
+                                                     "availableGender": "여자만",
+                                                     "authorName": "ZSJ",
+                                                     "authorGender": "남성",
+                                                     "matchDate": "3.22(토) 오후 2:00",
+                                                     "currentParticipantsCount": 1,
+                                                     "maximumParticipantsCount": 5,
+                                                     "partyThumbnailUrls": [
+                                                     
+                                                     ],
+                                                     "userThumbnailUrls": [
+   
+                                                     ]
+                                                  }
+                                             ]
+                    """
+                            )
+                    )
+            )
+    })
+    List<PartiesByMatchResponse> getPartiesByMatchId(@Valid PartiesByMatchRequest request);
 }

--- a/src/main/java/com/playus/twpservice/domain/party/vo/PartySummary.java
+++ b/src/main/java/com/playus/twpservice/domain/party/vo/PartySummary.java
@@ -42,7 +42,7 @@ public class PartySummary {
     public void updateWriterInfo(PartyWriterInfoFeignResponse partyWriterInfoFeignResponse) {
          this.writerName = partyWriterInfoFeignResponse.writerName();
          this.writerGender = partyWriterInfoFeignResponse.writerGender();
-         userThumbnailUrls.add(partyWriterInfoFeignResponse.writerThumbnailUrl());
+         this.userThumbnailUrls.add(0, partyWriterInfoFeignResponse.writerThumbnailUrl());
     }
 
     public void updateMatchDate(LocalDateTime matchDate) {
@@ -51,6 +51,7 @@ public class PartySummary {
 
     public PartiesByMatchResponse toResponse() {
         return PartiesByMatchResponse.of(
+                partyId,
                 title,
                 partyJoinMethod,
                 ages.stream().map(PartyAgeGroup::getAgeGroupByAge).toList(),
@@ -58,7 +59,7 @@ public class PartySummary {
                 writerName,
                 writerGender,
                 matchDate,
-                currentParticipantsCount + 1,
+                currentParticipantsCount + 1, // 방장 추가
                 maximumParticipants,
                 thumbnailUrls,
                 userThumbnailUrls

--- a/src/main/java/com/playus/twpservice/domain/party/vo/PartySummary.java
+++ b/src/main/java/com/playus/twpservice/domain/party/vo/PartySummary.java
@@ -1,0 +1,23 @@
+package com.playus.twpservice.domain.party.vo;
+
+import com.playus.twpservice.domain.party.enums.PartyGender;
+import com.playus.twpservice.domain.party.enums.PartyJoinMethod;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PartySummary {
+    private Long partyId;
+    private String title;
+    private PartyJoinMethod partyJoinMethod;
+    private PartyGender partyGender;
+    private List<Integer> ages;
+    private Long currentParticipantsCount;
+    private Long maximumParticipants;
+    private List<String> thumbnailUrls;
+}

--- a/src/main/java/com/playus/twpservice/domain/party/vo/PartySummary.java
+++ b/src/main/java/com/playus/twpservice/domain/party/vo/PartySummary.java
@@ -14,6 +14,7 @@ import java.util.List;
 public class PartySummary {
     private Long partyId;
     private String title;
+    private Long writerId;
     private PartyJoinMethod partyJoinMethod;
     private PartyGender partyGender;
     private List<Integer> ages;

--- a/src/main/java/com/playus/twpservice/domain/party/vo/PartySummary.java
+++ b/src/main/java/com/playus/twpservice/domain/party/vo/PartySummary.java
@@ -15,6 +15,7 @@ public class PartySummary {
     private Long partyId;
     private String title;
     private Long writerId;
+    private List<Long> userIdList;
     private PartyJoinMethod partyJoinMethod;
     private PartyGender partyGender;
     private List<Integer> ages;

--- a/src/main/java/com/playus/twpservice/domain/party/vo/PartySummary.java
+++ b/src/main/java/com/playus/twpservice/domain/party/vo/PartySummary.java
@@ -1,11 +1,15 @@
 package com.playus.twpservice.domain.party.vo;
 
+import com.playus.twpservice.domain.party.dto.partybymatch.PartiesByMatchResponse;
+import com.playus.twpservice.domain.party.enums.PartyAgeGroup;
 import com.playus.twpservice.domain.party.enums.PartyGender;
 import com.playus.twpservice.domain.party.enums.PartyJoinMethod;
+import com.playus.twpservice.domain.party.feign.response.PartyWriterInfoFeignResponse;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
@@ -15,6 +19,7 @@ public class PartySummary {
     private Long partyId;
     private String title;
     private Long writerId;
+    private Long matchId;
     private List<Long> userIdList;
     private PartyJoinMethod partyJoinMethod;
     private PartyGender partyGender;
@@ -22,4 +27,41 @@ public class PartySummary {
     private Long currentParticipantsCount;
     private Long maximumParticipants;
     private List<String> thumbnailUrls;
+
+    private String writerName;
+    private String writerGender;
+    private String writerThumbnailUrl;
+
+    private List<String> userThumbnailUrls;
+    private LocalDateTime matchDate;
+
+    public void updateUserThumbnailUrls(List<String> userThumbnailUrls) {
+        this.userThumbnailUrls = userThumbnailUrls;
+    }
+
+    public void updateWriterInfo(PartyWriterInfoFeignResponse partyWriterInfoFeignResponse) {
+         this.writerName = partyWriterInfoFeignResponse.writerName();
+         this.writerGender = partyWriterInfoFeignResponse.writerGender();
+         userThumbnailUrls.add(partyWriterInfoFeignResponse.writerThumbnailUrl());
+    }
+
+    public void updateMatchDate(LocalDateTime matchDate) {
+        this.matchDate = matchDate;
+    }
+
+    public PartiesByMatchResponse toResponse() {
+        return PartiesByMatchResponse.of(
+                title,
+                partyJoinMethod,
+                ages.stream().map(PartyAgeGroup::getAgeGroupByAge).toList(),
+                partyGender,
+                writerName,
+                writerGender,
+                matchDate,
+                currentParticipantsCount + 1,
+                maximumParticipants,
+                thumbnailUrls,
+                userThumbnailUrls
+        );
+    }
 }

--- a/src/main/java/com/playus/twpservice/global/exception/ExceptionAdvice.java
+++ b/src/main/java/com/playus/twpservice/global/exception/ExceptionAdvice.java
@@ -6,6 +6,7 @@ import com.playus.twpservice.domain.party.exception.enums.PartyGenderExceptionGr
 import com.playus.twpservice.domain.party.exception.enums.PartyJoinMethodExceptionGroup;
 import com.playus.twpservice.global.response.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cloud.client.circuitbreaker.NoFallbackAvailableException;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -21,7 +22,7 @@ public class ExceptionAdvice {
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(BindException.class)
-    public ErrorResponse bindExceptionHandler(BindException e) {
+    public ErrorResponse handleBindException(BindException e) {
         String errorMessage = e.getAllErrors().get(0).getDefaultMessage();
         log.warn("Validation Error: {}", errorMessage);
         return ErrorResponse.badRequestError(errorMessage);
@@ -33,7 +34,7 @@ public class ExceptionAdvice {
             PartyJoinMethodExceptionGroup.InvalidDescriptionException.class,
             PartyAgeGroupExceptionGroup.InvalidDescriptionException.class
     })
-    public ErrorResponse invalidDescriptionExceptionHandler(Exception e) {
+    public ErrorResponse handleInvalidDescriptionException(Exception e) {
         String errorMessage = e.getMessage();
         log.warn("Validation Error: {}", errorMessage);
         return ErrorResponse.badRequestError(errorMessage);
@@ -41,7 +42,7 @@ public class ExceptionAdvice {
 
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(SdkException.class)
-    public ErrorResponse sdkExceptionHandler(Exception e) {
+    public ErrorResponse handleSdkException(Exception e) {
         String errorMessage = e.getMessage();
         log.error("Object Storage Error: {}", errorMessage);
         return ErrorResponse.internalServerError("서버 에러가 발생했습니다! 관리자에게 문의해 주세요!");
@@ -49,9 +50,19 @@ public class ExceptionAdvice {
 
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(Exception.class)
-    public ErrorResponse otherExceptionHandler(Exception e) {
+    public ErrorResponse handleOtherException(Exception e) {
         String errorMessage = e.getMessage();
         log.error("Unexpected Error: {}", errorMessage);
         return ErrorResponse.internalServerError("서버 에러가 발생했습니다! 관리자에게 문의해 주세요!");
+    }
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(value = {
+            NoFallbackAvailableException.class
+    })
+    public ErrorResponse handleFailOpenFeignException(NoFallbackAvailableException exception) {
+        String errorMessage = exception.getMessage();
+        log.error(errorMessage);
+        return ErrorResponse.internalServerError(errorMessage);
     }
 }

--- a/src/main/java/com/playus/twpservice/global/exception/ExceptionAdvice.java
+++ b/src/main/java/com/playus/twpservice/global/exception/ExceptionAdvice.java
@@ -62,7 +62,7 @@ public class ExceptionAdvice {
     })
     public ErrorResponse handleFailOpenFeignException(NoFallbackAvailableException exception) {
         String errorMessage = exception.getMessage();
-        log.error(errorMessage);
-        return ErrorResponse.internalServerError(errorMessage);
+        log.error("Unexpected Error: {}", errorMessage);
+        return ErrorResponse.internalServerError("서버 에러가 발생했습니다! 관리자에게 문의해 주세요!");
     }
 }

--- a/src/main/java/com/playus/twpservice/global/s3/S3Config.java
+++ b/src/main/java/com/playus/twpservice/global/s3/S3Config.java
@@ -33,7 +33,7 @@ public class S3Config {
                                 AwsBasicCredentials.create(accessKey, secretKey)
                         )
                 )
-                .region(Region.US_EAST_1)
+                .region(Region.of("kr-central-2"))
                 .build();
     }
 }

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -55,3 +55,20 @@ logging:
 
 slack:
   webhook-url: ${SLACK_WEBHOOK_URL}
+
+resilience4j:
+  circuitbreaker:
+    configs:
+      default:
+        failure-rate-threshold: 50
+        slow-call-rate-threshold: 80
+        slow-call-duration-threshold: 10s
+        permitted-number-of-calls-in-half-open-state: 3
+        max-wait-duration-in-half-open-state: 0s
+        sliding-window-type: COUNT_BASED
+        sliding-window-size: 10
+        minimum-number-of-calls: 10
+        wait-duration-in-open-state: 10s
+    instances:
+      circuit:
+        base-config: default

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -14,6 +14,7 @@ spring:
         uri: ${SPRING_DATA_MONGODB_READ_URI}
       chat:
         uri: ${SPRING_DATA_MONGODB_CHAT_URI}
+      auto-index-creation: true
 
     redis:
       host: ${REDIS_HOST}

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -35,7 +35,7 @@ spring:
         show_sql: true
 
   jwt:
-    secret: secretsecretsecretesecretesecretesecret
+    secret: "secretkeysecretkeysecretkeysecretkeysecretkeysecretkeysecretkey"
 
 cloud:
   aws:
@@ -74,3 +74,11 @@ resilience4j:
     instances:
       circuit:
         base-config: default
+
+feign:
+  user:
+    url: http://user-dummy
+
+  match:
+    url: http://match-dummy
+

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -55,3 +55,20 @@ logging:
 
 slack:
   webhook-url: ${SLACK_WEBHOOK_URL}
+
+resilience4j:
+  circuitbreaker:
+    configs:
+      default:
+        failure-rate-threshold: 50
+        slow-call-rate-threshold: 80
+        slow-call-duration-threshold: 10s
+        permitted-number-of-calls-in-half-open-state: 3
+        max-wait-duration-in-half-open-state: 0
+        sliding-window-type: COUNT_BASED
+        sliding-window-size: 10
+        minimum-number-of-calls: 10
+        wait-duration-in-open-state: 10s
+    instances:
+      shboard-circuit-breaker:
+        base-config: default

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -16,6 +16,8 @@ spring:
       chat:
         uri: mongodb://localhost:27017/chat_db
 
+      auto-index-creation: true
+
     redis:
       host: localhost
       port: 6379

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -66,11 +66,11 @@ resilience4j:
         slow-call-rate-threshold: 80
         slow-call-duration-threshold: 10s
         permitted-number-of-calls-in-half-open-state: 3
-        max-wait-duration-in-half-open-state: 0
+        max-wait-duration-in-half-open-state: 0s
         sliding-window-type: COUNT_BASED
         sliding-window-size: 10
         minimum-number-of-calls: 10
         wait-duration-in-open-state: 10s
     instances:
-      shboard-circuit-breaker:
+      circuit:
         base-config: default

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -14,6 +14,7 @@ spring:
         uri: ${SPRING_DATA_MONGODB_READ_URI}
       chat:
         uri: ${SPRING_DATA_MONGODB_CHAT_URI}
+      auto-index-creation: true
 
     redis:
       host: ${REDIS_HOST}

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -20,3 +20,8 @@ logging:
           redis:
             core: DEBUG
             connection: TRACE
+          mongodb:
+            core:
+              MongoTemplate : DEBUG
+    com:
+      mongodb : DEBUG

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -40,13 +40,13 @@ resilience4j:
         slow-call-rate-threshold: 80
         slow-call-duration-threshold: 10s
         permitted-number-of-calls-in-half-open-state: 3
-        max-wait-duration-in-half-open-state: 0
+        max-wait-duration-in-half-open-state: 0s
         sliding-window-type: COUNT_BASED
         sliding-window-size: 10
         minimum-number-of-calls: 10
         wait-duration-in-open-state: 10s
     instances:
-      shboard-circuit-breaker:
+      circuit:
         base-config: default
 
 feign:

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -1,6 +1,4 @@
 spring:
-  jwt:
-    secret: "secretkeysecretkeysecretkeysecretkeysecretkeysecretkeysecretkey"
   jpa:
     hibernate:
         ddl-auto: create
@@ -11,6 +9,13 @@ spring:
           time_zone: Asia/Seoul
         show_sql: true
     database-platform: org.hibernate.dialect.MySQLDialect
+
+  web:
+    locale: ko_KR
+    locale-resolver: fixed
+
+  jwt:
+    secret: "secretkeysecretkeysecretkeysecretkeysecretkeysecretkeysecretkey"
 
 logging:
   level:

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -10,9 +10,7 @@ spring:
         show_sql: true
     database-platform: org.hibernate.dialect.MySQLDialect
 
-  web:
-    locale: ko_KR
-    locale-resolver: fixed
+
 
   jwt:
     secret: "secretkeysecretkeysecretkeysecretkeysecretkeysecretkeysecretkey"

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -23,6 +23,9 @@ logging:
           mongodb:
             core:
               MongoTemplate : DEBUG
+            repository:
+              query : DEBUG
+
     com:
       mongodb : DEBUG
 

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -43,3 +43,10 @@ resilience4j:
       shboard-circuit-breaker:
         base-config: default
 
+feign:
+  user:
+    url: http://user-dummy
+
+  match:
+    url: http://match-dummy
+

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -25,3 +25,21 @@ logging:
               MongoTemplate : DEBUG
     com:
       mongodb : DEBUG
+
+resilience4j:
+  circuitbreaker:
+    configs:
+      default:
+        failure-rate-threshold: 50
+        slow-call-rate-threshold: 80
+        slow-call-duration-threshold: 10s
+        permitted-number-of-calls-in-half-open-state: 3
+        max-wait-duration-in-half-open-state: 0
+        sliding-window-type: COUNT_BASED
+        sliding-window-size: 10
+        minimum-number-of-calls: 10
+        wait-duration-in-open-state: 10s
+    instances:
+      shboard-circuit-breaker:
+        base-config: default
+

--- a/src/test/java/com/playus/twpservice/ControllerTestSupport.java
+++ b/src/test/java/com/playus/twpservice/ControllerTestSupport.java
@@ -2,6 +2,7 @@ package com.playus.twpservice;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.playus.twpservice.domain.party.controller.PartyController;
+import com.playus.twpservice.domain.party.service.PartyReadOnlyService;
 import com.playus.twpservice.domain.party.service.PartyService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -34,6 +35,9 @@ public abstract class ControllerTestSupport {
 
     @MockitoBean
     protected PartyService partyService;
+
+    @MockitoBean
+    protected PartyReadOnlyService partyReadOnlyService;
 
     @TestConfiguration
     static class TestSecurityConfig {

--- a/src/test/java/com/playus/twpservice/IntegrationTestSupport.java
+++ b/src/test/java/com/playus/twpservice/IntegrationTestSupport.java
@@ -1,6 +1,8 @@
 package com.playus.twpservice;
 
 
+import com.playus.twpservice.domain.party.feign.client.MatchFeignClient;
+import com.playus.twpservice.domain.party.feign.client.UserFeignClient;
 import com.playus.twpservice.global.s3.S3PresignedUrlGenerator;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -32,6 +34,12 @@ public abstract class IntegrationTestSupport {
 
     @MockitoBean
     protected S3PresignedUrlGenerator s3PresignedUrlGenerator;
+
+    @MockitoBean
+    protected UserFeignClient userFeignClient;
+
+    @MockitoBean
+    protected MatchFeignClient matchFeignClient;
 
     static {
         mySQL = new MySQLContainer<>(MYSQL_VERSION)

--- a/src/test/java/com/playus/twpservice/IntegrationTestSupport.java
+++ b/src/test/java/com/playus/twpservice/IntegrationTestSupport.java
@@ -20,7 +20,7 @@ public abstract class IntegrationTestSupport {
 
     private static final String MYSQL_VERSION = "mysql:8.0.32";
     private static final String REDIS_VERSION = "redis:7.0.12";
-    private static final String MONGO_VERSION = "mongo:6.0.8";
+    private static final String MONGO_VERSION = "mongodb/mongodb-community-server:latest";
 
     private static final MySQLContainer<?> mySQL;
     private static final GenericContainer redis;

--- a/src/test/java/com/playus/twpservice/IntegrationTestSupport.java
+++ b/src/test/java/com/playus/twpservice/IntegrationTestSupport.java
@@ -1,8 +1,6 @@
 package com.playus.twpservice;
 
 
-import com.playus.twpservice.domain.party.feign.client.MatchFeignClient;
-import com.playus.twpservice.domain.party.feign.client.UserFeignClient;
 import com.playus.twpservice.global.s3.S3PresignedUrlGenerator;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -18,7 +16,7 @@ import java.time.Duration;
 
 @ActiveProfiles("test")
 @SpringBootTest
-public abstract class IntegrationTestSupport {
+public abstract class IntegrationTestSupport extends OpenFeignClientTestSupport {
 
     private static final String MYSQL_VERSION = "mysql:8.0.32";
     private static final String REDIS_VERSION = "redis:7.0.12";
@@ -34,12 +32,6 @@ public abstract class IntegrationTestSupport {
 
     @MockitoBean
     protected S3PresignedUrlGenerator s3PresignedUrlGenerator;
-
-    @MockitoBean
-    protected UserFeignClient userFeignClient;
-
-    @MockitoBean
-    protected MatchFeignClient matchFeignClient;
 
     static {
         mySQL = new MySQLContainer<>(MYSQL_VERSION)

--- a/src/test/java/com/playus/twpservice/IntegrationTestSupport.java
+++ b/src/test/java/com/playus/twpservice/IntegrationTestSupport.java
@@ -1,10 +1,12 @@
 package com.playus.twpservice;
 
 
+import com.playus.twpservice.global.s3.S3PresignedUrlGenerator;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
@@ -27,6 +29,9 @@ public abstract class IntegrationTestSupport {
 
     private static final int REDIS_PORT = 6379;
     private static final int MONGO_PORT = 27017;
+
+    @MockitoBean
+    protected S3PresignedUrlGenerator s3PresignedUrlGenerator;
 
     static {
         mySQL = new MySQLContainer<>(MYSQL_VERSION)

--- a/src/test/java/com/playus/twpservice/IntegrationTestSupport.java
+++ b/src/test/java/com/playus/twpservice/IntegrationTestSupport.java
@@ -74,5 +74,6 @@ public abstract class IntegrationTestSupport extends OpenFeignClientTestSupport 
                 () -> String.format("mongodb://%s:%d/chat_db", chatMongo.getHost(), chatMongo.getMappedPort(MONGO_PORT)));
         registry.add("spring.data.mongodb.chat.port", () -> String.valueOf(chatMongo.getMappedPort(MONGO_PORT)));
 
+        registry.add("spring.data.mongodb.auto-index-creation", () -> "true");
     }
 }

--- a/src/test/java/com/playus/twpservice/OpenFeignClientTestSupport.java
+++ b/src/test/java/com/playus/twpservice/OpenFeignClientTestSupport.java
@@ -1,0 +1,34 @@
+package com.playus.twpservice;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
+import org.springframework.test.context.TestPropertySource;
+
+@AutoConfigureWireMock(port = 0)
+@TestPropertySource(properties = {
+        "feign.user.url=http://localhost:${wiremock.server.port}",
+        "feign.match.url=http://localhost:${wiremock.server.port}",
+})
+public abstract class OpenFeignClientTestSupport {
+
+    @Autowired
+    protected WireMockServer wireMockServer;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        wireMockServer.stop();
+        wireMockServer.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        wireMockServer.resetAll();
+    }
+}

--- a/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
@@ -431,8 +431,10 @@ class PartyControllerTest extends ControllerTestSupport {
                 "ZSJ", "남성", matchDate,
                 10L, 14L, partyThumbnailUrls, userThumbnailUrls);
 
+        List<PartiesByMatchResponse> result = List.of(response);
+
         given(partyReadOnlyService.getPartiesBy(any(Long.class), any(Long.class)))
-                .willReturn(response);
+                .willReturn(result);
 
         // when // then
         mockMvc.perform(get("/party")
@@ -471,8 +473,11 @@ class PartyControllerTest extends ControllerTestSupport {
                 "ZSJ", "남성", matchDate,
                 10L, 14L, partyThumbnailUrls, userThumbnailUrls);
 
+        List<PartiesByMatchResponse> result = List.of(response);
+
         given(partyReadOnlyService.getPartiesBy(any(Long.class), any(Long.class)))
-                .willReturn(response);
+                .willReturn(result);
+
 
         // when // then
         mockMvc.perform(get("/party")
@@ -515,8 +520,11 @@ class PartyControllerTest extends ControllerTestSupport {
                 "ZSJ", "남성", matchDate,
                 10L, 14L, partyThumbnailUrls, userThumbnailUrls);
 
+        List<PartiesByMatchResponse> result = List.of(response);
+
         given(partyReadOnlyService.getPartiesBy(any(Long.class), any(Long.class)))
-                .willReturn(response);
+                .willReturn(result);
+
 
         // when // then
         mockMvc.perform(get("/party")
@@ -544,8 +552,10 @@ class PartyControllerTest extends ControllerTestSupport {
                 "ZSJ", "남성", matchDate,
                 10L, 14L, partyThumbnailUrls, userThumbnailUrls);
 
+        List<PartiesByMatchResponse> result = List.of(response);
+
         given(partyReadOnlyService.getPartiesBy(any(Long.class), any(Long.class)))
-                .willReturn(response);
+                .willReturn(result);
 
         // when // then
         mockMvc.perform(get("/party")

--- a/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
@@ -427,7 +427,7 @@ class PartyControllerTest extends ControllerTestSupport {
         List<String> partyThumbnailUrls = List.of("http://party-thumbnail", "http://party-thumbnail2.com");
         List<String> userThumbnailUrls = List.of("http://user-thumbnailUrl", "http://user2-thumbnailUrl");
 
-        PartiesByMatchResponse response = PartiesByMatchResponse.of("title", PartyJoinMethod.RESERVATION, partyAges, PartyGender.MALE,
+        PartiesByMatchResponse response = PartiesByMatchResponse.of(1L, "title", PartyJoinMethod.RESERVATION, partyAges, PartyGender.MALE,
                 "ZSJ", "남성", matchDate,
                 10L, 14L, partyThumbnailUrls, userThumbnailUrls);
 
@@ -469,7 +469,7 @@ class PartyControllerTest extends ControllerTestSupport {
         List<String> partyThumbnailUrls = List.of("http://party-thumbnail", "http://party-thumbnail2.com");
         List<String> userThumbnailUrls = List.of("http://user-thumbnailUrl", "http://user2-thumbnailUrl");
 
-        PartiesByMatchResponse response = PartiesByMatchResponse.of("title", PartyJoinMethod.RESERVATION, partyAges, PartyGender.MALE,
+        PartiesByMatchResponse response = PartiesByMatchResponse.of(1L, "title", PartyJoinMethod.RESERVATION, partyAges, PartyGender.MALE,
                 "ZSJ", "남성", matchDate,
                 10L, 14L, partyThumbnailUrls, userThumbnailUrls);
 
@@ -516,7 +516,7 @@ class PartyControllerTest extends ControllerTestSupport {
         List<String> partyThumbnailUrls = List.of("http://party-thumbnail", "http://party-thumbnail2.com");
         List<String> userThumbnailUrls = List.of("http://user-thumbnailUrl", "http://user2-thumbnailUrl");
 
-        PartiesByMatchResponse response = PartiesByMatchResponse.of("title", PartyJoinMethod.RESERVATION, partyAges, PartyGender.MALE,
+        PartiesByMatchResponse response = PartiesByMatchResponse.of(1L, "title", PartyJoinMethod.RESERVATION, partyAges, PartyGender.MALE,
                 "ZSJ", "남성", matchDate,
                 10L, 14L, partyThumbnailUrls, userThumbnailUrls);
 
@@ -548,7 +548,7 @@ class PartyControllerTest extends ControllerTestSupport {
         List<String> partyThumbnailUrls = List.of("http://party-thumbnail", "http://party-thumbnail2.com");
         List<String> userThumbnailUrls = List.of("http://user-thumbnailUrl", "http://user2-thumbnailUrl");
 
-        PartiesByMatchResponse response = PartiesByMatchResponse.of("title", PartyJoinMethod.RESERVATION, partyAges, PartyGender.MALE,
+        PartiesByMatchResponse response = PartiesByMatchResponse.of(1L, "title", PartyJoinMethod.RESERVATION, partyAges, PartyGender.MALE,
                 "ZSJ", "남성", matchDate,
                 10L, 14L, partyThumbnailUrls, userThumbnailUrls);
 

--- a/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
@@ -19,6 +19,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Stream;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -440,7 +441,7 @@ class PartyControllerTest extends ControllerTestSupport {
         mockMvc.perform(get("/party")
                         .param("matchId", String.valueOf(matchId))
                         .contentType(APPLICATION_JSON)
-                        .with(authentication(token)))
+                        .with(authentication(token)).locale(Locale.KOREA))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].title").value("title"))
@@ -483,7 +484,7 @@ class PartyControllerTest extends ControllerTestSupport {
         mockMvc.perform(get("/party")
                         .param("matchId", String.valueOf(matchId))
                         .contentType(APPLICATION_JSON)
-                        .with(authentication(token)))
+                        .with(authentication(token)).locale(Locale.KOREA))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].matchDate").value(expectedFormattedDate));

--- a/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
@@ -1,6 +1,7 @@
 package com.playus.twpservice.domain.party.controller;
 
 import com.playus.twpservice.ControllerTestSupport;
+import com.playus.twpservice.domain.party.dto.partybymatch.PartiesByMatchResponse;
 import com.playus.twpservice.domain.party.dto.party_create.PartyCreateRequest;
 import com.playus.twpservice.domain.party.dto.party_create.PartyCreateResponse;
 import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageRequest;
@@ -12,6 +13,7 @@ import org.junit.jupiter.params.provider.*;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
@@ -20,6 +22,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.*;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -408,6 +411,142 @@ class PartyControllerTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.code").value("400"))
                 .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
                 .andExpect(jsonPath("$.message").value("이미지 파일명은 필수입니다!"));
+    }
+
+    // 직관팟 반환
+    @DisplayName("특정 경기에 대한 직관팟을 가져올 수 있다.")
+    @Test
+    void getPartiesByMatchId() throws Exception {
+        // given
+        Long matchId = 1L;
+        List<String> partyAges = List.of("10대", "20대");
+        LocalDateTime matchDate = LocalDateTime.of(2025, 3, 22, 14, 0, 0);
+        List<String> partyThumbnailUrls = List.of("http://party-thumbnail", "http://party-thumbnail2.com");
+        List<String> userThumbnailUrls = List.of("http://user-thumbnailUrl", "http://user2-thumbnailUrl");
+
+        PartiesByMatchResponse response = PartiesByMatchResponse.of("title", "승인제", partyAges, "남자만",
+                "ZSJ", "남성", matchDate,
+                10L, 14L, partyThumbnailUrls, userThumbnailUrls);
+
+        given(partyReadOnlyService.getPartiesBy(any(Long.class), any(Long.class)))
+                .willReturn(response);
+
+        // when // then
+        mockMvc.perform(get("/party")
+                        .param("matchId", String.valueOf(matchId))
+                        .contentType(APPLICATION_JSON)
+                        .with(authentication(token)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title").value("title"))
+                .andExpect(jsonPath("$.partyJoinMethod").value("승인제"))
+                .andExpect(jsonPath("$.partyAges[0]").value("10대"))
+                .andExpect(jsonPath("$.partyAges[1]").value("20대"))
+                .andExpect(jsonPath("$.availableGender").value("남자만"))
+                .andExpect(jsonPath("$.authorName").value("ZSJ"))
+                .andExpect(jsonPath("$.authorGender").value("남성"))
+                .andExpect(jsonPath("$.matchDate").value("3.22(토) 오후 2:00"))
+                .andExpect(jsonPath("$.currentParticipantsCount").value(10))
+                .andExpect(jsonPath("$.maximumParticipantsCount").value(14))
+                .andExpect(jsonPath("$.partyThumbnailUrls[0]").value("http://party-thumbnail"))
+                .andExpect(jsonPath("$.partyThumbnailUrls[1]").value("http://party-thumbnail2.com"))
+                .andExpect(jsonPath("$.userThumbnailUrls[0]").value("http://user-thumbnailUrl"))
+                .andExpect(jsonPath("$.userThumbnailUrls[1]").value("http://user2-thumbnailUrl"));
+    }
+
+    @DisplayName("직관팟을 가져올 때, 날짜를 의도한 형식대로 변환해 반환할 수 있다.")
+    @MethodSource("matchDateWithFormattedResult")
+    @ParameterizedTest(name = "Date = {0}, formatted Date = {1}")
+    void getPartiesByMatchId(LocalDateTime matchDate, String expectedFormattedDate) throws Exception {
+        // given
+        Long matchId = 1L;
+        List<String> partyAges = List.of("10대", "20대");
+        List<String> partyThumbnailUrls = List.of("http://party-thumbnail", "http://party-thumbnail2.com");
+        List<String> userThumbnailUrls = List.of("http://user-thumbnailUrl", "http://user2-thumbnailUrl");
+
+        PartiesByMatchResponse response = PartiesByMatchResponse.of("title", "승인제", partyAges, "남자만",
+                "ZSJ", "남성", matchDate,
+                10L, 14L, partyThumbnailUrls, userThumbnailUrls);
+
+        given(partyReadOnlyService.getPartiesBy(any(Long.class), any(Long.class)))
+                .willReturn(response);
+
+        // when // then
+        mockMvc.perform(get("/party")
+                        .param("matchId", String.valueOf(matchId))
+                        .contentType(APPLICATION_JSON)
+                        .with(authentication(token)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.matchDate").value(expectedFormattedDate));
+    }
+
+    private static Stream<Arguments> matchDateWithFormattedResult() {
+        return Stream.of(
+                Arguments.of(LocalDateTime.of(2025, 3, 22, 14, 0), "3.22(토) 오후 2:00"),
+                Arguments.of(LocalDateTime.of(2025, 3, 22, 0, 0), "3.22(토) 오전 12:00"),
+                Arguments.of(LocalDateTime.of(2025, 5, 1, 19, 30), "5.1(목) 오후 7:30"),
+                Arguments.of(LocalDateTime.of(2025, 12, 15, 10, 5), "12.15(월) 오전 10:05"),
+                Arguments.of(LocalDateTime.of(2025, 3, 23, 12, 0), "3.23(일) 오후 12:00")
+        );
+    }
+
+    @DisplayName("직관팟을 가져올 때 그 경기의 ID는 필수이다.")
+    @NullAndEmptySource
+    @ParameterizedTest
+    void getPartiesByMatchId_EMPTY_MATCHID(String emptyMatchIdStr) throws Exception {
+        // given
+        List<String> partyAges = List.of("10대", "20대");
+        LocalDateTime matchDate = LocalDateTime.of(2025, 3, 22, 14, 0, 0);
+        List<String> partyThumbnailUrls = List.of("http://party-thumbnail", "http://party-thumbnail2.com");
+        List<String> userThumbnailUrls = List.of("http://user-thumbnailUrl", "http://user2-thumbnailUrl");
+
+        PartiesByMatchResponse response = PartiesByMatchResponse.of("title", "승인제", partyAges, "남자만",
+                "ZSJ", "남성", matchDate,
+                10L, 14L, partyThumbnailUrls, userThumbnailUrls);
+
+        given(partyReadOnlyService.getPartiesBy(any(Long.class), any(Long.class)))
+                .willReturn(response);
+
+        // when // then
+        mockMvc.perform(get("/party")
+                        .param("matchId", emptyMatchIdStr)
+                        .contentType(APPLICATION_JSON)
+                        .with(authentication(token)))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("400"))
+                .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+                .andExpect(jsonPath("$.message").value("경기 ID는 필수입니다!"));
+    }
+
+    @DisplayName("직관팟을 가져올 때, 그 경기의 ID는 1 이상이여야 한다.")
+    @CsvSource(value = {"0", "-1", "-100", "-1000", "-10000"})
+    @ParameterizedTest
+    void getPartiesByMatchId_INVALID_MATCHID(String invalidMatchIdStr) throws Exception {
+        // given
+        List<String> partyAges = List.of("10대", "20대");
+        LocalDateTime matchDate = LocalDateTime.of(2025, 3, 22, 14, 0, 0);
+        List<String> partyThumbnailUrls = List.of("http://party-thumbnail", "http://party-thumbnail2.com");
+        List<String> userThumbnailUrls = List.of("http://user-thumbnailUrl", "http://user2-thumbnailUrl");
+
+        PartiesByMatchResponse response = PartiesByMatchResponse.of("title", "승인제", partyAges, "남자만",
+                "ZSJ", "남성", matchDate,
+                10L, 14L, partyThumbnailUrls, userThumbnailUrls);
+
+        given(partyReadOnlyService.getPartiesBy(any(Long.class), any(Long.class)))
+                .willReturn(response);
+
+        // when // then
+        mockMvc.perform(get("/party")
+                        .param("matchId", invalidMatchIdStr)
+                        .contentType(APPLICATION_JSON)
+                        .with(authentication(token)))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("400"))
+                .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+                .andExpect(jsonPath("$.message").value("ID는 1 이상이여아 합니다!"));
     }
 
     private void assertBadRequestOfPartyCreateRequest(PartyCreateRequest request, String requestUri, String expectedResult) throws Exception {

--- a/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
@@ -487,7 +487,14 @@ class PartyControllerTest extends ControllerTestSupport {
                 Arguments.of(LocalDateTime.of(2025, 3, 22, 0, 0), "3.22(토) 오전 12:00"),
                 Arguments.of(LocalDateTime.of(2025, 5, 1, 19, 30), "5.1(목) 오후 7:30"),
                 Arguments.of(LocalDateTime.of(2025, 12, 15, 10, 5), "12.15(월) 오전 10:05"),
-                Arguments.of(LocalDateTime.of(2025, 3, 23, 12, 0), "3.23(일) 오후 12:00")
+                Arguments.of(LocalDateTime.of(2025, 3, 23, 12, 0), "3.23(일) 오후 12:00"),
+                Arguments.of(LocalDateTime.of(2025, 3, 23, 1, 0), "3.23(일) 오전 1:00"),
+                Arguments.of(LocalDateTime.of(2025, 12, 31, 23, 59), "12.31(수) 오후 11:59"),
+                Arguments.of(LocalDateTime.of(2026, 1, 1, 0, 0), "1.1(목) 오전 12:00"),
+                Arguments.of(LocalDateTime.of(2025, 6, 15, 11, 59), "6.15(일) 오전 11:59"),
+                Arguments.of(LocalDateTime.of(2025, 6, 15, 12, 0), "6.15(일) 오후 12:00"),
+                Arguments.of(LocalDateTime.of(2025, 7, 20, 0, 0), "7.20(일) 오전 12:00"),
+                Arguments.of(LocalDateTime.of(2025, 7, 20, 23, 59), "7.20(일) 오후 11:59")
         );
     }
 

--- a/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
@@ -443,20 +443,20 @@ class PartyControllerTest extends ControllerTestSupport {
                         .with(authentication(token)))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.title").value("title"))
-                .andExpect(jsonPath("$.partyJoinMethod").value("승인제"))
-                .andExpect(jsonPath("$.partyAges[0]").value("10대"))
-                .andExpect(jsonPath("$.partyAges[1]").value("20대"))
-                .andExpect(jsonPath("$.availableGender").value("남자만"))
-                .andExpect(jsonPath("$.authorName").value("ZSJ"))
-                .andExpect(jsonPath("$.authorGender").value("남성"))
-                .andExpect(jsonPath("$.matchDate").value("3.22(토) 오후 2:00"))
-                .andExpect(jsonPath("$.currentParticipantsCount").value(10))
-                .andExpect(jsonPath("$.maximumParticipantsCount").value(14))
-                .andExpect(jsonPath("$.partyThumbnailUrls[0]").value("http://party-thumbnail"))
-                .andExpect(jsonPath("$.partyThumbnailUrls[1]").value("http://party-thumbnail2.com"))
-                .andExpect(jsonPath("$.userThumbnailUrls[0]").value("http://user-thumbnailUrl"))
-                .andExpect(jsonPath("$.userThumbnailUrls[1]").value("http://user2-thumbnailUrl"));
+                .andExpect(jsonPath("$[0].title").value("title"))
+                .andExpect(jsonPath("$[0].partyJoinMethod").value("승인제"))
+                .andExpect(jsonPath("$[0].partyAges[0]").value("10대"))
+                .andExpect(jsonPath("$[0].partyAges[1]").value("20대"))
+                .andExpect(jsonPath("$[0].availableGender").value("남자만"))
+                .andExpect(jsonPath("$[0].authorName").value("ZSJ"))
+                .andExpect(jsonPath("$[0].authorGender").value("남성"))
+                .andExpect(jsonPath("$[0].matchDate").value("3.22(토) 오후 2:00"))
+                .andExpect(jsonPath("$[0].currentParticipantsCount").value(10))
+                .andExpect(jsonPath("$[0].maximumParticipantsCount").value(14))
+                .andExpect(jsonPath("$[0].partyThumbnailUrls[0]").value("http://party-thumbnail"))
+                .andExpect(jsonPath("$[0].partyThumbnailUrls[1]").value("http://party-thumbnail2.com"))
+                .andExpect(jsonPath("$[0].userThumbnailUrls[0]").value("http://user-thumbnailUrl"))
+                .andExpect(jsonPath("$[0].userThumbnailUrls[1]").value("http://user2-thumbnailUrl"));
     }
 
     @DisplayName("직관팟을 가져올 때, 날짜를 의도한 형식대로 변환해 반환할 수 있다.")
@@ -486,7 +486,7 @@ class PartyControllerTest extends ControllerTestSupport {
                         .with(authentication(token)))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.matchDate").value(expectedFormattedDate));
+                .andExpect(jsonPath("$[0].matchDate").value(expectedFormattedDate));
     }
 
     private static Stream<Arguments> matchDateWithFormattedResult() {

--- a/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
@@ -6,6 +6,9 @@ import com.playus.twpservice.domain.party.dto.party_create.PartyCreateRequest;
 import com.playus.twpservice.domain.party.dto.party_create.PartyCreateResponse;
 import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageRequest;
 import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageResponse;
+import com.playus.twpservice.domain.party.enums.PartyAgeGroup;
+import com.playus.twpservice.domain.party.enums.PartyGender;
+import com.playus.twpservice.domain.party.enums.PartyJoinMethod;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -419,12 +422,12 @@ class PartyControllerTest extends ControllerTestSupport {
     void getPartiesByMatchId() throws Exception {
         // given
         Long matchId = 1L;
-        List<String> partyAges = List.of("10대", "20대");
+        List<PartyAgeGroup> partyAges = List.of(PartyAgeGroup.AGE_10, PartyAgeGroup.AGE_20);
         LocalDateTime matchDate = LocalDateTime.of(2025, 3, 22, 14, 0, 0);
         List<String> partyThumbnailUrls = List.of("http://party-thumbnail", "http://party-thumbnail2.com");
         List<String> userThumbnailUrls = List.of("http://user-thumbnailUrl", "http://user2-thumbnailUrl");
 
-        PartiesByMatchResponse response = PartiesByMatchResponse.of("title", "승인제", partyAges, "남자만",
+        PartiesByMatchResponse response = PartiesByMatchResponse.of("title", PartyJoinMethod.RESERVATION, partyAges, PartyGender.MALE,
                 "ZSJ", "남성", matchDate,
                 10L, 14L, partyThumbnailUrls, userThumbnailUrls);
 
@@ -460,11 +463,11 @@ class PartyControllerTest extends ControllerTestSupport {
     void getPartiesByMatchId(LocalDateTime matchDate, String expectedFormattedDate) throws Exception {
         // given
         Long matchId = 1L;
-        List<String> partyAges = List.of("10대", "20대");
+        List<PartyAgeGroup> partyAges = List.of(PartyAgeGroup.AGE_10, PartyAgeGroup.AGE_20);
         List<String> partyThumbnailUrls = List.of("http://party-thumbnail", "http://party-thumbnail2.com");
         List<String> userThumbnailUrls = List.of("http://user-thumbnailUrl", "http://user2-thumbnailUrl");
 
-        PartiesByMatchResponse response = PartiesByMatchResponse.of("title", "승인제", partyAges, "남자만",
+        PartiesByMatchResponse response = PartiesByMatchResponse.of("title", PartyJoinMethod.RESERVATION, partyAges, PartyGender.MALE,
                 "ZSJ", "남성", matchDate,
                 10L, 14L, partyThumbnailUrls, userThumbnailUrls);
 
@@ -503,12 +506,12 @@ class PartyControllerTest extends ControllerTestSupport {
     @ParameterizedTest
     void getPartiesByMatchId_EMPTY_MATCHID(String emptyMatchIdStr) throws Exception {
         // given
-        List<String> partyAges = List.of("10대", "20대");
+        List<PartyAgeGroup> partyAges = List.of(PartyAgeGroup.AGE_10, PartyAgeGroup.AGE_20);
         LocalDateTime matchDate = LocalDateTime.of(2025, 3, 22, 14, 0, 0);
         List<String> partyThumbnailUrls = List.of("http://party-thumbnail", "http://party-thumbnail2.com");
         List<String> userThumbnailUrls = List.of("http://user-thumbnailUrl", "http://user2-thumbnailUrl");
 
-        PartiesByMatchResponse response = PartiesByMatchResponse.of("title", "승인제", partyAges, "남자만",
+        PartiesByMatchResponse response = PartiesByMatchResponse.of("title", PartyJoinMethod.RESERVATION, partyAges, PartyGender.MALE,
                 "ZSJ", "남성", matchDate,
                 10L, 14L, partyThumbnailUrls, userThumbnailUrls);
 
@@ -532,12 +535,12 @@ class PartyControllerTest extends ControllerTestSupport {
     @ParameterizedTest
     void getPartiesByMatchId_INVALID_MATCHID(String invalidMatchIdStr) throws Exception {
         // given
-        List<String> partyAges = List.of("10대", "20대");
+        List<PartyAgeGroup> partyAges = List.of(PartyAgeGroup.AGE_10, PartyAgeGroup.AGE_20);
         LocalDateTime matchDate = LocalDateTime.of(2025, 3, 22, 14, 0, 0);
         List<String> partyThumbnailUrls = List.of("http://party-thumbnail", "http://party-thumbnail2.com");
         List<String> userThumbnailUrls = List.of("http://user-thumbnailUrl", "http://user2-thumbnailUrl");
 
-        PartiesByMatchResponse response = PartiesByMatchResponse.of("title", "승인제", partyAges, "남자만",
+        PartiesByMatchResponse response = PartiesByMatchResponse.of("title", PartyJoinMethod.RESERVATION, partyAges, PartyGender.MALE,
                 "ZSJ", "남성", matchDate,
                 10L, 14L, partyThumbnailUrls, userThumbnailUrls);
 

--- a/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
@@ -19,7 +19,6 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Locale;
 import java.util.stream.Stream;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -441,7 +440,7 @@ class PartyControllerTest extends ControllerTestSupport {
         mockMvc.perform(get("/party")
                         .param("matchId", String.valueOf(matchId))
                         .contentType(APPLICATION_JSON)
-                        .with(authentication(token)).locale(Locale.KOREA))
+                        .with(authentication(token)))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].title").value("title"))
@@ -484,7 +483,7 @@ class PartyControllerTest extends ControllerTestSupport {
         mockMvc.perform(get("/party")
                         .param("matchId", String.valueOf(matchId))
                         .contentType(APPLICATION_JSON)
-                        .with(authentication(token)).locale(Locale.KOREA))
+                        .with(authentication(token)))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].matchDate").value(expectedFormattedDate));

--- a/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
@@ -433,7 +433,7 @@ class PartyControllerTest extends ControllerTestSupport {
 
         List<PartiesByMatchResponse> result = List.of(response);
 
-        given(partyReadOnlyService.getPartiesBy(any(Long.class), any(Long.class)))
+        given(partyReadOnlyService.getPartiesBy(any(Long.class)))
                 .willReturn(result);
 
         // when // then
@@ -475,7 +475,7 @@ class PartyControllerTest extends ControllerTestSupport {
 
         List<PartiesByMatchResponse> result = List.of(response);
 
-        given(partyReadOnlyService.getPartiesBy(any(Long.class), any(Long.class)))
+        given(partyReadOnlyService.getPartiesBy(any(Long.class)))
                 .willReturn(result);
 
 
@@ -522,7 +522,7 @@ class PartyControllerTest extends ControllerTestSupport {
 
         List<PartiesByMatchResponse> result = List.of(response);
 
-        given(partyReadOnlyService.getPartiesBy(any(Long.class), any(Long.class)))
+        given(partyReadOnlyService.getPartiesBy(any(Long.class)))
                 .willReturn(result);
 
 
@@ -554,7 +554,7 @@ class PartyControllerTest extends ControllerTestSupport {
 
         List<PartiesByMatchResponse> result = List.of(response);
 
-        given(partyReadOnlyService.getPartiesBy(any(Long.class), any(Long.class)))
+        given(partyReadOnlyService.getPartiesBy(any(Long.class)))
                 .willReturn(result);
 
         // when // then

--- a/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
@@ -569,6 +569,24 @@ class PartyControllerTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.message").value("ID는 1 이상이여아 합니다!"));
     }
 
+    @DisplayName("특정 경기에 대한 직관팟이 없을 수 있다.")
+    @Test
+    void getPartiesByMatchId_EMPTY_PARTY() throws Exception {
+        // given
+        Long matchId = 1L;
+
+        given(partyReadOnlyService.getPartiesBy(any(Long.class)))
+                .willReturn(List.of());
+
+        // when // then
+        mockMvc.perform(get("/party")
+                        .param("matchId", String.valueOf(matchId))
+                        .contentType(APPLICATION_JSON)
+                        .with(authentication(token)))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
     private void assertBadRequestOfPartyCreateRequest(PartyCreateRequest request, String requestUri, String expectedResult) throws Exception {
         mockMvc.perform(post(requestUri)
                         .content(objectMapper.writeValueAsString(request))

--- a/src/test/java/com/playus/twpservice/domain/party/feign/client/MatchFeignClientTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/feign/client/MatchFeignClientTest.java
@@ -1,0 +1,65 @@
+package com.playus.twpservice.domain.party.feign.client;
+
+import com.playus.twpservice.IntegrationTestSupport;
+import com.playus.twpservice.global.response.ErrorResponse;
+import feign.FeignException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import java.time.LocalDateTime;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class MatchFeignClientTest extends IntegrationTestSupport {
+
+    @Autowired
+    MatchFeignClient matchFeignClient;
+
+    @DisplayName("경기 날짜를 가져올 수 있다.")
+    @Test
+    void getMatchDate() throws Exception {
+        // given
+        Long matchId = 1L;
+        LocalDateTime expectedResponse = LocalDateTime.of(2023, 10, 1, 12, 0);
+
+        stubFor(get(urlEqualTo("/match/api/date?matchId=" + matchId))
+                .willReturn(aResponse()
+                        .withStatus(HttpStatus.OK.value())
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                        .withBody(objectMapper.writeValueAsString(expectedResponse))
+                ));
+
+        // when
+        LocalDateTime matchDate = matchFeignClient.getMatchDate(matchId);
+
+        // then
+        assertThat(matchDate)
+                .isEqualTo(expectedResponse);
+    }
+
+    @DisplayName("경기 날짜를 가져오지 못할 수 있다.")
+    @Test
+    void getMatchDate_404() throws Exception {
+        // given
+        Long matchId = 1L;
+        ErrorResponse errorResponse = ErrorResponse.notFoundError("찾을 수 없습니다!");
+
+        stubFor(get(urlEqualTo("/match/api/date?matchId=" + matchId))
+                .willReturn(aResponse()
+                        .withStatus(HttpStatus.NOT_FOUND.value())
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                        .withBody(objectMapper.writeValueAsString(errorResponse))
+                ));
+
+        // when // then
+        assertThatThrownBy(() -> matchFeignClient.getMatchDate(matchId))
+                .isInstanceOf(FeignException.class)
+                .hasMessageContaining("찾을 수 없습니다!");
+    }
+
+}

--- a/src/test/java/com/playus/twpservice/domain/party/feign/client/UserFeignClientTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/feign/client/UserFeignClientTest.java
@@ -1,0 +1,140 @@
+package com.playus.twpservice.domain.party.feign.client;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.playus.twpservice.IntegrationTestSupport;
+import com.playus.twpservice.domain.party.feign.response.PartyUserThumbnailUrlListResponse;
+import com.playus.twpservice.domain.party.feign.response.PartyWriterInfoFeignResponse;
+import com.playus.twpservice.global.response.ErrorResponse;
+import feign.FeignException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import java.util.List;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static org.assertj.core.api.Assertions.*;
+
+class UserFeignClientTest extends IntegrationTestSupport {
+
+    @Autowired
+    UserFeignClient userFeignClient;
+
+    @DisplayName("사용자의 썸네일 URL을 가져올 수 있다.")
+    @Test
+    void getPartyUserThumbnailUrls() throws JsonProcessingException {
+        // given
+        List<Long> userIdList = List.of(1L, 2L);
+        PartyUserThumbnailUrlListResponse expectedResponse = PartyUserThumbnailUrlListResponse.of(List.of("http://user-thumb", "http://user2-thumb"));
+        stubFor(post(urlEqualTo("/user/api/thumbnails"))
+                .withRequestBody(equalToJson(objectMapper.writeValueAsString(userIdList)))
+                .willReturn(aResponse()
+                        .withStatus(HttpStatus.OK.value())
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                        .withBody(objectMapper.writeValueAsString(expectedResponse))
+                ));
+
+        // when
+        PartyUserThumbnailUrlListResponse result = userFeignClient.getPartyUserThumbnailUrls(userIdList);
+
+        // then
+        assertThat(result.thumbnailUrls())
+                .hasSize(2)
+                .containsExactly("http://user-thumb", "http://user2-thumb");
+    }
+
+    @DisplayName("사용자가 존재하지 않을 수 있다.")
+    @Test
+    void getPartyUserThumbnailurls_INVALID_PK() throws JsonProcessingException {
+        // given
+        List<Long> userIdList = List.of(1L, 2L);
+        ErrorResponse errorResponse = ErrorResponse.notFoundError("사용자가 존재하지 않습니다!");
+        stubFor(post(urlEqualTo("/user/api/thumbnails"))
+                .withRequestBody(equalToJson(objectMapper.writeValueAsString(userIdList)))
+                .willReturn(aResponse()
+                        .withStatus(HttpStatus.NOT_FOUND.value())
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                        .withBody(objectMapper.writeValueAsString(errorResponse))
+                ));
+
+        // when // then
+        assertThatThrownBy(() -> userFeignClient.getPartyUserThumbnailUrls(userIdList))
+                .isInstanceOf(FeignException.class)
+                .hasMessageContaining("사용자가 존재하지 않습니다!");
+    }
+
+    @DisplayName("사용자의 썸네일 URL이 비어 있을 수 있다.")
+    @Test
+    void getPartyUserThumbnailUrls_EMPTY_THUMB() throws JsonProcessingException {
+        // given
+        List<Long> userIdList = List.of(1L, 2L);
+        PartyUserThumbnailUrlListResponse expectedResponse = PartyUserThumbnailUrlListResponse.of(List.of());
+        stubFor(post(urlEqualTo("/user/api/thumbnails"))
+                .withRequestBody(equalToJson(objectMapper.writeValueAsString(userIdList)))
+                .willReturn(aResponse()
+                        .withStatus(HttpStatus.OK.value())
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                        .withBody(objectMapper.writeValueAsString(expectedResponse))
+                ));
+
+        // when
+        PartyUserThumbnailUrlListResponse result = userFeignClient.getPartyUserThumbnailUrls(userIdList);
+
+        // then
+        assertThat(result.thumbnailUrls()).isEmpty();
+    }
+
+    @DisplayName("직관팟 작성자의 정보를 가져올 수 있다.")
+    @Test
+    void getWriterInfo() throws JsonProcessingException {
+        // given
+        List<Long> writerIdList = List.of(1L, 2L);
+        List<PartyWriterInfoFeignResponse> expectedResponse = List.of(
+                PartyWriterInfoFeignResponse.of(1L, "user1", "남성", "http://user1-thumb"),
+                PartyWriterInfoFeignResponse.of(2L, "user2", "여성", "http://user2-thumb")
+        );
+
+        stubFor(post(urlEqualTo("/user/api/writers"))
+                .withRequestBody(equalToJson(objectMapper.writeValueAsString(writerIdList)))
+                .willReturn(aResponse()
+                        .withStatus(HttpStatus.OK.value())
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                        .withBody(objectMapper.writeValueAsString(expectedResponse))
+                ));
+
+        // when
+        List<PartyWriterInfoFeignResponse> result = userFeignClient.getWriterInfo(writerIdList);
+
+        // then
+        assertThat(result).hasSize(2)
+                .extracting("id", "writerName", "writerGender", "writerThumbnailUrl")
+                .containsExactly(
+                        tuple(1L, "user1", "남성", "http://user1-thumb"),
+                        tuple(2L, "user2", "여성", "http://user2-thumb")
+                );
+    }
+
+    @DisplayName("직관팟 작성자가 존재하지 않을 수 있다.")
+    @Test
+    void getWriterInfo_INVALID_PK() throws JsonProcessingException {
+        // given
+        List<Long> writerIdList = List.of(1L, 2L);
+        ErrorResponse errorResponse = ErrorResponse.notFoundError("사용자가 존재하지 않습니다!");
+        stubFor(post(urlEqualTo("/user/api/writers"))
+                .withRequestBody(equalToJson(objectMapper.writeValueAsString(writerIdList)))
+                .willReturn(aResponse()
+                        .withStatus(HttpStatus.NOT_FOUND.value())
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                        .withBody(objectMapper.writeValueAsString(errorResponse))
+                ));
+
+        // when // then
+        assertThatThrownBy(() -> userFeignClient.getWriterInfo(writerIdList))
+                .isInstanceOf(FeignException.class)
+                .hasMessageContaining("사용자가 존재하지 않습니다!");
+    }
+
+}

--- a/src/test/java/com/playus/twpservice/domain/party/repository/read/PartyReadOnlyRepositoryTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/repository/read/PartyReadOnlyRepositoryTest.java
@@ -53,7 +53,8 @@ class PartyReadOnlyRepositoryTest extends IntegrationTestSupport {
         PartyDocument p2 = PartyDocument.createForOnlyTest(2L, "title2", "text2", 1L, 10L,
                 "http://thumbnail", PartyGender.FEMALE, PartyJoinMethod.RESERVATION, 2L, matchId, "chatRoom2Id");
         PartyDocument p3 = PartyDocument.createForOnlyTest(3L, "title3", "text3", 1L, 10L,
-                "http://thumbnail", PartyGender.NO_MATTER, PartyJoinMethod.RESERVATION, matchId, 3L, "chatRoom3Id");
+                "http://thumbnail", PartyGender.NO_MATTER, PartyJoinMethod.RESERVATION, 3L, matchId + 1, "chatRoom3Id");
+
         List<PartyDocument> partyDocuments = partyReadOnlyRepository.saveAll(List.of(p1, p2, p3));
 
         PartyAgeDocument pa1 = PartyAgeDocument.createForOnlyTest(1L, partyDocuments.get(0), 10);
@@ -73,11 +74,11 @@ class PartyReadOnlyRepositoryTest extends IntegrationTestSupport {
 
         // then
         assertThat(result).hasSize(2)
-                .extracting("partyId", "title", "partyJoinMethod", "partyGender", "ages",
+                .extracting("partyId", "title", "writerId", "partyJoinMethod", "partyGender", "ages",
                         "currentParticipantsCount", "maximumParticipants", "thumbnailUrls")
                 .containsExactlyInAnyOrder(
-                        tuple(1L, "title1", PartyJoinMethod.FIRST_COME, PartyGender.MALE, List.of(10), 2L, 10L, List.of("thumbnailUrl1", "thumbnailUrl2")),
-                        tuple(2L, "title2", PartyJoinMethod.RESERVATION, PartyGender.FEMALE, List.of(20), 0L, 10L, List.of())
+                        tuple(1L, "title1", 1L, PartyJoinMethod.FIRST_COME, PartyGender.MALE, List.of(10), 2L, 10L, List.of("thumbnailUrl1", "thumbnailUrl2")),
+                        tuple(2L, "title2", 2L, PartyJoinMethod.RESERVATION, PartyGender.FEMALE, List.of(20), 0L, 10L, List.of())
                 );
     }
 }

--- a/src/test/java/com/playus/twpservice/domain/party/repository/read/PartyReadOnlyRepositoryTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/repository/read/PartyReadOnlyRepositoryTest.java
@@ -1,8 +1,84 @@
 package com.playus.twpservice.domain.party.repository.read;
 
 import com.playus.twpservice.IntegrationTestSupport;
+import com.playus.twpservice.domain.party.document.PartyAgeDocument;
+import com.playus.twpservice.domain.party.document.PartyDocument;
+import com.playus.twpservice.domain.party.document.PartyJoinDocument;
+import com.playus.twpservice.domain.party.document.PartyThumbnailUrlDocument;
+import com.playus.twpservice.domain.party.enums.PartyGender;
+import com.playus.twpservice.domain.party.enums.PartyJoinMethod;
+import com.playus.twpservice.domain.party.enums.PartyJoinRequestStatus;
+import com.playus.twpservice.domain.party.vo.PartySummary;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 class PartyReadOnlyRepositoryTest extends IntegrationTestSupport {
 
+    @Autowired
+    PartyReadOnlyRepository partyReadOnlyRepository;
 
+    @Autowired
+    PartyAgeReadOnlyRepository partyAgeReadOnlyRepository;
+
+    @Autowired
+    PartyThumbnailUrlReadOnlyRepository partyThumbnailUrlReadOnlyRepository;
+
+    @Autowired
+    PartyJoinReadOnlyRepository partyJoinReadOnlyRepository;
+
+
+    @AfterEach
+    void tearDown() {
+        partyReadOnlyRepository.deleteAll();
+        partyAgeReadOnlyRepository.deleteAll();
+        partyThumbnailUrlReadOnlyRepository.deleteAll();
+        partyJoinReadOnlyRepository.deleteAll();
+    }
+
+    @DisplayName("직관팟 정보를 가져올 수 있다.")
+    @Test
+    void findPartySummaries() {
+        // given
+        Long matchId = 1L;
+
+        PartyDocument p1 = PartyDocument.createForOnlyTest(1L, "title1", "text1", 1L, 10L,
+                "http://thumbnail", PartyGender.MALE, PartyJoinMethod.FIRST_COME, matchId, "chatRoomId");
+        PartyDocument p2 = PartyDocument.createForOnlyTest(2L, "title2", "text2", 1L, 10L,
+                "http://thumbnail", PartyGender.FEMALE, PartyJoinMethod.RESERVATION, matchId, "chatRoom2Id");
+        PartyDocument p3 = PartyDocument.createForOnlyTest(3L, "title3", "text3", 1L, 10L,
+                "http://thumbnail", PartyGender.NO_MATTER, PartyJoinMethod.RESERVATION, 2L, "chatRoom3Id");
+        List<PartyDocument> partyDocuments = partyReadOnlyRepository.saveAll(List.of(p1, p2, p3));
+
+        PartyAgeDocument pa1 = PartyAgeDocument.createForOnlyTest(1L, partyDocuments.get(0), 10);
+        PartyAgeDocument pa2 = PartyAgeDocument.createForOnlyTest(2L, partyDocuments.get(1), 20);
+        partyAgeReadOnlyRepository.saveAll(List.of(pa1, pa2));
+
+        PartyThumbnailUrlDocument ptu1 = PartyThumbnailUrlDocument.createForOnlyTest(1L, partyDocuments.get(0), "thumbnailUrl1");
+        PartyThumbnailUrlDocument ptu2 = PartyThumbnailUrlDocument.createForOnlyTest(2L, partyDocuments.get(0), "thumbnailUrl2");
+        partyThumbnailUrlReadOnlyRepository.saveAll(List.of(ptu1, ptu2));
+
+        PartyJoinDocument pj1 = PartyJoinDocument.createForOnlyTest(1L, 1L, partyDocuments.get(0), PartyJoinRequestStatus.ACCEPT, null);
+        PartyJoinDocument pj2 = PartyJoinDocument.createForOnlyTest(2L, 2L, partyDocuments.get(0), PartyJoinRequestStatus.WAIT, "가입 원합니다!");
+        PartyJoinDocument pj3 = PartyJoinDocument.createForOnlyTest(3L, 3L, partyDocuments.get(1), PartyJoinRequestStatus.ACCEPT, null);
+        partyJoinReadOnlyRepository.saveAll(List.of(pj1, pj2, pj3));
+
+        // when
+        List<PartySummary> result = partyReadOnlyRepository.findPartySummariesByMatchId(matchId);
+
+        // then
+        assertThat(result).hasSize(2)
+                .extracting("partyId", "title", "partyJoinMethod", "partyGender", "ages",
+                        "currentParticipantsCount", "maximumParticipants", "thumbnailUrls")
+                .containsExactlyInAnyOrder(
+                        tuple(1L, "title1", PartyJoinMethod.FIRST_COME, PartyGender.MALE, List.of(10), 2L, 10L, List.of("thumbnailUrl1", "thumbnailUrl2")),
+                        tuple(2L, "title2", PartyJoinMethod.RESERVATION, PartyGender.FEMALE, List.of(20), 1L, 10L, List.of())
+                );
+    }
 }

--- a/src/test/java/com/playus/twpservice/domain/party/repository/read/PartyReadOnlyRepositoryTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/repository/read/PartyReadOnlyRepositoryTest.java
@@ -81,4 +81,17 @@ class PartyReadOnlyRepositoryTest extends IntegrationTestSupport {
                         tuple(2L, "title2", 2L, List.of(), PartyJoinMethod.RESERVATION, PartyGender.FEMALE, List.of(20), 0L, 10L, List.of())
                 );
     }
+
+    @DisplayName("특정 경기에 대한 직관팟이 없을 수 있다.")
+    @Test
+    void findPartySummaries_EMPTY_PARTY() {
+        // given
+        Long matchId = 1L;
+
+        // when
+        List<PartySummary> result = partyReadOnlyRepository.findPartySummariesByMatchId(matchId);
+
+        // then
+        assertThat(result).isEmpty();
+    }
 }

--- a/src/test/java/com/playus/twpservice/domain/party/repository/read/PartyReadOnlyRepositoryTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/repository/read/PartyReadOnlyRepositoryTest.java
@@ -74,11 +74,11 @@ class PartyReadOnlyRepositoryTest extends IntegrationTestSupport {
 
         // then
         assertThat(result).hasSize(2)
-                .extracting("partyId", "title", "writerId", "partyJoinMethod", "partyGender", "ages",
+                .extracting("partyId", "title", "writerId", "userIdList", "partyJoinMethod", "partyGender", "ages",
                         "currentParticipantsCount", "maximumParticipants", "thumbnailUrls")
                 .containsExactlyInAnyOrder(
-                        tuple(1L, "title1", 1L, PartyJoinMethod.FIRST_COME, PartyGender.MALE, List.of(10), 2L, 10L, List.of("thumbnailUrl1", "thumbnailUrl2")),
-                        tuple(2L, "title2", 2L, PartyJoinMethod.RESERVATION, PartyGender.FEMALE, List.of(20), 0L, 10L, List.of())
+                        tuple(1L, "title1", 1L, List.of(4L, 5L), PartyJoinMethod.FIRST_COME, PartyGender.MALE, List.of(10), 2L, 10L, List.of("thumbnailUrl1", "thumbnailUrl2")),
+                        tuple(2L, "title2", 2L, List.of(), PartyJoinMethod.RESERVATION, PartyGender.FEMALE, List.of(20), 0L, 10L, List.of())
                 );
     }
 }

--- a/src/test/java/com/playus/twpservice/domain/party/repository/read/PartyReadOnlyRepositoryTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/repository/read/PartyReadOnlyRepositoryTest.java
@@ -49,11 +49,11 @@ class PartyReadOnlyRepositoryTest extends IntegrationTestSupport {
         Long matchId = 1L;
 
         PartyDocument p1 = PartyDocument.createForOnlyTest(1L, "title1", "text1", 1L, 10L,
-                "http://thumbnail", PartyGender.MALE, PartyJoinMethod.FIRST_COME, matchId, "chatRoomId");
+                "http://thumbnail", PartyGender.MALE, PartyJoinMethod.FIRST_COME, 1L, matchId, "chatRoomId");
         PartyDocument p2 = PartyDocument.createForOnlyTest(2L, "title2", "text2", 1L, 10L,
-                "http://thumbnail", PartyGender.FEMALE, PartyJoinMethod.RESERVATION, matchId, "chatRoom2Id");
+                "http://thumbnail", PartyGender.FEMALE, PartyJoinMethod.RESERVATION, 2L, matchId, "chatRoom2Id");
         PartyDocument p3 = PartyDocument.createForOnlyTest(3L, "title3", "text3", 1L, 10L,
-                "http://thumbnail", PartyGender.NO_MATTER, PartyJoinMethod.RESERVATION, 2L, "chatRoom3Id");
+                "http://thumbnail", PartyGender.NO_MATTER, PartyJoinMethod.RESERVATION, matchId, 3L, "chatRoom3Id");
         List<PartyDocument> partyDocuments = partyReadOnlyRepository.saveAll(List.of(p1, p2, p3));
 
         PartyAgeDocument pa1 = PartyAgeDocument.createForOnlyTest(1L, partyDocuments.get(0), 10);
@@ -64,10 +64,9 @@ class PartyReadOnlyRepositoryTest extends IntegrationTestSupport {
         PartyThumbnailUrlDocument ptu2 = PartyThumbnailUrlDocument.createForOnlyTest(2L, partyDocuments.get(0), "thumbnailUrl2");
         partyThumbnailUrlReadOnlyRepository.saveAll(List.of(ptu1, ptu2));
 
-        PartyJoinDocument pj1 = PartyJoinDocument.createForOnlyTest(1L, 1L, partyDocuments.get(0), PartyJoinRequestStatus.ACCEPT, null);
-        PartyJoinDocument pj2 = PartyJoinDocument.createForOnlyTest(2L, 2L, partyDocuments.get(0), PartyJoinRequestStatus.WAIT, "가입 원합니다!");
-        PartyJoinDocument pj3 = PartyJoinDocument.createForOnlyTest(3L, 3L, partyDocuments.get(1), PartyJoinRequestStatus.ACCEPT, null);
-        partyJoinReadOnlyRepository.saveAll(List.of(pj1, pj2, pj3));
+        PartyJoinDocument pj1 = PartyJoinDocument.createForOnlyTest(1L, 4L, partyDocuments.get(0), PartyJoinRequestStatus.ACCEPT, null);
+        PartyJoinDocument pj2 = PartyJoinDocument.createForOnlyTest(2L, 5L, partyDocuments.get(0), PartyJoinRequestStatus.WAIT, "가입 원합니다!");
+        partyJoinReadOnlyRepository.saveAll(List.of(pj1, pj2));
 
         // when
         List<PartySummary> result = partyReadOnlyRepository.findPartySummariesByMatchId(matchId);
@@ -78,7 +77,7 @@ class PartyReadOnlyRepositoryTest extends IntegrationTestSupport {
                         "currentParticipantsCount", "maximumParticipants", "thumbnailUrls")
                 .containsExactlyInAnyOrder(
                         tuple(1L, "title1", PartyJoinMethod.FIRST_COME, PartyGender.MALE, List.of(10), 2L, 10L, List.of("thumbnailUrl1", "thumbnailUrl2")),
-                        tuple(2L, "title2", PartyJoinMethod.RESERVATION, PartyGender.FEMALE, List.of(20), 1L, 10L, List.of())
+                        tuple(2L, "title2", PartyJoinMethod.RESERVATION, PartyGender.FEMALE, List.of(20), 0L, 10L, List.of())
                 );
     }
 }

--- a/src/test/java/com/playus/twpservice/domain/party/service/PartyReadOnlyServiceTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/service/PartyReadOnlyServiceTest.java
@@ -9,6 +9,8 @@ import com.playus.twpservice.domain.party.dto.partybymatch.PartiesByMatchRespons
 import com.playus.twpservice.domain.party.enums.PartyGender;
 import com.playus.twpservice.domain.party.enums.PartyJoinMethod;
 import com.playus.twpservice.domain.party.enums.PartyJoinRequestStatus;
+import com.playus.twpservice.domain.party.feign.client.MatchFeignClient;
+import com.playus.twpservice.domain.party.feign.client.UserFeignClient;
 import com.playus.twpservice.domain.party.feign.response.PartyUserThumbnailUrlListResponse;
 import com.playus.twpservice.domain.party.feign.response.PartyWriterInfoFeignResponse;
 import com.playus.twpservice.domain.party.repository.read.PartyAgeReadOnlyRepository;
@@ -19,6 +21,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -44,6 +47,12 @@ class PartyReadOnlyServiceTest extends IntegrationTestSupport {
 
     @Autowired
     PartyJoinReadOnlyRepository partyJoinReadOnlyRepository;
+
+    @MockitoBean
+    protected UserFeignClient userFeignClient;
+
+    @MockitoBean
+    protected MatchFeignClient matchFeignClient;
 
 
     @AfterEach

--- a/src/test/java/com/playus/twpservice/domain/party/service/PartyReadOnlyServiceTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/service/PartyReadOnlyServiceTest.java
@@ -1,0 +1,115 @@
+package com.playus.twpservice.domain.party.service;
+
+import com.playus.twpservice.IntegrationTestSupport;
+import com.playus.twpservice.domain.party.document.PartyAgeDocument;
+import com.playus.twpservice.domain.party.document.PartyDocument;
+import com.playus.twpservice.domain.party.document.PartyJoinDocument;
+import com.playus.twpservice.domain.party.document.PartyThumbnailUrlDocument;
+import com.playus.twpservice.domain.party.dto.partybymatch.PartiesByMatchResponse;
+import com.playus.twpservice.domain.party.enums.PartyGender;
+import com.playus.twpservice.domain.party.enums.PartyJoinMethod;
+import com.playus.twpservice.domain.party.enums.PartyJoinRequestStatus;
+import com.playus.twpservice.domain.party.feign.response.PartyUserThumbnailUrlListResponse;
+import com.playus.twpservice.domain.party.feign.response.PartyWriterInfoFeignResponse;
+import com.playus.twpservice.domain.party.repository.read.PartyAgeReadOnlyRepository;
+import com.playus.twpservice.domain.party.repository.read.PartyJoinReadOnlyRepository;
+import com.playus.twpservice.domain.party.repository.read.PartyReadOnlyRepository;
+import com.playus.twpservice.domain.party.repository.read.PartyThumbnailUrlReadOnlyRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.BDDMockito.*;
+
+class PartyReadOnlyServiceTest extends IntegrationTestSupport {
+
+    @Autowired
+    PartyReadOnlyService partyReadOnlyService;
+
+    @Autowired
+    PartyReadOnlyRepository partyReadOnlyRepository;
+
+    @Autowired
+    PartyAgeReadOnlyRepository partyAgeReadOnlyRepository;
+
+    @Autowired
+    PartyThumbnailUrlReadOnlyRepository partyThumbnailUrlReadOnlyRepository;
+
+    @Autowired
+    PartyJoinReadOnlyRepository partyJoinReadOnlyRepository;
+
+
+    @AfterEach
+    void tearDown() {
+        partyReadOnlyRepository.deleteAll();
+        partyAgeReadOnlyRepository.deleteAll();
+        partyThumbnailUrlReadOnlyRepository.deleteAll();
+        partyJoinReadOnlyRepository.deleteAll();
+    }
+
+    @DisplayName("특정 경기에 대한 직관팟을 불러올 수 있다.")
+    @Test
+    void getPartiesBy() {
+        // given
+        Long matchId = 1L;
+
+        given(userFeignClient.getPartyUserThumbnailUrls(List.of())).willReturn(PartyUserThumbnailUrlListResponse.of(new ArrayList<>()));
+        given(userFeignClient.getPartyUserThumbnailUrls(List.of(4L, 5L))).willReturn(
+                PartyUserThumbnailUrlListResponse.of(new ArrayList<>(List.of("http://user1", "http://user2")))
+        );
+
+        given(userFeignClient.getWriterInfo(List.of(1L, 2L))).willReturn(List.of(
+                PartyWriterInfoFeignResponse.of(1L, "writer1", "남성", "http://writer1-thumbnail"),
+                PartyWriterInfoFeignResponse.of(2L, "writer2", "여성", "http://writer2-thumbnail")
+        ));
+
+        LocalDateTime matchDate = LocalDateTime.of(2025, 3, 22, 14, 0);
+        given(matchFeignClient.getMatchDate(matchId)).willReturn(matchDate);
+
+        PartyDocument p1 = PartyDocument.createForOnlyTest(1L, "title1", "text1", 1L, 10L,
+                "http://thumbnail", PartyGender.MALE, PartyJoinMethod.FIRST_COME, 1L, matchId, "chatRoomId");
+        PartyDocument p2 = PartyDocument.createForOnlyTest(2L, "title2", "text2", 1L, 10L,
+                "http://thumbnail", PartyGender.FEMALE, PartyJoinMethod.RESERVATION, 2L, matchId, "chatRoom2Id");
+        PartyDocument p3 = PartyDocument.createForOnlyTest(3L, "title3", "text3", 1L, 10L,
+                "http://thumbnail", PartyGender.NO_MATTER, PartyJoinMethod.RESERVATION, 3L, matchId + 1, "chatRoom3Id");
+
+        List<PartyDocument> partyDocuments = partyReadOnlyRepository.saveAll(List.of(p1, p2, p3));
+
+        PartyAgeDocument pa1 = PartyAgeDocument.createForOnlyTest(1L, partyDocuments.get(0), 10);
+        PartyAgeDocument pa2 = PartyAgeDocument.createForOnlyTest(2L, partyDocuments.get(1), 20);
+        partyAgeReadOnlyRepository.saveAll(List.of(pa1, pa2));
+
+        PartyThumbnailUrlDocument ptu1 = PartyThumbnailUrlDocument.createForOnlyTest(1L, partyDocuments.get(0), "thumbnailUrl1");
+        PartyThumbnailUrlDocument ptu2 = PartyThumbnailUrlDocument.createForOnlyTest(2L, partyDocuments.get(0), "thumbnailUrl2");
+        partyThumbnailUrlReadOnlyRepository.saveAll(List.of(ptu1, ptu2));
+
+        PartyJoinDocument pj1 = PartyJoinDocument.createForOnlyTest(1L, 4L, partyDocuments.get(0), PartyJoinRequestStatus.ACCEPT, null);
+        PartyJoinDocument pj2 = PartyJoinDocument.createForOnlyTest(2L, 5L, partyDocuments.get(0), PartyJoinRequestStatus.WAIT, "가입 원합니다!");
+        partyJoinReadOnlyRepository.saveAll(List.of(pj1, pj2));
+
+        // when
+        List<PartiesByMatchResponse> result = partyReadOnlyService.getPartiesBy(matchId);
+
+        // then
+        assertThat(result).hasSize(2)
+
+                .extracting("partyId", "title", "partyJoinMethod", "partyAges", "availableGender", "authorName", "authorGender",
+                        "matchDate", "currentParticipantsCount", "maximumParticipantsCount", "partyThumbnailUrls", "userThumbnailUrls")
+
+                .containsExactlyInAnyOrder(
+                        tuple(1L, "title1", PartyJoinMethod.FIRST_COME.getDescription(), List.of("10대"), PartyGender.MALE.getDescription(), "writer1", "남성",
+                                matchDate, 3L, 10L, List.of("thumbnailUrl1", "thumbnailUrl2"), List.of("http://writer1-thumbnail", "http://user1", "http://user2")),
+
+                        tuple(2L, "title2", PartyJoinMethod.RESERVATION.getDescription(), List.of("20대"), PartyGender.FEMALE.getDescription(), "writer2", "여성",
+                                matchDate, 1L, 10L, List.of(), List.of("http://writer2-thumbnail"))
+                );
+    }
+
+}

--- a/src/test/java/com/playus/twpservice/domain/party/service/PartyReadOnlyServiceTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/service/PartyReadOnlyServiceTest.java
@@ -112,4 +112,17 @@ class PartyReadOnlyServiceTest extends IntegrationTestSupport {
                 );
     }
 
+    @DisplayName("특정 경기에 대한 직관팟이 없을 수 있다.")
+    @Test
+    void getPartiesBy_EMPTY_PARTY() {
+
+        // given
+        Long matchId = 1L;
+
+        // when
+        List<PartiesByMatchResponse> result = partyReadOnlyService.getPartiesBy(matchId);
+
+        // then
+        assertThat(result).isEmpty();
+    }
 }

--- a/src/test/java/com/playus/twpservice/domain/party/service/PartyServiceTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/service/PartyServiceTest.java
@@ -20,12 +20,10 @@ import com.playus.twpservice.domain.party.repository.write.PartyAgeRepository;
 import com.playus.twpservice.domain.party.repository.write.PartyJoinRepository;
 import com.playus.twpservice.domain.party.repository.write.PartyRepository;
 import com.playus.twpservice.domain.party.repository.write.PartyThumbnailUrlRepository;
-import com.playus.twpservice.global.s3.S3PresignedUrlGenerator;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.util.List;
 
@@ -36,9 +34,6 @@ class PartyServiceTest extends IntegrationTestSupport {
 
     @Autowired
     private PartyService partyService;
-
-    @MockitoBean
-    private S3PresignedUrlGenerator s3PresignedUrlGenerator;
 
     @Autowired
     private PartyRepository partyRepository;

--- a/src/test/java/com/playus/twpservice/domain/party/service/PartyServiceTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/service/PartyServiceTest.java
@@ -11,11 +11,9 @@ import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImage
 import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageResponse;
 import com.playus.twpservice.domain.party.entity.Party;
 import com.playus.twpservice.domain.party.entity.PartyAge;
-import com.playus.twpservice.domain.party.entity.PartyJoin;
 import com.playus.twpservice.domain.party.entity.PartyThumbnailUrl;
 import com.playus.twpservice.domain.party.enums.PartyGender;
 import com.playus.twpservice.domain.party.enums.PartyJoinMethod;
-import com.playus.twpservice.domain.party.enums.PartyJoinRequestStatus;
 import com.playus.twpservice.domain.party.repository.write.PartyAgeRepository;
 import com.playus.twpservice.domain.party.repository.write.PartyJoinRepository;
 import com.playus.twpservice.domain.party.repository.write.PartyRepository;
@@ -77,7 +75,7 @@ class PartyServiceTest extends IntegrationTestSupport {
 
         // then
         assertThat(partyRepository.count()).isEqualTo(1);
-        assertThat(partyJoinRepository.count()).isEqualTo(1);
+        assertThat(partyJoinRepository.count()).isZero();
         assertThat(partyThumbnailUrlRepository.count()).isEqualTo(2);
         assertThat(chatRoomRepository.count()).isEqualTo(1);
         assertThat(chatPartRepository.count()).isEqualTo(1);
@@ -96,12 +94,8 @@ class PartyServiceTest extends IntegrationTestSupport {
         assertThat(savedParty.getMaximumParticipants()).isEqualTo(10L);
         assertThat(savedParty.getPartyGender()).isEqualTo(PartyGender.MALE);
         assertThat(savedParty.getPartyJoinMethod()).isEqualTo(PartyJoinMethod.FIRST_COME);
+        assertThat(savedParty.getWriterId()).isEqualTo(userId);
         assertThat(savedParty.getChatRoomId()).isEqualTo(savedChatRoom.getId());
-
-        PartyJoin savedPartyJoin = partyJoinRepository.findAll().get(0);
-        assertThat(savedPartyJoin.getUserId()).isEqualTo(userId);
-        assertThat(savedPartyJoin.getPartyJoinRequestStatus()).isEqualTo(PartyJoinRequestStatus.ACCEPT);
-        assertThat(savedPartyJoin.getRequireMessage()).isNull();
 
         List<PartyThumbnailUrl> savedUrl = partyThumbnailUrlRepository.findAll();
         assertThat(savedUrl).hasSize(2);
@@ -116,7 +110,6 @@ class PartyServiceTest extends IntegrationTestSupport {
                 .containsExactlyInAnyOrder(10, 20);
 
         Long savedPartyId = savedParty.getId();
-        assertThat(savedPartyJoin.getParty().getId()).isEqualTo(savedPartyId);
         assertThat(savedUrl).allMatch(url -> url.getParty().getId().equals(savedPartyId));
         assertThat(savedPartyAges).allMatch(age -> age.getParty().getId().equals(savedPartyId));
 
@@ -138,7 +131,7 @@ class PartyServiceTest extends IntegrationTestSupport {
 
         // then
         assertThat(partyRepository.count()).isEqualTo(1);
-        assertThat(partyJoinRepository.count()).isEqualTo(1);
+        assertThat(partyJoinRepository.count()).isZero();
         assertThat(partyAgeRepository.count()).isEqualTo(2);
         assertThat(partyThumbnailUrlRepository.count()).isZero();
     }
@@ -156,7 +149,7 @@ class PartyServiceTest extends IntegrationTestSupport {
 
         // then
         assertThat(partyRepository.count()).isEqualTo(1);
-        assertThat(partyJoinRepository.count()).isEqualTo(1);
+        assertThat(partyJoinRepository.count()).isZero();
         assertThat(partyAgeRepository.count()).isEqualTo(2);
         assertThat(partyThumbnailUrlRepository.count()).isZero();
     }

--- a/src/test/java/com/playus/twpservice/domain/party/service/PartyServiceTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/service/PartyServiceTest.java
@@ -15,7 +15,7 @@ import com.playus.twpservice.domain.party.entity.PartyJoin;
 import com.playus.twpservice.domain.party.entity.PartyThumbnailUrl;
 import com.playus.twpservice.domain.party.enums.PartyGender;
 import com.playus.twpservice.domain.party.enums.PartyJoinMethod;
-import com.playus.twpservice.domain.party.enums.Status;
+import com.playus.twpservice.domain.party.enums.PartyJoinRequestStatus;
 import com.playus.twpservice.domain.party.repository.write.PartyAgeRepository;
 import com.playus.twpservice.domain.party.repository.write.PartyJoinRepository;
 import com.playus.twpservice.domain.party.repository.write.PartyRepository;
@@ -105,7 +105,7 @@ class PartyServiceTest extends IntegrationTestSupport {
 
         PartyJoin savedPartyJoin = partyJoinRepository.findAll().get(0);
         assertThat(savedPartyJoin.getUserId()).isEqualTo(userId);
-        assertThat(savedPartyJoin.getStatus()).isEqualTo(Status.ACCEPT);
+        assertThat(savedPartyJoin.getPartyJoinRequestStatus()).isEqualTo(PartyJoinRequestStatus.ACCEPT);
         assertThat(savedPartyJoin.getRequireMessage()).isNull();
 
         List<PartyThumbnailUrl> savedUrl = partyThumbnailUrlRepository.findAll();


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
직관팟 조회 API 구현했습니다. 따로 Request body는 존재하지 않고, `/party?matchId={matchId}`  `(ex) /party?matchId=1)` 형식으로 보내면 다음과 같이 응답합니다.

```
[
  {
    "partyId": 1,
    "title": "title",
    "partyJoinMethod": "승인제",
    "partyAges": ["10대", "20대"],
    "availableGender": "남자만",
    "authorName": "ZSJ",
    "authorGender": "남성",
    "matchDate": "3.22(토) 오후 2:00",
    "currentParticipantsCount": 10,
    "maximumParticipantsCount": 14,
    "partyThumbnailUrls": [
      "http://party-thumbnail",
      "http://party-thumbnail2.com"
    ],
    "userThumbnailUrls": [
      "http://user-thumbnailUrl",
      "http://user2-thumbnailUrl"
    ]
  }
]
```

이 API에 사용되는 외부 MSA는 user-service, match-service가 있으며, 전원 `WireMockServer` 통해 테스트 완료했습니다.

|     Method Name     | HTTP Method |       Request Format         |   Response Type   |
|:-------------------:|:-----------:|:------------------------------:|:-----------------:|
|    getMatchDate     |     GET     | /match/api/date?matchId={matchId}  |  LocalDateTime    |



|     Method Name           | HTTP Method |         Path         |           Request Format            |           Response Type            |
|:-------------------------:|:-----------:|:--------------------:|:-----------------------------------:|:----------------------------------:|
| getPartyUserThumbnailUrls |     POST    | /user/api/thumbnails | userIdList : List&lt;Long&gt;         | PartyUserThumbnailUrlListResponse (thumbnailUrls : List&lt;String&gt;) |
| getWriterInfo             |     POST    | /user/api/writers    | writerIdList : List&lt;Long&gt;        | List&lt;PartyWriterInfoFeignResponse&gt;<br/>(id : Long, writerName : String, writerGender : String, writerThumbnailUrl : String) |



---

## 🔗 관련 이슈
- closes #24 

---

## 💡 추가 사항

테스트 시 MongoDB의 이미지 버전을 현재 온프레미스 환경의 이미지로 변경했습니다.


---

## ✏️ MongoDB에서의 Join

MongoDB에서 조인하는 방법은 크게 세 가지로 나뉩니다. 기존 제가 작성했던 `@DBRef`와 앱 조인, Aggregation Pipeline으로 나뉩니다. 각자의 방법에 대해 설명 드리겠습니다.

우선 `DBRef` 방법입니다. 우리가 MySQL에서 타 테이블과 관계를 맺을 때에는 외래 키를 이용해 Long 형태의 FK를 필드로 저장하는데, `@DBRef` 를 통해 관리할 경우 key 값 대신 다음처럼 컬렉션이 나옵니다. `_id` 는 Mongo에서 만들어준 값이지만, 우리가 주목해야 할 필드는 `address` 입니다. 우리가 평소에 보는 외래키를 저장하는 방식이 아닌, 전체 값이 들어가 있는 걸 보실 수 있습니다. 그리고 위처럼 DBRef로 관리할 경우 타 두 방식과 달리 성능 이슈도 존재하는데, 이는 마지막에 보여드리겠습니다.

```
{
    "_id": {"$oid": "64328083bf0cde597a587e43"},
    "_class": "com.practice.kotlinmongo.entity.Person",
    "address": "{ \"$ref\" : \"Address\", \"$id\" : \"64328083bf0cde597a587e44\" }",
    "age": 27,
    "name": "mizz",
    "sex": "MALE"
  }
```

두 번째로는 앱 조인 방법입니다. 앱 조인 방식은 `Repository` 에서 조인 관련 문을 작성하는 것이 아닌, `service` 단에서 조인하는 방식입니다.  아래 코드를 보시면 `appJoinUserRepository` 에서 `findUser`를 가져오고, `schoolRepository` 에서 `findUser` 의 pk를 이용해 `school` 을 가져온 걸 보실 수 있습니다.

```
val school = schoolRepository.save(
                    School(name = "물감초등학교", grade = SchoolGrade.ELEMENT)
                )
                val user = appJoinUserRepository.save(
                    AppJoinUser(nickname = "오징어", age = 12, schoolId = school.id)
                )

                val findUser = appJoinUserRepository.findByIdOrNull(user.id)
                val findSchool = schoolRepository.findByIdOrNull(findUser?.schoolId)
```

마지막으로는 제가 이번에 사용한 `Aggregation Pipeline` 방식입니다. `Aggregation Pipeline` 방식은 MySQL에서 평소 작성하는 쿼리문을 여러 오퍼레이션으로 쪼개서 원하는 값을 가져오는 방식입니다.  아래 method는 `Querydsl` 사용 시 종종 사용되는 custom repository를 통해 작성했습니다.
      
       - `match()` : 소위 MySQL의 `where` 문입니다. 매개변수 `matchId` 의 값을 가져와서 적용합니다.
       - `lookup()` : 소위 MySQL의 `join` 문입니다. 
       -                   차례대로 분석하면 "party_age" ("party_age" 에 대해 조인), "_id" ('party' 컬렉션의 '_id' 와) "party_id" ("party_join" 컬렉션의 "party_id" 에 대해 조인한 결과물을) "partyAge" ("partyAge"  라 명명합니다) 
       - (필드 이름은 class의 필드명이 아닌, collection의 필드명이여야 합니다!!!!)
       - `project()` : 소위 MySQL의 `p.title, p.id` 같은 느낌으로 보시면 될 거 같습니다. 우측의 `as()` 에는 앞서 작성한 `PartySummary` 의 field를 입력해줍시다.

       - `Aggregation.newAggregation(...)` : 앞서 작성한 Operation을 적용해 Aggregation pipeline 을 생성합니다!
       - AggregationResults<PartySummary> results = readMongoTemplate.aggregate(aggregation, "party", PartySummary.class);` : 
       -  `party` 컬렉션에 대해 앞서 생성한 Aggregation을 실행하며, 그 결과는 `PartySummary` 에 project 합니다.

```
@Override
    public List<PartySummary> findPartySummariesByMatchId(Long matchId) {

        MatchOperation matchOperation = match(new Criteria("match_id").is(matchId));

        // 이 때 Party의 '_id' 와 Party_Age의 "party_id" 는 같은 값이여야 합니다! (Mongo 쪽에서 'id'는 생성이 안 되더라고요...
        // CDC할 때 참고하시면 될 거 같습니다!)
        LookupOperation partyAgeLookupOperation = lookup("party_age", "_id", "party_id", "partyAge");
        LookupOperation partyJoinLookupOperation = lookup("party_join", "_id", "party_id", "partyJoin");
        LookupOperation partyThumbnailUrlLookupOperation = lookup("party_thumbnailurl", "_id", "party_id", "partyThumbnailUrl");

        ProjectionOperation projectionOperation = Aggregation.project()
                .and("_id").as("partyId")
                .and("title").as("title")
                .and("writer_id").as("writerId")
                .and("match_id").as("matchId")
                .and("partyJoin.user_id").as("userIdList")
                .and("partyJoinMethod").as("partyJoinMethod")
                .and("party_gender").as("partyGender")
                .and("maximum_participants").as("maximumParticipants")
                .and("partyAge.age").as("ages")
                .and("partyJoin").size().as("currentParticipantsCount")
                .and("partyThumbnailUrl.thumbnailUrl").as("thumbnailUrls");

        Aggregation aggregation = Aggregation.newAggregation(
                matchOperation,
                partyAgeLookupOperation,
                partyJoinLookupOperation,
                partyThumbnailUrlLookupOperation,
                projectionOperation
        );

        AggregationResults<PartySummary> results = readMongoTemplate.aggregate(aggregation, "party", PartySummary.class);

       
        return results.getMappedResults();
    }
```

아래 사진은 성능 측정 결과로, 출처는 아래쪽에 명시하겠습니다!
![image](https://github.com/user-attachments/assets/0227f6bb-9d13-4546-b9d3-9ca58fbb7c0b)

저의 경우에 이번 직관팟 조회에서 Aggregation Pipeline을 사용한 이유는 조인해야 할 컬렉션이 많아서 앱 조인으로 할 경우 코드가 많이 지저분해질 거 같아 결정했습니다! 조인해야 할 컬렉션의 수가 적을 경우에는 앱 조인을 적용할 생각도 하고 잇습니다!

기존 `@DBRef` 를 적용했던 field는 아래처럼 `@DocumentReference` 를 적용해 id 값만 가져오도록 했습니다

```
    @NotNull
    @Indexed
    @DocumentReference(lazy = true)
    @Field(name = "party_id")
    private PartyDocument party;
```


https://velog.io/@devmizz/SpringMongo-%EC%A1%B0%EC%9D%B8%EC%9D%80-%EC%96%B4%EB%96%BB%EA%B2%8C-%EC%B2%98%EB%A6%AC%ED%95%A0%EA%B9%8C#mongotemplate-pipeline-%EA%B5%AC%EC%84%B1 

aggregation 관련해서 참고하면 좋을 거 같아서 가져왓습니다!
https://yearnlune.github.io/java/java-mongodb-aggregation-operation-01/#matchoperation
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **신규 기능**
  - 경기 ID로 파티 목록을 조회하는 API가 추가되었습니다.
  - 파티 요약 정보, 작성자 정보, 썸네일 이미지, 참가자 정보 등을 포함한 상세 파티 목록 응답이 제공됩니다.
  - 외부 서비스와의 통신을 위한 OpenFeign 기반 클라이언트 및 장애 대응을 위한 회로 차단기(fallback) 기능이 도입되었습니다.
  - 파티 생성 시 작성자 정보(writerId)가 포함되어 관리됩니다.

- **버그 수정**
  - 예외 처리 핸들러가 일관된 네이밍으로 정리되고, 회로 차단기 예외에 대한 처리가 추가되었습니다.

- **문서화**
  - 신규 파티 조회 API에 대한 Swagger 문서 및 예시 응답이 추가되었습니다.

- **테스트**
  - 파티 조회, 외부 API 연동, 레포지토리 집계, 서비스 통합 등 다양한 테스트가 추가되어 안정성이 향상되었습니다.

- **환경설정**
  - MongoDB 인덱스 자동 생성 및 회로 차단기 관련 설정이 환경별로 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->