### PR TITLE
CS-263 feat/직관팟 수정

### DIFF
--- a/src/main/java/com/playus/twpservice/domain/common/MinimumMaximumValidatable.java
+++ b/src/main/java/com/playus/twpservice/domain/common/MinimumMaximumValidatable.java
@@ -1,0 +1,6 @@
+package com.playus.twpservice.domain.common;
+
+public interface MinimumMaximumValidatable {
+    Long minimumParticipants();
+    Long maximumParticipants();
+}

--- a/src/main/java/com/playus/twpservice/domain/party/assertion/PartyAssert.java
+++ b/src/main/java/com/playus/twpservice/domain/party/assertion/PartyAssert.java
@@ -1,0 +1,16 @@
+package com.playus.twpservice.domain.party.assertion;
+
+import org.springframework.util.Assert;
+
+import java.util.Objects;
+
+import static com.playus.twpservice.domain.party.exception.entity.PartyException.*;
+
+public class PartyAssert extends Assert {
+
+    public static void isLoginUserWriter(Long userId, Long writerId) {
+        if (!Objects.equals(userId, writerId)) {
+            throw new NotPartyWriterException("직관팟 작성자가 아니면 수정할 수 없습니다!");
+        }
+    }
+}

--- a/src/main/java/com/playus/twpservice/domain/party/controller/PartyController.java
+++ b/src/main/java/com/playus/twpservice/domain/party/controller/PartyController.java
@@ -6,6 +6,9 @@ import com.playus.twpservice.domain.party.dto.partyinfobymatch.PartyInfoListByMa
 import com.playus.twpservice.domain.party.dto.partyinfobymatch.PartyInfoResponse;
 import com.playus.twpservice.domain.party.dto.partycreate.PartyCreateRequest;
 import com.playus.twpservice.domain.party.dto.partycreate.PartyCreateResponse;
+import com.playus.twpservice.domain.party.dto.partyupdate.PartyIdRequest;
+import com.playus.twpservice.domain.party.dto.partyupdate.PartyUpdateRequest;
+import com.playus.twpservice.domain.party.dto.partyupdate.PartyUpdateResponse;
 import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageRequest;
 import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageResponse;
 import com.playus.twpservice.domain.party.service.PartyReadOnlyService;
@@ -34,11 +37,6 @@ public class PartyController implements PartyControllerSpecification {
         return ResponseEntity.status(HttpStatus.CREATED).body(partyService.createParty(userId, request));
     }
 
-    @PostMapping("/presigned-url")
-    public PresignedUrlForSaveImageResponse generatePresignedUrlForSaveImage(@Valid @RequestBody PresignedUrlForSaveImageRequest request) {
-        return partyService.generatePresignedUrlForSaveImage(request);
-    }
-
     @GetMapping
     public List<PartyInfoResponse> getPartiesByMatchId(@Valid PartyInfoListByMatchRequest request) {
         return partyReadOnlyService.getPartyInfoListByMatchId(request.matchId());
@@ -47,5 +45,16 @@ public class PartyController implements PartyControllerSpecification {
     @GetMapping("/{partyId}")
     public PartyDetailResponse getPartyDetail(@Valid PartyDetailRequest request) {
         return partyReadOnlyService.getPartyDetail(request.partyId());
+    }
+
+    @PutMapping("/{partyId}")
+    public PartyUpdateResponse updateParty(@AuthenticationPrincipal Long userId, @Valid PartyIdRequest idRequest,
+                                           @Valid @RequestBody PartyUpdateRequest request) {
+        return partyService.updateParty(userId, request.toParty(idRequest.partyId()));
+    }
+
+    @PostMapping("/presigned-url")
+    public PresignedUrlForSaveImageResponse generatePresignedUrlForSaveImage(@Valid @RequestBody PresignedUrlForSaveImageRequest request) {
+        return partyService.generatePresignedUrlForSaveImage(request);
     }
 }

--- a/src/main/java/com/playus/twpservice/domain/party/controller/PartyController.java
+++ b/src/main/java/com/playus/twpservice/domain/party/controller/PartyController.java
@@ -50,7 +50,7 @@ public class PartyController implements PartyControllerSpecification {
     @PutMapping("/{partyId}")
     public PartyUpdateResponse updateParty(@AuthenticationPrincipal Long userId, @Valid PartyIdRequest idRequest,
                                            @Valid @RequestBody PartyUpdateRequest request) {
-        return partyService.updateParty(userId, request.toParty(idRequest.partyId()));
+        return partyService.updateParty(userId, idRequest, request);
     }
 
     @PostMapping("/presigned-url")

--- a/src/main/java/com/playus/twpservice/domain/party/dto/partycreate/PartyCreateRequest.java
+++ b/src/main/java/com/playus/twpservice/domain/party/dto/partycreate/PartyCreateRequest.java
@@ -1,5 +1,6 @@
 package com.playus.twpservice.domain.party.dto.partycreate;
 
+import com.playus.twpservice.domain.common.MinimumMaximumValidatable;
 import com.playus.twpservice.global.validation.ValidEnum;
 import com.playus.twpservice.global.validation.ValidEnumList;
 import com.playus.twpservice.domain.party.entity.Party;
@@ -15,7 +16,7 @@ import java.util.List;
 
 @Builder
 @ValidMinimumMaximumParticipants(message = "최소 참여 인원은 최대 참여 인원보다 클 수 없습니다!")
-public record PartyCreateRequest(
+public record PartyCreateRequest (
 
         @NotBlank(message = "직관팟 제목이 비어 있습니다!")
         @Size(max = 225, message = "제목의 길이를 1~225자 이내로 작성해 주세요!")
@@ -54,7 +55,7 @@ public record PartyCreateRequest(
         @Size(max = 100, message = "직관팟 소개 문구의 길이를 1~100자 이내로 작성해 주세요!")
         String message
 
-) {
+) implements MinimumMaximumValidatable {
 
     public static PartyCreateRequest of(String title, String method, String gender, List<String> ageGroup,
                                         Long minimumParticipants, Long maximumParticipants,

--- a/src/main/java/com/playus/twpservice/domain/party/dto/partydescription/PartyDetailResponse.java
+++ b/src/main/java/com/playus/twpservice/domain/party/dto/partydescription/PartyDetailResponse.java
@@ -12,6 +12,7 @@ import java.util.List;
 @Builder
 public record PartyDetailResponse(
         Long partyId,
+        Long writerId,
         String title,
         String partyJoinMethod,
         String text,
@@ -32,6 +33,7 @@ public record PartyDetailResponse(
 
         public static PartyDetailResponse of(
                 Long partyId,
+                Long writerId,
                 String title,
                 PartyJoinMethod partyJoinMethod,
                 String text,
@@ -47,6 +49,7 @@ public record PartyDetailResponse(
         ) {
                 return PartyDetailResponse.builder()
                         .partyId(partyId)
+                        .writerId(writerId)
                         .title(title)
                         .partyJoinMethod(partyJoinMethod.getDescription())
                         .text(text)

--- a/src/main/java/com/playus/twpservice/domain/party/dto/partyinfobymatch/PartyInfoResponse.java
+++ b/src/main/java/com/playus/twpservice/domain/party/dto/partyinfobymatch/PartyInfoResponse.java
@@ -12,6 +12,7 @@ import java.util.List;
 @Builder
 public record PartyInfoResponse(
         Long partyId,
+        Long writerId,
         String title,
         String partyJoinMethod,
         List<String> partyAges,
@@ -31,6 +32,7 @@ public record PartyInfoResponse(
 
     public static PartyInfoResponse of(
             Long partyId,
+            Long writerId,
             String title,
             PartyJoinMethod partyJoinMethod,
             List<PartyAgeGroup> partyAges,
@@ -45,6 +47,7 @@ public record PartyInfoResponse(
     ) {
         return PartyInfoResponse.builder()
                 .partyId(partyId)
+                .writerId(writerId)
                 .title(title)
                 .partyJoinMethod(partyJoinMethod.getDescription())
                 .partyAges(partyAges.stream().map(PartyAgeGroup::getDescription).toList())

--- a/src/main/java/com/playus/twpservice/domain/party/dto/partyupdate/PartyIdRequest.java
+++ b/src/main/java/com/playus/twpservice/domain/party/dto/partyupdate/PartyIdRequest.java
@@ -1,0 +1,12 @@
+package com.playus.twpservice.domain.party.dto.partyupdate;
+
+import jakarta.validation.constraints.Min;
+
+public record PartyIdRequest(
+        @Min(value = 1, message = "직관팟 ID는 1 이상이어야 합니다!")
+        Long partyId
+) {
+    public static PartyIdRequest of(Long partyId) {
+        return new PartyIdRequest(partyId);
+    }
+}

--- a/src/main/java/com/playus/twpservice/domain/party/dto/partyupdate/PartyUpdateRequest.java
+++ b/src/main/java/com/playus/twpservice/domain/party/dto/partyupdate/PartyUpdateRequest.java
@@ -71,9 +71,4 @@ public record PartyUpdateRequest  (
                 .message(message)
                 .build();
     }
-
-    public Party toParty(Long partyId) {
-        return Party.createForUpdateParty(partyId, writerId, title, message, minimumParticipants,
-                maximumParticipants, PartyGender.toEnumValue(partyGender), PartyJoinMethod.toEnumValue(partyJoinMethod));
-    }
 }

--- a/src/main/java/com/playus/twpservice/domain/party/dto/partyupdate/PartyUpdateRequest.java
+++ b/src/main/java/com/playus/twpservice/domain/party/dto/partyupdate/PartyUpdateRequest.java
@@ -21,6 +21,9 @@ public record PartyUpdateRequest  (
         @Size(max = 225, message = "제목의 길이를 1~225자 이내로 작성해 주세요!")
         String title,
 
+        @Min(value = 1, message = "작성자 ID는 1 이상이어야 합니다!")
+        Long writerId,
+
         @ValidEnum(enumClass = PartyJoinMethod.class, emptyValueMessage = "신청 방식이 비어 있습니다!", invalidValueMessage = "잘못된 신청 방식입니다!")
         String partyJoinMethod,
 
@@ -52,12 +55,13 @@ public record PartyUpdateRequest  (
 
 ) implements MinimumMaximumValidatable {
 
-    public static PartyUpdateRequest of(String title, String method, String gender, List<String> ageGroup,
+    public static PartyUpdateRequest of(String title, Long writerId, String method, String gender, List<String> ageGroup,
                                         Long minimumParticipants, Long maximumParticipants,
                                         List<String> thumbnailUrl, String message) {
 
         return PartyUpdateRequest.builder()
                 .title(title)
+                .writerId(writerId)
                 .partyJoinMethod(method)
                 .partyGender(gender)
                 .ageGroup(ageGroup)
@@ -69,8 +73,7 @@ public record PartyUpdateRequest  (
     }
 
     public Party toParty(Long partyId) {
-        return Party.createForUpdateParty(partyId, title, message, minimumParticipants,
+        return Party.createForUpdateParty(partyId, writerId, title, message, minimumParticipants,
                 maximumParticipants, PartyGender.toEnumValue(partyGender), PartyJoinMethod.toEnumValue(partyJoinMethod));
     }
-
 }

--- a/src/main/java/com/playus/twpservice/domain/party/dto/partyupdate/PartyUpdateRequest.java
+++ b/src/main/java/com/playus/twpservice/domain/party/dto/partyupdate/PartyUpdateRequest.java
@@ -1,0 +1,76 @@
+package com.playus.twpservice.domain.party.dto.partyupdate;
+
+import com.playus.twpservice.domain.common.MinimumMaximumValidatable;
+import com.playus.twpservice.domain.party.entity.Party;
+import com.playus.twpservice.domain.party.enums.PartyAgeGroup;
+import com.playus.twpservice.domain.party.enums.PartyGender;
+import com.playus.twpservice.domain.party.enums.PartyJoinMethod;
+import com.playus.twpservice.domain.party.validation.ValidMinimumMaximumParticipants;
+import com.playus.twpservice.global.validation.ValidEnum;
+import com.playus.twpservice.global.validation.ValidEnumList;
+import jakarta.validation.constraints.*;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+@ValidMinimumMaximumParticipants(message = "최소 참여 인원은 최대 참여 인원보다 클 수 없습니다!")
+public record PartyUpdateRequest  (
+
+        @NotBlank(message = "직관팟 제목이 비어 있습니다!")
+        @Size(max = 225, message = "제목의 길이를 1~225자 이내로 작성해 주세요!")
+        String title,
+
+        @ValidEnum(enumClass = PartyJoinMethod.class, emptyValueMessage = "신청 방식이 비어 있습니다!", invalidValueMessage = "잘못된 신청 방식입니다!")
+        String partyJoinMethod,
+
+        @ValidEnum(enumClass = PartyGender.class, emptyValueMessage = "참여 원하는 성별이 비어 있습니다!", invalidValueMessage = "잘못된 성별 형식입니다!")
+        String partyGender,
+
+        @ValidEnumList(enumClass = PartyAgeGroup.class, emptyValueMessage = "참여자 나이가 비어 있습니다!",
+                invalidValueMessage = "잘못된 참여자 나이입니다!", overValueMessage = "참여자 나이는 최대 6개까지 가능합니다!")
+        List<String> ageGroup,
+
+        @NotNull(message = "최소 참여 인원이 비어 있습니다!")
+        @Min(value = 1, message = "최소 참여 인원은 1명 이상이여야 합니다!")
+        Long minimumParticipants,
+
+        @NotNull(message = "최대 참여 인원이 비어 있습니다!")
+        @Min(value = 1, message = "최대 참여 인원은 1명 이상이여야 합니다!")
+        Long maximumParticipants,
+
+        @Size(max = 10, message = "썸네일은 최대 10개까지만 가능합니다!")
+        List<
+                @NotBlank(message = "사진 URL이 비어 있습니다!")
+                @Pattern(regexp = "^(https?|ftp)://.*$", message = "올바른 URL 형식이 아닙니다!")
+                        String>
+                thumbnailUrl,
+
+        @NotBlank(message = "직관팟 소개 문구가 비어 있습니다!")
+        @Size(max = 100, message = "직관팟 소개 문구의 길이를 1~100자 이내로 작성해 주세요!")
+        String message
+
+) implements MinimumMaximumValidatable {
+
+    public static PartyUpdateRequest of(String title, String method, String gender, List<String> ageGroup,
+                                        Long minimumParticipants, Long maximumParticipants,
+                                        List<String> thumbnailUrl, String message) {
+
+        return PartyUpdateRequest.builder()
+                .title(title)
+                .partyJoinMethod(method)
+                .partyGender(gender)
+                .ageGroup(ageGroup)
+                .minimumParticipants(minimumParticipants)
+                .maximumParticipants(maximumParticipants)
+                .thumbnailUrl(thumbnailUrl)
+                .message(message)
+                .build();
+    }
+
+    public Party toParty(Long partyId) {
+        return Party.createForUpdateParty(partyId, title, message, minimumParticipants,
+                maximumParticipants, PartyGender.toEnumValue(partyGender), PartyJoinMethod.toEnumValue(partyJoinMethod));
+    }
+
+}

--- a/src/main/java/com/playus/twpservice/domain/party/dto/partyupdate/PartyUpdateResponse.java
+++ b/src/main/java/com/playus/twpservice/domain/party/dto/partyupdate/PartyUpdateResponse.java
@@ -1,0 +1,14 @@
+package com.playus.twpservice.domain.party.dto.partyupdate;
+
+import lombok.Builder;
+
+@Builder
+public record PartyUpdateResponse(
+        Long partyId
+) {
+    public static PartyUpdateResponse of(Long partyId) {
+        return PartyUpdateResponse.builder()
+                .partyId(partyId)
+                .build();
+    }
+}

--- a/src/main/java/com/playus/twpservice/domain/party/entity/Party.java
+++ b/src/main/java/com/playus/twpservice/domain/party/entity/Party.java
@@ -49,7 +49,8 @@ public class Party extends BaseTimeEntity {
     private String text;
 
     @Builder
-    private Party(String title, String text, Long minimumParticipants, Long maximumParticipants, PartyGender partyGender, PartyJoinMethod partyJoinMethod, Long writerId, Long matchId){
+    private Party(Long id, String title, String text, Long minimumParticipants, Long maximumParticipants, PartyGender partyGender, PartyJoinMethod partyJoinMethod, Long writerId, Long matchId){
+        this.id = id;
         this.title = title;
         this.text = text;
         this.minimumParticipants = minimumParticipants;
@@ -58,6 +59,11 @@ public class Party extends BaseTimeEntity {
         this.partyJoinMethod = partyJoinMethod;
         this.writerId = writerId;
         this.matchId = matchId;
+    }
+
+    public Party assignChatRoom(String chatRoomId) {
+        this.chatRoomId = chatRoomId;
+        return this;
     }
 
     public static Party create(String title, String text, Long minimumParticipants, Long maximumParticipants,
@@ -74,8 +80,16 @@ public class Party extends BaseTimeEntity {
                 .build();
     }
 
-    public Party assignChatRoom(String chatRoomId) {
-        this.chatRoomId = chatRoomId;
-        return this;
+    public static Party createForUpdateParty(Long id, String title, String text, Long minimumParticipants, Long maximumParticipants,
+                                             PartyGender partyGender, PartyJoinMethod partyJoinMethod){
+        return Party.builder()
+                .id(id)
+                .title(title)
+                .text(text)
+                .minimumParticipants(minimumParticipants)
+                .maximumParticipants(maximumParticipants)
+                .partyGender(partyGender)
+                .partyJoinMethod(partyJoinMethod)
+                .build();
     }
 }

--- a/src/main/java/com/playus/twpservice/domain/party/entity/Party.java
+++ b/src/main/java/com/playus/twpservice/domain/party/entity/Party.java
@@ -1,6 +1,7 @@
 package com.playus.twpservice.domain.party.entity;
 
 import com.playus.twpservice.domain.common.BaseTimeEntity;
+import com.playus.twpservice.domain.party.dto.partyupdate.PartyUpdateRequest;
 import com.playus.twpservice.domain.party.enums.PartyJoinMethod;
 import com.playus.twpservice.domain.party.enums.PartyGender;
 import jakarta.persistence.*;
@@ -61,6 +62,16 @@ public class Party extends BaseTimeEntity {
         this.matchId = matchId;
     }
 
+    // setter
+    public void updateParty(PartyUpdateRequest updateRequest) {
+        this.title = updateRequest.title();
+        this.text = updateRequest.message();
+        this.minimumParticipants = updateRequest.minimumParticipants();
+        this.maximumParticipants = updateRequest.maximumParticipants();
+        this.partyGender = PartyGender.toEnumValue(updateRequest.partyGender());
+        this.partyJoinMethod = PartyJoinMethod.toEnumValue(updateRequest.partyJoinMethod());
+    }
+
     public Party assignChatRoom(String chatRoomId) {
         this.chatRoomId = chatRoomId;
         return this;
@@ -77,20 +88,6 @@ public class Party extends BaseTimeEntity {
                 .partyJoinMethod(partyJoinMethod)
                 .writerId(writerId)
                 .matchId(matchId)
-                .build();
-    }
-
-    public static Party createForUpdateParty(Long id, Long writerId, String title, String text, Long minimumParticipants, Long maximumParticipants,
-                                             PartyGender partyGender, PartyJoinMethod partyJoinMethod){
-        return Party.builder()
-                .id(id)
-                .writerId(writerId)
-                .title(title)
-                .text(text)
-                .minimumParticipants(minimumParticipants)
-                .maximumParticipants(maximumParticipants)
-                .partyGender(partyGender)
-                .partyJoinMethod(partyJoinMethod)
                 .build();
     }
 }

--- a/src/main/java/com/playus/twpservice/domain/party/entity/Party.java
+++ b/src/main/java/com/playus/twpservice/domain/party/entity/Party.java
@@ -80,10 +80,11 @@ public class Party extends BaseTimeEntity {
                 .build();
     }
 
-    public static Party createForUpdateParty(Long id, String title, String text, Long minimumParticipants, Long maximumParticipants,
+    public static Party createForUpdateParty(Long id, Long writerId, String title, String text, Long minimumParticipants, Long maximumParticipants,
                                              PartyGender partyGender, PartyJoinMethod partyJoinMethod){
         return Party.builder()
                 .id(id)
+                .writerId(writerId)
                 .title(title)
                 .text(text)
                 .minimumParticipants(minimumParticipants)

--- a/src/main/java/com/playus/twpservice/domain/party/exception/entity/PartyException.java
+++ b/src/main/java/com/playus/twpservice/domain/party/exception/entity/PartyException.java
@@ -1,0 +1,22 @@
+package com.playus.twpservice.domain.party.exception.entity;
+
+public abstract class PartyException {
+
+    public static class NotPartyWriterException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+
+        public NotPartyWriterException(String message) {
+            super(message);
+        }
+    }
+
+    public static class NotFoundException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+
+        public NotFoundException(String message) {
+            super(message);
+        }
+    }
+
+
+}

--- a/src/main/java/com/playus/twpservice/domain/party/repository/write/PartyAgeRepository.java
+++ b/src/main/java/com/playus/twpservice/domain/party/repository/write/PartyAgeRepository.java
@@ -4,4 +4,5 @@ import com.playus.twpservice.domain.party.entity.PartyAge;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PartyAgeRepository extends JpaRepository<PartyAge, Long> {
+    void deleteByPartyId(Long partyId);
 }

--- a/src/main/java/com/playus/twpservice/domain/party/repository/write/PartyThumbnailUrlRepository.java
+++ b/src/main/java/com/playus/twpservice/domain/party/repository/write/PartyThumbnailUrlRepository.java
@@ -4,5 +4,5 @@ import com.playus.twpservice.domain.party.entity.PartyThumbnailUrl;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PartyThumbnailUrlRepository extends JpaRepository<PartyThumbnailUrl, Long> {
-
+    void deleteByPartyId(Long partyId);
 }

--- a/src/main/java/com/playus/twpservice/domain/party/service/PartyService.java
+++ b/src/main/java/com/playus/twpservice/domain/party/service/PartyService.java
@@ -4,8 +4,11 @@ import com.playus.twpservice.domain.chat.entity.ChatPart;
 import com.playus.twpservice.domain.chat.entity.ChatRoom;
 import com.playus.twpservice.domain.chat.repository.ChatPartRepository;
 import com.playus.twpservice.domain.chat.repository.ChatRoomRepository;
+import com.playus.twpservice.domain.party.assertion.PartyAssert;
 import com.playus.twpservice.domain.party.dto.partycreate.PartyCreateRequest;
 import com.playus.twpservice.domain.party.dto.partycreate.PartyCreateResponse;
+import com.playus.twpservice.domain.party.dto.partyupdate.PartyIdRequest;
+import com.playus.twpservice.domain.party.dto.partyupdate.PartyUpdateRequest;
 import com.playus.twpservice.domain.party.dto.partyupdate.PartyUpdateResponse;
 import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageRequest;
 import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageResponse;
@@ -14,7 +17,6 @@ import com.playus.twpservice.domain.party.entity.PartyAge;
 import com.playus.twpservice.domain.party.entity.PartyThumbnailUrl;
 import com.playus.twpservice.domain.party.enums.PartyAgeGroup;
 import com.playus.twpservice.domain.party.repository.write.PartyAgeRepository;
-import com.playus.twpservice.domain.party.repository.write.PartyJoinRepository;
 import com.playus.twpservice.domain.party.repository.write.PartyRepository;
 import com.playus.twpservice.domain.party.repository.write.PartyThumbnailUrlRepository;
 import com.playus.twpservice.global.s3.S3PresignedUrlGenerator;
@@ -25,13 +27,14 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Objects;
 
+import static com.playus.twpservice.domain.party.exception.entity.PartyException.*;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class PartyService {
 
     private final PartyRepository partyRepository;
-    private final PartyJoinRepository partyJoinRepository;
     private final PartyAgeRepository partyAgeRepository;
     private final PartyThumbnailUrlRepository partyThumbnailUrlRepository;
 
@@ -53,14 +56,44 @@ public class PartyService {
         return PartyCreateResponse.of(party.getId(), chatRoom.getId());
     }
 
-    public PartyUpdateResponse updateParty(Long userId, Party savedParty) {
-        return null;
+    public PartyUpdateResponse updateParty(Long userId, PartyIdRequest idRequest, PartyUpdateRequest updateRequest) {
+        Long partyId = idRequest.partyId();
+        Long writerId = updateRequest.writerId();
+
+        PartyAssert.isLoginUserWriter(userId, writerId);
+
+        Party savedParty = partyRepository.findById(partyId)
+                .orElseThrow(() -> new NotFoundException("잘못된 직관팟 번호입니다!"));
+
+        savedParty.updateParty(updateRequest);
+
+        updatePartyThumbnails(updateRequest, partyId, savedParty);
+        updatePartyAgeGroup(updateRequest, partyId, savedParty);
+
+        return PartyUpdateResponse.of(partyId);
     }
 
     public PresignedUrlForSaveImageResponse generatePresignedUrlForSaveImage(PresignedUrlForSaveImageRequest request) {
         return new PresignedUrlForSaveImageResponse(s3PresignedUrlGenerator.generatePresignedUrl(request.imageFileName()));
     }
 
+    private void updatePartyAgeGroup(PartyUpdateRequest updateRequest, Long partyId, Party savedParty) {
+        partyAgeRepository.deleteByPartyId(partyId);
+        partyAgeRepository.saveAll(
+                updateRequest.ageGroup().stream()
+                        .map(age -> PartyAge.create(savedParty, PartyAgeGroup.getAgeByDescription(age)))
+                        .toList()
+        );
+    }
+
+    private void updatePartyThumbnails(PartyUpdateRequest updateRequest, Long partyId, Party savedParty) {
+        partyThumbnailUrlRepository.deleteByPartyId(partyId);
+        partyThumbnailUrlRepository.saveAll(
+                updateRequest.thumbnailUrl().stream()
+                        .map(thumbnailUrl -> PartyThumbnailUrl.create(savedParty, thumbnailUrl))
+                        .toList()
+        );
+    }
 
     private ChatRoom initializeChatRoomAsWriter(Long userId, PartyCreateRequest request) {
         ChatRoom chatRoom = chatRoomRepository.save(ChatRoom.create(request.title()));
@@ -90,6 +123,4 @@ public class PartyService {
                 .map(age -> PartyAge.create(party, PartyAgeGroup.getAgeByDescription(age)))
                 .toList();
     }
-
-
 }

--- a/src/main/java/com/playus/twpservice/domain/party/service/PartyService.java
+++ b/src/main/java/com/playus/twpservice/domain/party/service/PartyService.java
@@ -6,6 +6,7 @@ import com.playus.twpservice.domain.chat.repository.ChatPartRepository;
 import com.playus.twpservice.domain.chat.repository.ChatRoomRepository;
 import com.playus.twpservice.domain.party.dto.partycreate.PartyCreateRequest;
 import com.playus.twpservice.domain.party.dto.partycreate.PartyCreateResponse;
+import com.playus.twpservice.domain.party.dto.partyupdate.PartyUpdateResponse;
 import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageRequest;
 import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageResponse;
 import com.playus.twpservice.domain.party.entity.Party;
@@ -52,9 +53,14 @@ public class PartyService {
         return PartyCreateResponse.of(party.getId(), chatRoom.getId());
     }
 
+    public PartyUpdateResponse updateParty(Long userId, Party savedParty) {
+        return null;
+    }
+
     public PresignedUrlForSaveImageResponse generatePresignedUrlForSaveImage(PresignedUrlForSaveImageRequest request) {
         return new PresignedUrlForSaveImageResponse(s3PresignedUrlGenerator.generatePresignedUrl(request.imageFileName()));
     }
+
 
     private ChatRoom initializeChatRoomAsWriter(Long userId, PartyCreateRequest request) {
         ChatRoom chatRoom = chatRoomRepository.save(ChatRoom.create(request.title()));
@@ -84,4 +90,6 @@ public class PartyService {
                 .map(age -> PartyAge.create(party, PartyAgeGroup.getAgeByDescription(age)))
                 .toList();
     }
+
+
 }

--- a/src/main/java/com/playus/twpservice/domain/party/specification/PartyControllerSpecification.java
+++ b/src/main/java/com/playus/twpservice/domain/party/specification/PartyControllerSpecification.java
@@ -6,6 +6,9 @@ import com.playus.twpservice.domain.party.dto.partydescription.PartyDetailReques
 import com.playus.twpservice.domain.party.dto.partydescription.PartyDetailResponse;
 import com.playus.twpservice.domain.party.dto.partyinfobymatch.PartyInfoListByMatchRequest;
 import com.playus.twpservice.domain.party.dto.partyinfobymatch.PartyInfoResponse;
+import com.playus.twpservice.domain.party.dto.partyupdate.PartyIdRequest;
+import com.playus.twpservice.domain.party.dto.partyupdate.PartyUpdateRequest;
+import com.playus.twpservice.domain.party.dto.partyupdate.PartyUpdateResponse;
 import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageRequest;
 import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -46,7 +49,7 @@ public interface PartyControllerSpecification {
                                               "ageGroup": ["10대", "20대"],
                                               "minimumParticipants": 3,
                                               "maximumParticipants": 5,
-                                              "thumbnailUrl": "https://image.example.com/party.jpg",
+                                              "thumbnailUrl": ["https://image.example.com/party.jpg"],
                                               "matchId" : "1",
                                               "message": "재밌게 응원할 분 구해요!"
                                             }
@@ -232,4 +235,60 @@ public interface PartyControllerSpecification {
             )
     })
     PartyDetailResponse getPartyDetail(@Valid PartyDetailRequest request);
+
+
+    @Tag(name = "Put", description = "직관팟 수정 API")
+    @Operation(
+            summary = "직관팟 수정",
+            description = "직관팟 작성자인 로그인한 유저가 직관팟을 수정합니다.",
+            parameters = {
+                    @Parameter(
+                            name = "partyId",
+                            in = ParameterIn.PATH,
+                            description = "직관팟 ID",
+                            required = true,
+                            example = "1"
+                    )
+            },
+            requestBody = @RequestBody(
+                    required = true,
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    name = "직관팟 수정 요청 예시",
+                                    value = """
+                                            {
+                                              "title": "롯데 vs LG 직관 같이 가요!",
+                                              "writerId" : 1L,
+                                              "partyJoinMethod": "선착순",
+                                              "partyGender": "남자만",
+                                              "ageGroup": ["10대", "20대"],
+                                              "minimumParticipants": 3,
+                                              "maximumParticipants": 5,
+                                              "thumbnailUrl": ["https://image.example.com/party.jpg"],
+                                              "message": "재밌게 응원할 분 구해요!"
+                                            }
+                                            """
+                            )
+                    )
+            )
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "수정 성공",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    name = "직관팟 수정 응답 예시",
+                                    value = """
+                                            {
+                                              "partyId": 1,
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    PartyUpdateResponse updateParty(Long userId, @Valid PartyIdRequest idRequest,
+                                           @Valid @RequestBody PartyUpdateRequest request);
 }

--- a/src/main/java/com/playus/twpservice/domain/party/specification/PartyControllerSpecification.java
+++ b/src/main/java/com/playus/twpservice/domain/party/specification/PartyControllerSpecification.java
@@ -259,7 +259,7 @@ public interface PartyControllerSpecification {
                                     value = """
                                             {
                                               "title": "롯데 vs LG 직관 같이 가요!",
-                                              "writerId" : 1L,
+                                              "writerId" : 1,
                                               "partyJoinMethod": "선착순",
                                               "partyGender": "남자만",
                                               "ageGroup": ["10대", "20대"],
@@ -282,7 +282,7 @@ public interface PartyControllerSpecification {
                                     name = "직관팟 수정 응답 예시",
                                     value = """
                                             {
-                                              "partyId": 1,
+                                              "partyId": 1
                                             }
                                             """
                             )

--- a/src/main/java/com/playus/twpservice/domain/party/validation/MinimumMaximumValidator.java
+++ b/src/main/java/com/playus/twpservice/domain/party/validation/MinimumMaximumValidator.java
@@ -1,13 +1,13 @@
 package com.playus.twpservice.domain.party.validation;
 
-import com.playus.twpservice.domain.party.dto.partycreate.PartyCreateRequest;
+import com.playus.twpservice.domain.common.MinimumMaximumValidatable;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 
-public class MinimumMaximumValidator implements ConstraintValidator<ValidMinimumMaximumParticipants, PartyCreateRequest> {
+public class MinimumMaximumValidator implements ConstraintValidator<ValidMinimumMaximumParticipants, MinimumMaximumValidatable> {
 
     @Override
-    public boolean isValid(PartyCreateRequest request, ConstraintValidatorContext context) {
+    public boolean isValid(MinimumMaximumValidatable request, ConstraintValidatorContext context) {
         if (request.minimumParticipants() == null || request.maximumParticipants() == null) {
             return true;
         }

--- a/src/main/java/com/playus/twpservice/domain/party/vo/PartyInfo.java
+++ b/src/main/java/com/playus/twpservice/domain/party/vo/PartyInfo.java
@@ -54,6 +54,7 @@ public class PartyInfo {
     public PartyInfoResponse toResponse() {
         return PartyInfoResponse.of(
                 partyId,
+                writerId,
                 title,
                 partyJoinMethod,
                 ages.stream().map(PartyAgeGroup::getAgeGroupByAge).toList(),
@@ -71,6 +72,7 @@ public class PartyInfo {
     public PartyDetailResponse toPartyDetailResponse() {
         return PartyDetailResponse.of(
                 partyId,
+                writerId,
                 title,
                 partyJoinMethod,
                 text,

--- a/src/main/java/com/playus/twpservice/global/config/sentry/SentryConfig.java
+++ b/src/main/java/com/playus/twpservice/global/config/sentry/SentryConfig.java
@@ -8,7 +8,7 @@ import io.sentry.Sentry;
 import jakarta.annotation.PostConstruct;
 
 @Configuration
-@Profile({"!test"})
+@Profile({"prod", "dev"})
 public class SentryConfig {
 
 	@Value("${sentry.dsn}")

--- a/src/main/java/com/playus/twpservice/global/exception/ExceptionAdvice.java
+++ b/src/main/java/com/playus/twpservice/global/exception/ExceptionAdvice.java
@@ -2,6 +2,7 @@ package com.playus.twpservice.global.exception;
 
 import com.playus.twpservice.domain.party.controller.PartyController;
 import com.playus.twpservice.domain.party.exception.document.PartyDocumentException;
+import com.playus.twpservice.domain.party.exception.entity.PartyException;
 import com.playus.twpservice.domain.party.exception.enums.PartyAgeGroupException;
 import com.playus.twpservice.domain.party.exception.enums.PartyGenderException;
 import com.playus.twpservice.domain.party.exception.enums.PartyJoinMethodException;
@@ -43,6 +44,7 @@ public class ExceptionAdvice {
 
     @ResponseStatus(HttpStatus.NOT_FOUND)
     @ExceptionHandler({
+            PartyException.NotFoundException.class,
             PartyDocumentException.NotFoundException.class
     })
     public ErrorResponse handleNotFoundException(Exception e) {

--- a/src/main/java/com/playus/twpservice/global/s3/S3Config.java
+++ b/src/main/java/com/playus/twpservice/global/s3/S3Config.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Profile;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 import java.net.URI;
@@ -23,6 +24,20 @@ public class S3Config {
 
     @Value("${cloud.aws.s3.endpoint}")
     private String endpoint;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .endpointOverride(URI.create(endpoint))
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(accessKey, secretKey)
+                        )
+                )
+                .forcePathStyle(true)
+                .region(Region.of("kr-central-2"))
+                .build();
+    }
 
     @Bean
     public S3Presigner s3Presigner() {

--- a/src/main/java/com/playus/twpservice/global/s3/S3Service.java
+++ b/src/main/java/com/playus/twpservice/global/s3/S3Service.java
@@ -1,11 +1,13 @@
 package com.playus.twpservice.global.s3;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class S3Service {
@@ -24,5 +26,7 @@ public class S3Service {
                 .build();
 
         s3Client.deleteObject(deleteObjectRequest);
+
+        log.info("S3에서 이미지 삭제 완료: {}", imageFileName);
     }
 }

--- a/src/main/java/com/playus/twpservice/global/s3/S3Service.java
+++ b/src/main/java/com/playus/twpservice/global/s3/S3Service.java
@@ -1,0 +1,28 @@
+package com.playus.twpservice.global.s3;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+
+@Component
+@RequiredArgsConstructor
+public class S3Service {
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    private final S3Client s3Client;
+
+    // String fileName = imageUrl.substring(imageUrl.lastIndexOf("/") + 1);
+    public void deleteImage(String imageFileName) {
+
+        DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                .bucket(bucketName)
+                .key(imageFileName)
+                .build();
+
+        s3Client.deleteObject(deleteObjectRequest);
+    }
+}

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -3,24 +3,23 @@ spring:
     name: twp-service
 
   datasource:
-    url: jdbc:mysql://localhost:3306/playus
-    username: ${DB_USER}
-    password: ${DB_PASSWORD}
+    url: ${SPRING_DATASOURCE_URL}
+    username: ${SPRING_DATASOURCE_USERNAME}
+    password: ${SPRING_DATASOURCE_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   data:
     mongodb:
       read:
-        uri: mongodb://localhost:27017/read_db
-
+        uri: ${SPRING_DATA_MONGODB_READ_URI}
       chat:
-        uri: mongodb://localhost:27017/chat_db
+        uri: ${SPRING_DATA_MONGODB_CHAT_URI}
 
       auto-index-creation: true
 
     redis:
-      host: localhost
-      port: 6379
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
 
   jpa:
     show-sql: true
@@ -46,17 +45,17 @@ cloud:
       bucket : ${BUCKET_NAME}
       endpoint : ${BUCKET_ENDPOINT}
 
-sentry:
-  dsn: ${SENTRY_REPOSITORY_DSN}
-  environment: ${SENTRY_ENVIRONMENT}
-  servername: ${SENTRY_SERVERNAME}
-  repository-uri: ${SENTRY_REPOSITORY_URI}
-
-logging:
-  config: classpath:logback-spring.xml
-
-slack:
-  webhook-url: ${SLACK_WEBHOOK_URL}
+#sentry:
+#  dsn: ${SENTRY_REPOSITORY_DSN}
+#  environment: ${SENTRY_ENVIRONMENT}
+#  servername: ${SENTRY_SERVERNAME}
+#  repository-uri: ${SENTRY_REPOSITORY_URI}
+#
+#logging:
+#  config: classpath:logback-spring.xml
+#
+#slack:
+#  webhook-url: ${SLACK_WEBHOOK_URL}
 
 resilience4j:
   circuitbreaker:

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -18,8 +18,8 @@ spring:
       auto-index-creation: true
 
     redis:
-      host: ${REDIS_HOST}
-      port: ${REDIS_PORT}
+      host: localhost
+      port: 6379
 
   jpa:
     show-sql: true

--- a/src/test/java/com/playus/twpservice/IntegrationTestSupport.java
+++ b/src/test/java/com/playus/twpservice/IntegrationTestSupport.java
@@ -2,6 +2,7 @@ package com.playus.twpservice;
 
 
 import com.playus.twpservice.global.s3.S3PresignedUrlGenerator;
+import com.playus.twpservice.global.s3.S3Service;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
@@ -32,6 +33,9 @@ public abstract class IntegrationTestSupport extends OpenFeignClientTestSupport 
 
     @MockitoBean
     protected S3PresignedUrlGenerator s3PresignedUrlGenerator;
+
+    @MockitoBean
+    protected S3Service s3Service;
 
     static {
         mySQL = new MySQLContainer<>(MYSQL_VERSION)

--- a/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
@@ -5,8 +5,11 @@ import com.playus.twpservice.domain.party.dto.partydescription.PartyDetailRespon
 import com.playus.twpservice.domain.party.dto.partyinfobymatch.PartyInfoResponse;
 import com.playus.twpservice.domain.party.dto.partycreate.PartyCreateRequest;
 import com.playus.twpservice.domain.party.dto.partycreate.PartyCreateResponse;
+import com.playus.twpservice.domain.party.dto.partyupdate.PartyUpdateRequest;
+import com.playus.twpservice.domain.party.dto.partyupdate.PartyUpdateResponse;
 import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageRequest;
 import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageResponse;
+import com.playus.twpservice.domain.party.entity.Party;
 import com.playus.twpservice.domain.party.enums.PartyAgeGroup;
 import com.playus.twpservice.domain.party.enums.PartyGender;
 import com.playus.twpservice.domain.party.enums.PartyJoinMethod;
@@ -26,8 +29,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.*;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -645,8 +647,336 @@ class PartyControllerTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.message").value("직관팟 ID는 1 이상이어야 합니다!"));
     }
 
+    @DisplayName("직관팟을 수정할 수 있다.")
+    @Test
+    void updateParty() throws Exception {
+        // given
+        Long partyId = 1L;
+        PartyUpdateRequest request = PartyUpdateRequest.of("title", "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
+        PartyUpdateResponse response = PartyUpdateResponse.of(partyId);
+        given(partyService.updateParty(any(Long.class), any(Party.class))).willReturn(response);
+
+        // when // then
+        mockMvc.perform(put("/party/" + partyId)
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(APPLICATION_JSON)
+                        .with(authentication(token)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.partyId").value("1"));
+    }
+
+    @DisplayName("직관팟을 수정할 때, 직관팟의 ID는 1 이상이여야 한다..")
+    @CsvSource(value = {"0", "-1", "-100", "-1000", "-10000"})
+    @ParameterizedTest(name = "invalidPartyIdStr = {0}")
+    void updateParty_EMPTY_PARTYID(String invalidPartyIdStr) throws Exception {
+        // given
+        Long partyId = 1L;
+        PartyUpdateRequest request = PartyUpdateRequest.of("title", "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
+        PartyUpdateResponse response = PartyUpdateResponse.of(partyId);
+        given(partyService.updateParty(any(Long.class), any(Party.class))).willReturn(response);
+
+        // when // then
+        assertBadRequestOfPartyUpdateRequest(request, "/party/" + invalidPartyIdStr, "직관팟 ID는 1 이상이어야 합니다!");
+    }
+
+    @DisplayName("직관팟 수정 중 제목은 필수이다.")
+    @NullAndEmptySource
+    @ParameterizedTest(name = "title = {0}")
+    void updateParty_EMPTY_TITLE(String emptyTitle) throws Exception {
+        // given
+        Long partyId = 1L;
+        PartyUpdateRequest request = PartyUpdateRequest.of(null, "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
+        PartyUpdateResponse response = PartyUpdateResponse.of(partyId);
+        given(partyService.updateParty(any(Long.class), any(Party.class))).willReturn(response);
+
+
+        // when // then
+        assertBadRequestOfPartyUpdateRequest(request, "/party/" + partyId, "직관팟 제목이 비어 있습니다!");
+    }
+
+    @DisplayName("직관팟 수정 중 제목은 225자를 넘길 수 없다.")
+    @Test
+    void updateParty_EXCEED_TITLE() throws Exception {
+        String exceedTitle = "a".repeat(226);
+        Long partyId = 1L;
+        PartyUpdateRequest request = PartyUpdateRequest.of(exceedTitle, "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
+        PartyUpdateResponse response = PartyUpdateResponse.of(partyId);
+        given(partyService.updateParty(any(Long.class), any(Party.class))).willReturn(response);
+
+        // when // then
+        assertBadRequestOfPartyUpdateRequest(request, "/party/" + partyId, "제목의 길이를 1~225자 이내로 작성해 주세요!");
+    }
+
+    //  직관팟 수정 partyJoinMethod 이슈
+    @DisplayName("직관팟 수정 중 신청 방식은 필수이다.")
+    @NullAndEmptySource
+    @ParameterizedTest(name = "partyJoinMethod = {0}")
+    void updateParty_EMPTY_METHOD(String emptyMethod) throws Exception {
+        // given
+        Long partyId = 1L;
+        PartyUpdateRequest request = PartyUpdateRequest.of("제목", emptyMethod, "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
+        PartyUpdateResponse response = PartyUpdateResponse.of(1L);
+        given(partyService.updateParty(any(Long.class), any(Party.class))).willReturn(response);
+
+        // when // then
+        assertBadRequestOfPartyUpdateRequest(request, "/party/" + partyId, "신청 방식이 비어 있습니다!");
+    }
+
+    @DisplayName("직관팟 수정 중 신청 방식은 정해진 양식대로 입력해야 한다.")
+    @CsvSource(value = {"FIRST_COME", "RESERVATION", "ABCDEFG", "ㄱㄴㄷㄹㅁㅂㅅㅇ", "!@#$%^&", "123456789"})
+    @ParameterizedTest(name = "partyJoinMethod = {0}")
+    void updateParty_INVALID_METHOD(String invalidMethod) throws Exception {
+        // given
+        Long partyId = 1L;
+        PartyUpdateRequest request = PartyUpdateRequest.of("제목", invalidMethod, "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
+        PartyUpdateResponse response = PartyUpdateResponse.of(1L);
+        given(partyService.updateParty(any(Long.class), any(Party.class))).willReturn(response);
+
+        // when // then
+        assertBadRequestOfPartyUpdateRequest(request, "/party/" + partyId, "잘못된 신청 방식입니다!");
+    }
+
+    //  직관팟 수정 partyGender 이슈
+    @DisplayName("직관팟 수정 중 참여 원하는 성별은 필수이다.")
+    @NullAndEmptySource
+    @ParameterizedTest(name = "partyGender = {0}")
+    void updateParty_EMPTY_GENDER(String emptyGender) throws Exception {
+        // given
+        Long partyId = 1L;
+        PartyUpdateRequest request = PartyUpdateRequest.of("제목", "선착순", emptyGender, List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
+        PartyUpdateResponse response = PartyUpdateResponse.of(1L);
+        given(partyService.updateParty(any(Long.class), any(Party.class))).willReturn(response);
+
+        // when // then
+        assertBadRequestOfPartyUpdateRequest(request, "/party/" + partyId, "참여 원하는 성별이 비어 있습니다!");
+    }
+
+    @DisplayName("직관팟 수정 중 성별은 정해진 양식대로 입력해야 한다.")
+    @CsvSource(value = {"MALE", "FEMALE", "NO_MATTER", "ㄱㄴㄷㄹㅁㅂㅅㅇ", "!@#$%^&", "123456789"})
+    @ParameterizedTest(name = "partyGender = {0}")
+    void updateParty_INVALID_GENDER(String invalidGender) throws Exception {
+        // given
+        Long partyId = 1L;
+        PartyUpdateRequest request = PartyUpdateRequest.of("제목", "선착순", invalidGender, List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
+        PartyUpdateResponse response = PartyUpdateResponse.of(1L);
+        given(partyService.updateParty(any(Long.class), any(Party.class))).willReturn(response);
+
+        // when // then
+        assertBadRequestOfPartyUpdateRequest(request, "/party/" + partyId, "잘못된 성별 형식입니다!");
+    }
+
+    @DisplayName("직관팟 수정 중 성별은 남자만, 여자만, 상관없음 중 하나만 입력해아 한다.")
+    @CsvSource(value = {"남자만", "여자만", "상관없음"})
+    @ParameterizedTest(name = "partyGender = {0}")
+    void updateParty_VALID_GENDER(String gender) throws Exception {
+        // given
+        Long partyId = 1L;
+        PartyUpdateRequest request = PartyUpdateRequest.of("title", "선착순", gender, List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
+        PartyUpdateResponse response = PartyUpdateResponse.of(1L);
+        given(partyService.updateParty(any(Long.class), any(Party.class))).willReturn(response);
+
+        // when // then
+        mockMvc.perform(put("/party/" + partyId)
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(APPLICATION_JSON)
+                        .with(authentication(token)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.partyId").value("1"));
+    }
+
+    //  직관팟 수정 ageGroup 이슈
+    @DisplayName("직관팟 수정 중 참여자 나이는 필수이다.")
+    @NullAndEmptySource
+    @ParameterizedTest(name = "age = {0}")
+    void updateParty_EMPTY_AGE(List<String> emptyAgeList) throws Exception {
+
+        // given
+        Long partyId = 1L;
+        PartyUpdateRequest request = PartyUpdateRequest.of("제목", "선착순", "남자만", emptyAgeList, 1L, 10L, thumbnailUrl, "message");
+        PartyUpdateResponse response = PartyUpdateResponse.of(1L);
+        given(partyService.updateParty(any(Long.class), any(Party.class))).willReturn(response);
+
+        // when // then
+        assertBadRequestOfPartyUpdateRequest(request, "/party/" + partyId, "참여자 나이가 비어 있습니다!");
+    }
+
+    @DisplayName("직관팟 수정 중 참여자 나이는 정해진 양식대로 입력해야 한다.")
+    @MethodSource("invalidAgeGroupProvider")
+    @ParameterizedTest(name = "age = {0}")
+    void updateParty_INVALID_AGE(List<String> emptyAgeList) throws Exception {
+
+        // given
+        Long partyId = 1L;
+        PartyUpdateRequest request = PartyUpdateRequest.of("제목", "선착순", "남자만", emptyAgeList, 1L, 10L, thumbnailUrl, "message");
+        PartyUpdateResponse response = PartyUpdateResponse.of(1L);
+        given(partyService.updateParty(any(Long.class), any(Party.class))).willReturn(response);
+
+        // when // then
+        assertBadRequestOfPartyUpdateRequest(request, "/party/" + partyId, "잘못된 참여자 나이입니다!");
+    }
+
+    @DisplayName("직관팟 수정 중 참여자 나이는 정해진 수를 넘을 수 없다.")
+    @Test
+    void updateParty_TOO_MANY_AGE() throws Exception {
+
+        // given
+        Long partyId = 1L;
+        List<String> tooManyAgeList = List.of("10대", "20대", "30대", "40대", "50대", "60대 이상", "70대", "80대", "90대");
+        PartyUpdateRequest request = PartyUpdateRequest.of("제목", "선착순", "남자만", tooManyAgeList, 1L, 10L, thumbnailUrl, "message");
+        PartyUpdateResponse response = PartyUpdateResponse.of(1L);
+        given(partyService.updateParty(any(Long.class), any(Party.class))).willReturn(response);
+
+        // when // then
+        assertBadRequestOfPartyUpdateRequest(request, "/party/" + partyId, "참여자 나이는 최대 6개까지 가능합니다!");
+    }
+
+    //  직관팟 수정 minimumParticipants 이슈
+    @DisplayName("직관팟 최소 인원은 필수이다.")
+    @Test
+    void updateParty_EMPTY_MINIMUM() throws Exception {
+        Long partyId = 1L;
+        PartyUpdateRequest request = PartyUpdateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), null, 10L, thumbnailUrl, "message");
+        PartyUpdateResponse response = PartyUpdateResponse.of(1L);
+        given(partyService.updateParty(any(Long.class), any(Party.class))).willReturn(response);
+
+        // when // then
+        assertBadRequestOfPartyUpdateRequest(request, "/party/" + partyId, "최소 참여 인원이 비어 있습니다!");
+    }
+
+    @DisplayName("직관팟 최소 인원은 1 이상이여야 한다.")
+    @Test
+    void updateParty_INVALID_MINIMUM() throws Exception {
+        Long partyId = 1L;
+        PartyUpdateRequest request = PartyUpdateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), 0L, 10L, thumbnailUrl, "message");
+        PartyUpdateResponse response = PartyUpdateResponse.of(1L);
+        given(partyService.updateParty(any(Long.class), any(Party.class))).willReturn(response);
+
+        // when // then
+        assertBadRequestOfPartyUpdateRequest(request, "/party/" + partyId, "최소 참여 인원은 1명 이상이여야 합니다!");
+    }
+
+    //  직관팟 수정 maximumParticipants 이슈
+    @DisplayName("직관팟 최대 인원은 필수이다.")
+    @Test
+    void updateParty_EMPTY_MAXIMUM() throws Exception {
+        Long partyId = 1L;
+        PartyUpdateRequest request = PartyUpdateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), 1L, null, thumbnailUrl, "message");
+        PartyUpdateResponse response = PartyUpdateResponse.of(1L);
+        given(partyService.updateParty(any(Long.class), any(Party.class))).willReturn(response);
+
+        // when // then
+        assertBadRequestOfPartyUpdateRequest(request, "/party/" + partyId, "최대 참여 인원이 비어 있습니다!");
+    }
+
+    @DisplayName("직관팟 최소 인원은 최대 인원보다 클 수 없다.")
+    @Test
+    void updateParty_MINIMUM_MAXIMUM() throws Exception {
+        Long partyId = 1L;
+        PartyUpdateRequest request = PartyUpdateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), 10L, 9L, thumbnailUrl, "message");
+        PartyUpdateResponse response = PartyUpdateResponse.of(1L);
+        given(partyService.updateParty(any(Long.class), any(Party.class))).willReturn(response);
+
+        // when // then
+        assertBadRequestOfPartyUpdateRequest(request, "/party/" + partyId, "최소 참여 인원은 최대 참여 인원보다 클 수 없습니다!");
+    }
+
+    //  직관팟 수정 thumbnailUrl 이슈
+    @DisplayName("직관팟 수정 중 사진 url은 비어 있거나, http/https/ftp로 시작해야 한다.")
+    @MethodSource("validUrlGroupProvider")
+    @ParameterizedTest(name = "url = {0}")
+    void updateParty_VALID_IMAGE_URL(List<String> validUrl) throws Exception {
+        // given
+        Long partyId = 1L;
+        PartyUpdateRequest request = PartyUpdateRequest.of("title", "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, validUrl, "message");
+        PartyUpdateResponse response = PartyUpdateResponse.of(1L);
+        given(partyService.updateParty(any(Long.class), any(Party.class))).willReturn(response);
+
+        // when // then
+        mockMvc.perform(put("/party/" + partyId)
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(APPLICATION_JSON)
+                        .with(authentication(token)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.partyId").value("1"));
+    }
+
+    @DisplayName("직관팟 수정 중 사진 url은 최대 10개까지만 담을 수 있다.")
+    @Test
+    void updateParty_NULL_IMAGE_URL() throws Exception {
+        // given
+        Long partyId = 1L;
+        List<String> tooManyUrlList = List.of("http://image.com", "https://image.com", "ftp://image.com", "http://image.com",
+                "https://image.com", "ftp://image.com", "ftp://image.com", "http://image.com",
+                "https://image.com", "ftp://image.com", "http://image.com");
+        PartyUpdateRequest request = PartyUpdateRequest.of("title", "선착순", "남자만", List.of("10대", "20대"),
+                1L, 10L, tooManyUrlList, "message");
+        PartyUpdateResponse response = PartyUpdateResponse.of(1L);
+        given(partyService.updateParty(any(Long.class), any(Party.class))).willReturn(response);
+
+        // when // then
+        assertBadRequestOfPartyUpdateRequest(request, "/party/" + partyId, "썸네일은 최대 10개까지만 가능합니다!");
+    }
+
+    @DisplayName("직관팟 수정 중 사진 url은 올바른 format이여야 한다.")
+    @MethodSource("invalidUrlGroupProvider")
+    @ParameterizedTest(name = "url = {0}")
+    void updateParty_INVALID_IMAGE_URL(List<String> invalidUrl) throws Exception {
+        // given
+        Long partyId = 1L;
+        PartyUpdateRequest request = PartyUpdateRequest.of("title", "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, invalidUrl, "message");
+        PartyUpdateResponse response = PartyUpdateResponse.of(1L);
+        given(partyService.updateParty(any(Long.class), any(Party.class))).willReturn(response);
+
+        // when // then
+        assertBadRequestOfPartyUpdateRequest(request, "/party/" + partyId, "올바른 URL 형식이 아닙니다!");
+    }
+
+    //  직관팟 수정 message 이슈
+    @DisplayName("직관팟 수정 중 소개 문구는 필수이다.")
+    @NullAndEmptySource
+    @ParameterizedTest(name = "message = {0}")
+    void updateParty_EMPTY_MESSAGE(String emptyMessage) throws Exception {
+        // given
+        Long partyId = 1L;
+        PartyUpdateRequest request = PartyUpdateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, emptyMessage);
+        PartyUpdateResponse response = PartyUpdateResponse.of(1L);
+        given(partyService.updateParty(any(Long.class), any(Party.class))).willReturn(response);
+
+        // when // then
+        assertBadRequestOfPartyUpdateRequest(request, "/party/" + partyId, "직관팟 소개 문구가 비어 있습니다!");
+    }
+
+    @DisplayName("직관팟 수정 중 소개 문구는 100자 이내여야 한다.")
+    @Test
+    void updateParty_EXCEED_MESSAGE() throws Exception {
+        // given
+        Long partyId = 1L;
+        String exceedMessage = "a".repeat(101);
+        PartyUpdateRequest request = PartyUpdateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, exceedMessage);
+        PartyUpdateResponse response = PartyUpdateResponse.of(1L);
+        given(partyService.updateParty(any(Long.class), any(Party.class))).willReturn(response);
+
+        // when // then
+        assertBadRequestOfPartyUpdateRequest(request, "/party/" + partyId, "직관팟 소개 문구의 길이를 1~100자 이내로 작성해 주세요!");
+    }
+
     private void assertBadRequestOfPartyCreateRequest(PartyCreateRequest request, String requestUri, String expectedResult) throws Exception {
         mockMvc.perform(post(requestUri)
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(APPLICATION_JSON)
+                        .with(authentication(token)))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("400"))
+                .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+                .andExpect(jsonPath("$.message").value(expectedResult));
+    }
+
+    private void assertBadRequestOfPartyUpdateRequest(PartyUpdateRequest request, String requestUri, String expectedResult) throws Exception {
+        mockMvc.perform(put(requestUri)
                         .content(objectMapper.writeValueAsString(request))
                         .contentType(APPLICATION_JSON)
                         .with(authentication(token)))

--- a/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
@@ -5,6 +5,7 @@ import com.playus.twpservice.domain.party.dto.partydescription.PartyDetailRespon
 import com.playus.twpservice.domain.party.dto.partyinfobymatch.PartyInfoResponse;
 import com.playus.twpservice.domain.party.dto.partycreate.PartyCreateRequest;
 import com.playus.twpservice.domain.party.dto.partycreate.PartyCreateResponse;
+import com.playus.twpservice.domain.party.dto.partyupdate.PartyIdRequest;
 import com.playus.twpservice.domain.party.dto.partyupdate.PartyUpdateRequest;
 import com.playus.twpservice.domain.party.dto.partyupdate.PartyUpdateResponse;
 import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageRequest;
@@ -654,7 +655,7 @@ class PartyControllerTest extends ControllerTestSupport {
         Long partyId = 1L;
         PartyUpdateRequest request = PartyUpdateRequest.of("title", "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
         PartyUpdateResponse response = PartyUpdateResponse.of(partyId);
-        given(partyService.updateParty(any(Long.class), any(Party.class))).willReturn(response);
+        given(partyService.updateParty(any(Long.class), any(PartyIdRequest.class), any(PartyUpdateRequest.class))).willReturn(response);
 
         // when // then
         mockMvc.perform(put("/party/" + partyId)
@@ -674,7 +675,7 @@ class PartyControllerTest extends ControllerTestSupport {
         Long partyId = 1L;
         PartyUpdateRequest request = PartyUpdateRequest.of("title", "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
         PartyUpdateResponse response = PartyUpdateResponse.of(partyId);
-        given(partyService.updateParty(any(Long.class), any(Party.class))).willReturn(response);
+        given(partyService.updateParty(any(Long.class), any(PartyIdRequest.class), any(PartyUpdateRequest.class))).willReturn(response);
 
         // when // then
         assertBadRequestOfPartyUpdateRequest(request, "/party/" + invalidPartyIdStr, "직관팟 ID는 1 이상이어야 합니다!");
@@ -688,7 +689,7 @@ class PartyControllerTest extends ControllerTestSupport {
         Long partyId = 1L;
         PartyUpdateRequest request = PartyUpdateRequest.of(null, "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
         PartyUpdateResponse response = PartyUpdateResponse.of(partyId);
-        given(partyService.updateParty(any(Long.class), any(Party.class))).willReturn(response);
+        given(partyService.updateParty(any(Long.class), any(PartyIdRequest.class), any(PartyUpdateRequest.class))).willReturn(response);
 
 
         // when // then
@@ -702,7 +703,7 @@ class PartyControllerTest extends ControllerTestSupport {
         Long partyId = 1L;
         PartyUpdateRequest request = PartyUpdateRequest.of(exceedTitle, "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
         PartyUpdateResponse response = PartyUpdateResponse.of(partyId);
-        given(partyService.updateParty(any(Long.class), any(Party.class))).willReturn(response);
+        given(partyService.updateParty(any(Long.class), any(PartyIdRequest.class), any(PartyUpdateRequest.class))).willReturn(response);
 
         // when // then
         assertBadRequestOfPartyUpdateRequest(request, "/party/" + partyId, "제목의 길이를 1~225자 이내로 작성해 주세요!");
@@ -717,7 +718,7 @@ class PartyControllerTest extends ControllerTestSupport {
         Long partyId = 1L;
         PartyUpdateRequest request = PartyUpdateRequest.of("제목", emptyMethod, "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
         PartyUpdateResponse response = PartyUpdateResponse.of(1L);
-        given(partyService.updateParty(any(Long.class), any(Party.class))).willReturn(response);
+        given(partyService.updateParty(any(Long.class), any(PartyIdRequest.class), any(PartyUpdateRequest.class))).willReturn(response);
 
         // when // then
         assertBadRequestOfPartyUpdateRequest(request, "/party/" + partyId, "신청 방식이 비어 있습니다!");
@@ -731,7 +732,7 @@ class PartyControllerTest extends ControllerTestSupport {
         Long partyId = 1L;
         PartyUpdateRequest request = PartyUpdateRequest.of("제목", invalidMethod, "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
         PartyUpdateResponse response = PartyUpdateResponse.of(1L);
-        given(partyService.updateParty(any(Long.class), any(Party.class))).willReturn(response);
+        given(partyService.updateParty(any(Long.class), any(PartyIdRequest.class), any(PartyUpdateRequest.class))).willReturn(response);
 
         // when // then
         assertBadRequestOfPartyUpdateRequest(request, "/party/" + partyId, "잘못된 신청 방식입니다!");
@@ -746,7 +747,7 @@ class PartyControllerTest extends ControllerTestSupport {
         Long partyId = 1L;
         PartyUpdateRequest request = PartyUpdateRequest.of("제목", "선착순", emptyGender, List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
         PartyUpdateResponse response = PartyUpdateResponse.of(1L);
-        given(partyService.updateParty(any(Long.class), any(Party.class))).willReturn(response);
+        given(partyService.updateParty(any(Long.class), any(PartyIdRequest.class), any(PartyUpdateRequest.class))).willReturn(response);
 
         // when // then
         assertBadRequestOfPartyUpdateRequest(request, "/party/" + partyId, "참여 원하는 성별이 비어 있습니다!");
@@ -760,7 +761,7 @@ class PartyControllerTest extends ControllerTestSupport {
         Long partyId = 1L;
         PartyUpdateRequest request = PartyUpdateRequest.of("제목", "선착순", invalidGender, List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
         PartyUpdateResponse response = PartyUpdateResponse.of(1L);
-        given(partyService.updateParty(any(Long.class), any(Party.class))).willReturn(response);
+        given(partyService.updateParty(any(Long.class), any(PartyIdRequest.class), any(PartyUpdateRequest.class))).willReturn(response);
 
         // when // then
         assertBadRequestOfPartyUpdateRequest(request, "/party/" + partyId, "잘못된 성별 형식입니다!");
@@ -774,7 +775,7 @@ class PartyControllerTest extends ControllerTestSupport {
         Long partyId = 1L;
         PartyUpdateRequest request = PartyUpdateRequest.of("title", "선착순", gender, List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
         PartyUpdateResponse response = PartyUpdateResponse.of(1L);
-        given(partyService.updateParty(any(Long.class), any(Party.class))).willReturn(response);
+        given(partyService.updateParty(any(Long.class), any(PartyIdRequest.class), any(PartyUpdateRequest.class))).willReturn(response);
 
         // when // then
         mockMvc.perform(put("/party/" + partyId)
@@ -796,7 +797,7 @@ class PartyControllerTest extends ControllerTestSupport {
         Long partyId = 1L;
         PartyUpdateRequest request = PartyUpdateRequest.of("제목", "선착순", "남자만", emptyAgeList, 1L, 10L, thumbnailUrl, "message");
         PartyUpdateResponse response = PartyUpdateResponse.of(1L);
-        given(partyService.updateParty(any(Long.class), any(Party.class))).willReturn(response);
+        given(partyService.updateParty(any(Long.class), any(PartyIdRequest.class), any(PartyUpdateRequest.class))).willReturn(response);
 
         // when // then
         assertBadRequestOfPartyUpdateRequest(request, "/party/" + partyId, "참여자 나이가 비어 있습니다!");
@@ -811,7 +812,7 @@ class PartyControllerTest extends ControllerTestSupport {
         Long partyId = 1L;
         PartyUpdateRequest request = PartyUpdateRequest.of("제목", "선착순", "남자만", emptyAgeList, 1L, 10L, thumbnailUrl, "message");
         PartyUpdateResponse response = PartyUpdateResponse.of(1L);
-        given(partyService.updateParty(any(Long.class), any(Party.class))).willReturn(response);
+        given(partyService.updateParty(any(Long.class), any(PartyIdRequest.class), any(PartyUpdateRequest.class))).willReturn(response);
 
         // when // then
         assertBadRequestOfPartyUpdateRequest(request, "/party/" + partyId, "잘못된 참여자 나이입니다!");
@@ -826,7 +827,7 @@ class PartyControllerTest extends ControllerTestSupport {
         List<String> tooManyAgeList = List.of("10대", "20대", "30대", "40대", "50대", "60대 이상", "70대", "80대", "90대");
         PartyUpdateRequest request = PartyUpdateRequest.of("제목", "선착순", "남자만", tooManyAgeList, 1L, 10L, thumbnailUrl, "message");
         PartyUpdateResponse response = PartyUpdateResponse.of(1L);
-        given(partyService.updateParty(any(Long.class), any(Party.class))).willReturn(response);
+        given(partyService.updateParty(any(Long.class), any(PartyIdRequest.class), any(PartyUpdateRequest.class))).willReturn(response);
 
         // when // then
         assertBadRequestOfPartyUpdateRequest(request, "/party/" + partyId, "참여자 나이는 최대 6개까지 가능합니다!");
@@ -839,7 +840,7 @@ class PartyControllerTest extends ControllerTestSupport {
         Long partyId = 1L;
         PartyUpdateRequest request = PartyUpdateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), null, 10L, thumbnailUrl, "message");
         PartyUpdateResponse response = PartyUpdateResponse.of(1L);
-        given(partyService.updateParty(any(Long.class), any(Party.class))).willReturn(response);
+        given(partyService.updateParty(any(Long.class), any(PartyIdRequest.class), any(PartyUpdateRequest.class))).willReturn(response);
 
         // when // then
         assertBadRequestOfPartyUpdateRequest(request, "/party/" + partyId, "최소 참여 인원이 비어 있습니다!");
@@ -851,7 +852,7 @@ class PartyControllerTest extends ControllerTestSupport {
         Long partyId = 1L;
         PartyUpdateRequest request = PartyUpdateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), 0L, 10L, thumbnailUrl, "message");
         PartyUpdateResponse response = PartyUpdateResponse.of(1L);
-        given(partyService.updateParty(any(Long.class), any(Party.class))).willReturn(response);
+        given(partyService.updateParty(any(Long.class), any(PartyIdRequest.class), any(PartyUpdateRequest.class))).willReturn(response);
 
         // when // then
         assertBadRequestOfPartyUpdateRequest(request, "/party/" + partyId, "최소 참여 인원은 1명 이상이여야 합니다!");
@@ -864,7 +865,7 @@ class PartyControllerTest extends ControllerTestSupport {
         Long partyId = 1L;
         PartyUpdateRequest request = PartyUpdateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), 1L, null, thumbnailUrl, "message");
         PartyUpdateResponse response = PartyUpdateResponse.of(1L);
-        given(partyService.updateParty(any(Long.class), any(Party.class))).willReturn(response);
+        given(partyService.updateParty(any(Long.class), any(PartyIdRequest.class), any(PartyUpdateRequest.class))).willReturn(response);
 
         // when // then
         assertBadRequestOfPartyUpdateRequest(request, "/party/" + partyId, "최대 참여 인원이 비어 있습니다!");
@@ -876,7 +877,7 @@ class PartyControllerTest extends ControllerTestSupport {
         Long partyId = 1L;
         PartyUpdateRequest request = PartyUpdateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), 10L, 9L, thumbnailUrl, "message");
         PartyUpdateResponse response = PartyUpdateResponse.of(1L);
-        given(partyService.updateParty(any(Long.class), any(Party.class))).willReturn(response);
+        given(partyService.updateParty(any(Long.class), any(PartyIdRequest.class), any(PartyUpdateRequest.class))).willReturn(response);
 
         // when // then
         assertBadRequestOfPartyUpdateRequest(request, "/party/" + partyId, "최소 참여 인원은 최대 참여 인원보다 클 수 없습니다!");
@@ -891,7 +892,7 @@ class PartyControllerTest extends ControllerTestSupport {
         Long partyId = 1L;
         PartyUpdateRequest request = PartyUpdateRequest.of("title", "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, validUrl, "message");
         PartyUpdateResponse response = PartyUpdateResponse.of(1L);
-        given(partyService.updateParty(any(Long.class), any(Party.class))).willReturn(response);
+        given(partyService.updateParty(any(Long.class), any(PartyIdRequest.class), any(PartyUpdateRequest.class))).willReturn(response);
 
         // when // then
         mockMvc.perform(put("/party/" + partyId)
@@ -914,7 +915,7 @@ class PartyControllerTest extends ControllerTestSupport {
         PartyUpdateRequest request = PartyUpdateRequest.of("title", "선착순", "남자만", List.of("10대", "20대"),
                 1L, 10L, tooManyUrlList, "message");
         PartyUpdateResponse response = PartyUpdateResponse.of(1L);
-        given(partyService.updateParty(any(Long.class), any(Party.class))).willReturn(response);
+        given(partyService.updateParty(any(Long.class), any(PartyIdRequest.class), any(PartyUpdateRequest.class))).willReturn(response);
 
         // when // then
         assertBadRequestOfPartyUpdateRequest(request, "/party/" + partyId, "썸네일은 최대 10개까지만 가능합니다!");
@@ -928,7 +929,7 @@ class PartyControllerTest extends ControllerTestSupport {
         Long partyId = 1L;
         PartyUpdateRequest request = PartyUpdateRequest.of("title", "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, invalidUrl, "message");
         PartyUpdateResponse response = PartyUpdateResponse.of(1L);
-        given(partyService.updateParty(any(Long.class), any(Party.class))).willReturn(response);
+        given(partyService.updateParty(any(Long.class), any(PartyIdRequest.class), any(PartyUpdateRequest.class))).willReturn(response);
 
         // when // then
         assertBadRequestOfPartyUpdateRequest(request, "/party/" + partyId, "올바른 URL 형식이 아닙니다!");
@@ -943,7 +944,7 @@ class PartyControllerTest extends ControllerTestSupport {
         Long partyId = 1L;
         PartyUpdateRequest request = PartyUpdateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, emptyMessage);
         PartyUpdateResponse response = PartyUpdateResponse.of(1L);
-        given(partyService.updateParty(any(Long.class), any(Party.class))).willReturn(response);
+        given(partyService.updateParty(any(Long.class), any(PartyIdRequest.class), any(PartyUpdateRequest.class))).willReturn(response);
 
         // when // then
         assertBadRequestOfPartyUpdateRequest(request, "/party/" + partyId, "직관팟 소개 문구가 비어 있습니다!");
@@ -957,7 +958,7 @@ class PartyControllerTest extends ControllerTestSupport {
         String exceedMessage = "a".repeat(101);
         PartyUpdateRequest request = PartyUpdateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, exceedMessage);
         PartyUpdateResponse response = PartyUpdateResponse.of(1L);
-        given(partyService.updateParty(any(Long.class), any(Party.class))).willReturn(response);
+        given(partyService.updateParty(any(Long.class), any(PartyIdRequest.class), any(PartyUpdateRequest.class))).willReturn(response);
 
         // when // then
         assertBadRequestOfPartyUpdateRequest(request, "/party/" + partyId, "직관팟 소개 문구의 길이를 1~100자 이내로 작성해 주세요!");

--- a/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
@@ -658,7 +658,8 @@ class PartyControllerTest extends ControllerTestSupport {
     void updateParty() throws Exception {
         // given
         Long partyId = 1L;
-        PartyUpdateRequest request = PartyUpdateRequest.of("title", "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
+        Long writerId = 1L;
+        PartyUpdateRequest request = PartyUpdateRequest.of("title", writerId, "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
         PartyUpdateResponse response = PartyUpdateResponse.of(partyId);
         given(partyService.updateParty(any(Long.class), any(PartyIdRequest.class), any(PartyUpdateRequest.class))).willReturn(response);
 
@@ -678,7 +679,8 @@ class PartyControllerTest extends ControllerTestSupport {
     void updateParty_EMPTY_PARTYID(String invalidPartyIdStr) throws Exception {
         // given
         Long partyId = 1L;
-        PartyUpdateRequest request = PartyUpdateRequest.of("title", "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
+        Long writerId = 1L;
+        PartyUpdateRequest request = PartyUpdateRequest.of("title", writerId, "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
         PartyUpdateResponse response = PartyUpdateResponse.of(partyId);
         given(partyService.updateParty(any(Long.class), any(PartyIdRequest.class), any(PartyUpdateRequest.class))).willReturn(response);
 
@@ -692,7 +694,8 @@ class PartyControllerTest extends ControllerTestSupport {
     void updateParty_EMPTY_TITLE(String emptyTitle) throws Exception {
         // given
         Long partyId = 1L;
-        PartyUpdateRequest request = PartyUpdateRequest.of(null, "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
+        Long writerId = 1L;
+        PartyUpdateRequest request = PartyUpdateRequest.of(null, writerId, "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
         PartyUpdateResponse response = PartyUpdateResponse.of(partyId);
         given(partyService.updateParty(any(Long.class), any(PartyIdRequest.class), any(PartyUpdateRequest.class))).willReturn(response);
 
@@ -706,12 +709,27 @@ class PartyControllerTest extends ControllerTestSupport {
     void updateParty_EXCEED_TITLE() throws Exception {
         String exceedTitle = "a".repeat(226);
         Long partyId = 1L;
-        PartyUpdateRequest request = PartyUpdateRequest.of(exceedTitle, "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
+        Long writerId = 1L;
+        PartyUpdateRequest request = PartyUpdateRequest.of(exceedTitle, writerId, "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
         PartyUpdateResponse response = PartyUpdateResponse.of(partyId);
         given(partyService.updateParty(any(Long.class), any(PartyIdRequest.class), any(PartyUpdateRequest.class))).willReturn(response);
 
         // when // then
         assertBadRequestOfPartyUpdateRequest(request, "/party/" + partyId, "제목의 길이를 1~225자 이내로 작성해 주세요!");
+    }
+
+    @DisplayName("직관팟을 수정할 때, 직관팟 작성자의 ID는 1 이상이여야 한다..")
+    @CsvSource(value = {"0", "-1", "-100", "-1000", "-10000"})
+    @ParameterizedTest(name = "invalidWriterIdStr = {0}")
+    void updateParty_INVALID_WRITERID(String invalidWriterIdStr) throws Exception {
+        // given
+        Long partyId = 1L;
+        PartyUpdateRequest request = PartyUpdateRequest.of("title", Long.parseLong(invalidWriterIdStr), "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
+        PartyUpdateResponse response = PartyUpdateResponse.of(partyId);
+        given(partyService.updateParty(any(Long.class), any(PartyIdRequest.class), any(PartyUpdateRequest.class))).willReturn(response);
+
+        // when // then
+        assertBadRequestOfPartyUpdateRequest(request, "/party/" + partyId, "작성자 ID는 1 이상이어야 합니다!");
     }
 
     //  직관팟 수정 partyJoinMethod 이슈
@@ -721,7 +739,8 @@ class PartyControllerTest extends ControllerTestSupport {
     void updateParty_EMPTY_METHOD(String emptyMethod) throws Exception {
         // given
         Long partyId = 1L;
-        PartyUpdateRequest request = PartyUpdateRequest.of("제목", emptyMethod, "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
+        Long writerId = 1L;
+        PartyUpdateRequest request = PartyUpdateRequest.of("제목", writerId, emptyMethod, "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
         PartyUpdateResponse response = PartyUpdateResponse.of(1L);
         given(partyService.updateParty(any(Long.class), any(PartyIdRequest.class), any(PartyUpdateRequest.class))).willReturn(response);
 
@@ -735,7 +754,8 @@ class PartyControllerTest extends ControllerTestSupport {
     void updateParty_INVALID_METHOD(String invalidMethod) throws Exception {
         // given
         Long partyId = 1L;
-        PartyUpdateRequest request = PartyUpdateRequest.of("제목", invalidMethod, "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
+        Long writerId = 1L;
+        PartyUpdateRequest request = PartyUpdateRequest.of("제목", writerId, invalidMethod, "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
         PartyUpdateResponse response = PartyUpdateResponse.of(1L);
         given(partyService.updateParty(any(Long.class), any(PartyIdRequest.class), any(PartyUpdateRequest.class))).willReturn(response);
 
@@ -750,7 +770,8 @@ class PartyControllerTest extends ControllerTestSupport {
     void updateParty_EMPTY_GENDER(String emptyGender) throws Exception {
         // given
         Long partyId = 1L;
-        PartyUpdateRequest request = PartyUpdateRequest.of("제목", "선착순", emptyGender, List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
+        Long writerId = 1L;
+        PartyUpdateRequest request = PartyUpdateRequest.of("제목", writerId, "선착순", emptyGender, List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
         PartyUpdateResponse response = PartyUpdateResponse.of(1L);
         given(partyService.updateParty(any(Long.class), any(PartyIdRequest.class), any(PartyUpdateRequest.class))).willReturn(response);
 
@@ -764,7 +785,8 @@ class PartyControllerTest extends ControllerTestSupport {
     void updateParty_INVALID_GENDER(String invalidGender) throws Exception {
         // given
         Long partyId = 1L;
-        PartyUpdateRequest request = PartyUpdateRequest.of("제목", "선착순", invalidGender, List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
+        Long writerId = 1L;
+        PartyUpdateRequest request = PartyUpdateRequest.of("제목", writerId, "선착순", invalidGender, List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
         PartyUpdateResponse response = PartyUpdateResponse.of(1L);
         given(partyService.updateParty(any(Long.class), any(PartyIdRequest.class), any(PartyUpdateRequest.class))).willReturn(response);
 
@@ -778,7 +800,8 @@ class PartyControllerTest extends ControllerTestSupport {
     void updateParty_VALID_GENDER(String gender) throws Exception {
         // given
         Long partyId = 1L;
-        PartyUpdateRequest request = PartyUpdateRequest.of("title", "선착순", gender, List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
+        Long writerId = 1L;
+        PartyUpdateRequest request = PartyUpdateRequest.of("title", writerId, "선착순", gender, List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
         PartyUpdateResponse response = PartyUpdateResponse.of(1L);
         given(partyService.updateParty(any(Long.class), any(PartyIdRequest.class), any(PartyUpdateRequest.class))).willReturn(response);
 
@@ -800,7 +823,8 @@ class PartyControllerTest extends ControllerTestSupport {
 
         // given
         Long partyId = 1L;
-        PartyUpdateRequest request = PartyUpdateRequest.of("제목", "선착순", "남자만", emptyAgeList, 1L, 10L, thumbnailUrl, "message");
+        Long writerId = 1L;
+        PartyUpdateRequest request = PartyUpdateRequest.of("제목", writerId, "선착순", "남자만", emptyAgeList, 1L, 10L, thumbnailUrl, "message");
         PartyUpdateResponse response = PartyUpdateResponse.of(1L);
         given(partyService.updateParty(any(Long.class), any(PartyIdRequest.class), any(PartyUpdateRequest.class))).willReturn(response);
 
@@ -815,7 +839,8 @@ class PartyControllerTest extends ControllerTestSupport {
 
         // given
         Long partyId = 1L;
-        PartyUpdateRequest request = PartyUpdateRequest.of("제목", "선착순", "남자만", emptyAgeList, 1L, 10L, thumbnailUrl, "message");
+        Long writerId = 1L;
+        PartyUpdateRequest request = PartyUpdateRequest.of("제목", writerId, "선착순", "남자만", emptyAgeList, 1L, 10L, thumbnailUrl, "message");
         PartyUpdateResponse response = PartyUpdateResponse.of(1L);
         given(partyService.updateParty(any(Long.class), any(PartyIdRequest.class), any(PartyUpdateRequest.class))).willReturn(response);
 
@@ -829,8 +854,9 @@ class PartyControllerTest extends ControllerTestSupport {
 
         // given
         Long partyId = 1L;
+        Long writerId = 1L;
         List<String> tooManyAgeList = List.of("10대", "20대", "30대", "40대", "50대", "60대 이상", "70대", "80대", "90대");
-        PartyUpdateRequest request = PartyUpdateRequest.of("제목", "선착순", "남자만", tooManyAgeList, 1L, 10L, thumbnailUrl, "message");
+        PartyUpdateRequest request = PartyUpdateRequest.of("제목", writerId, "선착순", "남자만", tooManyAgeList, 1L, 10L, thumbnailUrl, "message");
         PartyUpdateResponse response = PartyUpdateResponse.of(1L);
         given(partyService.updateParty(any(Long.class), any(PartyIdRequest.class), any(PartyUpdateRequest.class))).willReturn(response);
 
@@ -843,7 +869,8 @@ class PartyControllerTest extends ControllerTestSupport {
     @Test
     void updateParty_EMPTY_MINIMUM() throws Exception {
         Long partyId = 1L;
-        PartyUpdateRequest request = PartyUpdateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), null, 10L, thumbnailUrl, "message");
+        Long writerId = 1L;
+        PartyUpdateRequest request = PartyUpdateRequest.of("제목", writerId, "선착순", "남자만", List.of("10대", "20대"), null, 10L, thumbnailUrl, "message");
         PartyUpdateResponse response = PartyUpdateResponse.of(1L);
         given(partyService.updateParty(any(Long.class), any(PartyIdRequest.class), any(PartyUpdateRequest.class))).willReturn(response);
 
@@ -855,7 +882,8 @@ class PartyControllerTest extends ControllerTestSupport {
     @Test
     void updateParty_INVALID_MINIMUM() throws Exception {
         Long partyId = 1L;
-        PartyUpdateRequest request = PartyUpdateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), 0L, 10L, thumbnailUrl, "message");
+        Long writerId = 1L;
+        PartyUpdateRequest request = PartyUpdateRequest.of("제목", writerId, "선착순", "남자만", List.of("10대", "20대"), 0L, 10L, thumbnailUrl, "message");
         PartyUpdateResponse response = PartyUpdateResponse.of(1L);
         given(partyService.updateParty(any(Long.class), any(PartyIdRequest.class), any(PartyUpdateRequest.class))).willReturn(response);
 
@@ -868,7 +896,8 @@ class PartyControllerTest extends ControllerTestSupport {
     @Test
     void updateParty_EMPTY_MAXIMUM() throws Exception {
         Long partyId = 1L;
-        PartyUpdateRequest request = PartyUpdateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), 1L, null, thumbnailUrl, "message");
+        Long writerId = 1L;
+        PartyUpdateRequest request = PartyUpdateRequest.of("제목", writerId, "선착순", "남자만", List.of("10대", "20대"), 1L, null, thumbnailUrl, "message");
         PartyUpdateResponse response = PartyUpdateResponse.of(1L);
         given(partyService.updateParty(any(Long.class), any(PartyIdRequest.class), any(PartyUpdateRequest.class))).willReturn(response);
 
@@ -880,7 +909,8 @@ class PartyControllerTest extends ControllerTestSupport {
     @Test
     void updateParty_MINIMUM_MAXIMUM() throws Exception {
         Long partyId = 1L;
-        PartyUpdateRequest request = PartyUpdateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), 10L, 9L, thumbnailUrl, "message");
+        Long writerId = 1L;
+        PartyUpdateRequest request = PartyUpdateRequest.of("제목", writerId, "선착순", "남자만", List.of("10대", "20대"), 10L, 9L, thumbnailUrl, "message");
         PartyUpdateResponse response = PartyUpdateResponse.of(1L);
         given(partyService.updateParty(any(Long.class), any(PartyIdRequest.class), any(PartyUpdateRequest.class))).willReturn(response);
 
@@ -895,7 +925,8 @@ class PartyControllerTest extends ControllerTestSupport {
     void updateParty_VALID_IMAGE_URL(List<String> validUrl) throws Exception {
         // given
         Long partyId = 1L;
-        PartyUpdateRequest request = PartyUpdateRequest.of("title", "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, validUrl, "message");
+        Long writerId = 1L;
+        PartyUpdateRequest request = PartyUpdateRequest.of("title", writerId, "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, validUrl, "message");
         PartyUpdateResponse response = PartyUpdateResponse.of(1L);
         given(partyService.updateParty(any(Long.class), any(PartyIdRequest.class), any(PartyUpdateRequest.class))).willReturn(response);
 
@@ -914,10 +945,11 @@ class PartyControllerTest extends ControllerTestSupport {
     void updateParty_NULL_IMAGE_URL() throws Exception {
         // given
         Long partyId = 1L;
+        Long writerId = 1L;
         List<String> tooManyUrlList = List.of("http://image.com", "https://image.com", "ftp://image.com", "http://image.com",
                 "https://image.com", "ftp://image.com", "ftp://image.com", "http://image.com",
                 "https://image.com", "ftp://image.com", "http://image.com");
-        PartyUpdateRequest request = PartyUpdateRequest.of("title", "선착순", "남자만", List.of("10대", "20대"),
+        PartyUpdateRequest request = PartyUpdateRequest.of("title", writerId, "선착순", "남자만", List.of("10대", "20대"),
                 1L, 10L, tooManyUrlList, "message");
         PartyUpdateResponse response = PartyUpdateResponse.of(1L);
         given(partyService.updateParty(any(Long.class), any(PartyIdRequest.class), any(PartyUpdateRequest.class))).willReturn(response);
@@ -932,7 +964,8 @@ class PartyControllerTest extends ControllerTestSupport {
     void updateParty_INVALID_IMAGE_URL(List<String> invalidUrl) throws Exception {
         // given
         Long partyId = 1L;
-        PartyUpdateRequest request = PartyUpdateRequest.of("title", "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, invalidUrl, "message");
+        Long writerId = 1L;
+        PartyUpdateRequest request = PartyUpdateRequest.of("title", writerId, "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, invalidUrl, "message");
         PartyUpdateResponse response = PartyUpdateResponse.of(1L);
         given(partyService.updateParty(any(Long.class), any(PartyIdRequest.class), any(PartyUpdateRequest.class))).willReturn(response);
 
@@ -947,7 +980,8 @@ class PartyControllerTest extends ControllerTestSupport {
     void updateParty_EMPTY_MESSAGE(String emptyMessage) throws Exception {
         // given
         Long partyId = 1L;
-        PartyUpdateRequest request = PartyUpdateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, emptyMessage);
+        Long writerId = 1L;
+        PartyUpdateRequest request = PartyUpdateRequest.of("제목", writerId, "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, emptyMessage);
         PartyUpdateResponse response = PartyUpdateResponse.of(1L);
         given(partyService.updateParty(any(Long.class), any(PartyIdRequest.class), any(PartyUpdateRequest.class))).willReturn(response);
 
@@ -960,8 +994,9 @@ class PartyControllerTest extends ControllerTestSupport {
     void updateParty_EXCEED_MESSAGE() throws Exception {
         // given
         Long partyId = 1L;
+        Long writerId = 1L;
         String exceedMessage = "a".repeat(101);
-        PartyUpdateRequest request = PartyUpdateRequest.of("제목", "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, exceedMessage);
+        PartyUpdateRequest request = PartyUpdateRequest.of("제목", writerId, "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, exceedMessage);
         PartyUpdateResponse response = PartyUpdateResponse.of(1L);
         given(partyService.updateParty(any(Long.class), any(PartyIdRequest.class), any(PartyUpdateRequest.class))).willReturn(response);
 

--- a/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
@@ -695,7 +695,7 @@ class PartyControllerTest extends ControllerTestSupport {
         // given
         Long partyId = 1L;
         Long writerId = 1L;
-        PartyUpdateRequest request = PartyUpdateRequest.of(null, writerId, "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
+        PartyUpdateRequest request = PartyUpdateRequest.of(emptyTitle, writerId, "선착순", "남자만", List.of("10대", "20대"), 1L, 10L, thumbnailUrl, "message");
         PartyUpdateResponse response = PartyUpdateResponse.of(partyId);
         given(partyService.updateParty(any(Long.class), any(PartyIdRequest.class), any(PartyUpdateRequest.class))).willReturn(response);
 

--- a/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
@@ -10,7 +10,6 @@ import com.playus.twpservice.domain.party.dto.partyupdate.PartyUpdateRequest;
 import com.playus.twpservice.domain.party.dto.partyupdate.PartyUpdateResponse;
 import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageRequest;
 import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageResponse;
-import com.playus.twpservice.domain.party.entity.Party;
 import com.playus.twpservice.domain.party.enums.PartyAgeGroup;
 import com.playus.twpservice.domain.party.enums.PartyGender;
 import com.playus.twpservice.domain.party.enums.PartyJoinMethod;
@@ -426,12 +425,13 @@ class PartyControllerTest extends ControllerTestSupport {
     void getPartiesByMatchId() throws Exception {
         // given
         Long matchId = 1L;
+        Long writerId = 1L;
         List<PartyAgeGroup> partyAges = List.of(PartyAgeGroup.AGE_10, PartyAgeGroup.AGE_20);
         LocalDateTime matchDate = LocalDateTime.of(2025, 3, 22, 14, 0, 0);
         List<String> partyThumbnailUrls = List.of("http://party-thumbnail", "http://party-thumbnail2.com");
         List<String> userThumbnailUrls = List.of("http://user-thumbnailUrl", "http://user2-thumbnailUrl");
 
-        PartyInfoResponse response = PartyInfoResponse.of(1L, "title", PartyJoinMethod.RESERVATION, partyAges, PartyGender.MALE,
+        PartyInfoResponse response = PartyInfoResponse.of(1L, writerId, "title", PartyJoinMethod.RESERVATION, partyAges, PartyGender.MALE,
                 "ZSJ", "남성", matchDate,
                 10L, 14L, partyThumbnailUrls, userThumbnailUrls);
 
@@ -447,6 +447,8 @@ class PartyControllerTest extends ControllerTestSupport {
                         .with(authentication(token)))
                 .andDo(print())
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].partyId").value(1L))
+                .andExpect(jsonPath("$[0].writerId").value(writerId))
                 .andExpect(jsonPath("$[0].title").value("title"))
                 .andExpect(jsonPath("$[0].partyJoinMethod").value("승인제"))
                 .andExpect(jsonPath("$[0].partyAges[0]").value("10대"))
@@ -473,7 +475,7 @@ class PartyControllerTest extends ControllerTestSupport {
         List<String> partyThumbnailUrls = List.of("http://party-thumbnail", "http://party-thumbnail2.com");
         List<String> userThumbnailUrls = List.of("http://user-thumbnailUrl", "http://user2-thumbnailUrl");
 
-        PartyInfoResponse response = PartyInfoResponse.of(1L, "title", PartyJoinMethod.RESERVATION, partyAges, PartyGender.MALE,
+        PartyInfoResponse response = PartyInfoResponse.of(1L, 1L, "title", PartyJoinMethod.RESERVATION, partyAges, PartyGender.MALE,
                 "ZSJ", "남성", matchDate,
                 10L, 14L, partyThumbnailUrls, userThumbnailUrls);
 
@@ -520,7 +522,7 @@ class PartyControllerTest extends ControllerTestSupport {
         List<String> partyThumbnailUrls = List.of("http://party-thumbnail", "http://party-thumbnail2.com");
         List<String> userThumbnailUrls = List.of("http://user-thumbnailUrl", "http://user2-thumbnailUrl");
 
-        PartyInfoResponse response = PartyInfoResponse.of(1L, "title", PartyJoinMethod.RESERVATION, partyAges, PartyGender.MALE,
+        PartyInfoResponse response = PartyInfoResponse.of(1L, 1L, "title", PartyJoinMethod.RESERVATION, partyAges, PartyGender.MALE,
                 "ZSJ", "남성", matchDate,
                 10L, 14L, partyThumbnailUrls, userThumbnailUrls);
 
@@ -552,7 +554,7 @@ class PartyControllerTest extends ControllerTestSupport {
         List<String> partyThumbnailUrls = List.of("http://party-thumbnail", "http://party-thumbnail2.com");
         List<String> userThumbnailUrls = List.of("http://user-thumbnailUrl", "http://user2-thumbnailUrl");
 
-        PartyInfoResponse response = PartyInfoResponse.of(1L, "title", PartyJoinMethod.RESERVATION, partyAges, PartyGender.MALE,
+        PartyInfoResponse response = PartyInfoResponse.of(1L, 1L, "title", PartyJoinMethod.RESERVATION, partyAges, PartyGender.MALE,
                 "ZSJ", "남성", matchDate,
                 10L, 14L, partyThumbnailUrls, userThumbnailUrls);
 
@@ -596,12 +598,13 @@ class PartyControllerTest extends ControllerTestSupport {
     void getPartyDetail() throws Exception {
         // given
         Long partyId = 1L;
+        Long writerId = 1L;
         List<PartyAgeGroup> partyAges = List.of(PartyAgeGroup.AGE_10, PartyAgeGroup.AGE_20);
         LocalDateTime matchDate = LocalDateTime.of(2025, 3, 22, 14, 0, 0);
         List<String> partyThumbnailUrls = List.of("http://party-thumbnail", "http://party-thumbnail2.com");
         List<String> userThumbnailUrls = List.of("http://user-thumbnailUrl", "http://user2-thumbnailUrl");
 
-        PartyDetailResponse response = PartyDetailResponse.of(1L, "title", PartyJoinMethod.RESERVATION,
+        PartyDetailResponse response = PartyDetailResponse.of(1L, writerId, "title", PartyJoinMethod.RESERVATION,
                 "explanation", partyAges, PartyGender.MALE, "ZSJ", "남성", matchDate,
                 10L, 14L, partyThumbnailUrls, userThumbnailUrls);
 
@@ -615,6 +618,8 @@ class PartyControllerTest extends ControllerTestSupport {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.title").value("title"))
+                .andExpect(jsonPath("$.partyId").value(partyId))
+                .andExpect(jsonPath("$.writerId").value(writerId))
                 .andExpect(jsonPath("$.partyJoinMethod").value("승인제"))
                 .andExpect(jsonPath("$.partyAges[0]").value("10대"))
                 .andExpect(jsonPath("$.partyAges[1]").value("20대"))

--- a/src/test/java/com/playus/twpservice/domain/party/service/PartyReadOnlyServiceTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/service/PartyReadOnlyServiceTest.java
@@ -110,14 +110,14 @@ class PartyReadOnlyServiceTest extends IntegrationTestSupport {
         // then
         assertThat(result).hasSize(2)
 
-                .extracting("partyId", "title", "partyJoinMethod", "partyAges", "availableGender", "authorName", "authorGender",
+                .extracting("partyId", "writerId", "title", "partyJoinMethod", "partyAges", "availableGender", "authorName", "authorGender",
                         "matchDate", "currentParticipantsCount", "maximumParticipantsCount", "partyThumbnailUrls", "userThumbnailUrls")
 
                 .containsExactlyInAnyOrder(
-                        tuple(1L, "title1", PartyJoinMethod.FIRST_COME.getDescription(), List.of("10대"), PartyGender.MALE.getDescription(), "writer1", "남성",
+                        tuple(1L, 1L, "title1", PartyJoinMethod.FIRST_COME.getDescription(), List.of("10대"), PartyGender.MALE.getDescription(), "writer1", "남성",
                                 matchDate, 3L, 10L, List.of("thumbnailUrl1", "thumbnailUrl2"), List.of("http://writer1-thumbnail", "http://user1", "http://user2")),
 
-                        tuple(2L, "title2", PartyJoinMethod.RESERVATION.getDescription(), List.of("20대"), PartyGender.FEMALE.getDescription(), "writer2", "여성",
+                        tuple(2L, 2L, "title2", PartyJoinMethod.RESERVATION.getDescription(), List.of("20대"), PartyGender.FEMALE.getDescription(), "writer2", "여성",
                                 matchDate, 1L, 10L, List.of(), List.of("http://writer2-thumbnail"))
                 );
     }
@@ -183,11 +183,11 @@ class PartyReadOnlyServiceTest extends IntegrationTestSupport {
         // then
         assertThat(result)
 
-                .extracting("partyId", "title", "partyJoinMethod", "text", "partyAges", "availableGender", "authorName", "authorGender",
+                .extracting("partyId", "writerId", "title", "partyJoinMethod", "text", "partyAges", "availableGender", "authorName", "authorGender",
                         "matchDate", "currentParticipantsCount", "maximumParticipantsCount", "partyThumbnailUrls", "userThumbnailUrls")
 
                 .containsExactly(
-                        1L, "title1", PartyJoinMethod.FIRST_COME.getDescription(), "text1", List.of("10대"), PartyGender.MALE.getDescription(), "writer1", "남성",
+                        1L, 1L, "title1", PartyJoinMethod.FIRST_COME.getDescription(), "text1", List.of("10대"), PartyGender.MALE.getDescription(), "writer1", "남성",
                                 matchDate, 3L, 10L, List.of("thumbnailUrl1", "thumbnailUrl2"), List.of("http://writer1-thumbnail", "http://user1", "http://user2")
 
                 );

--- a/src/test/java/com/playus/twpservice/domain/party/service/PartyServiceTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/service/PartyServiceTest.java
@@ -7,13 +7,19 @@ import com.playus.twpservice.domain.chat.repository.ChatPartRepository;
 import com.playus.twpservice.domain.chat.repository.ChatRoomRepository;
 import com.playus.twpservice.domain.party.dto.partycreate.PartyCreateRequest;
 import com.playus.twpservice.domain.party.dto.partycreate.PartyCreateResponse;
+import com.playus.twpservice.domain.party.dto.partyupdate.PartyIdRequest;
+import com.playus.twpservice.domain.party.dto.partyupdate.PartyUpdateRequest;
+import com.playus.twpservice.domain.party.dto.partyupdate.PartyUpdateResponse;
 import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageRequest;
 import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageResponse;
 import com.playus.twpservice.domain.party.entity.Party;
 import com.playus.twpservice.domain.party.entity.PartyAge;
+import com.playus.twpservice.domain.party.entity.PartyJoin;
 import com.playus.twpservice.domain.party.entity.PartyThumbnailUrl;
 import com.playus.twpservice.domain.party.enums.PartyGender;
 import com.playus.twpservice.domain.party.enums.PartyJoinMethod;
+import com.playus.twpservice.domain.party.enums.PartyJoinRequestStatus;
+import com.playus.twpservice.domain.party.exception.entity.PartyException;
 import com.playus.twpservice.domain.party.repository.write.PartyAgeRepository;
 import com.playus.twpservice.domain.party.repository.write.PartyJoinRepository;
 import com.playus.twpservice.domain.party.repository.write.PartyRepository;
@@ -26,6 +32,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.*;
 
 class PartyServiceTest extends IntegrationTestSupport {
@@ -124,7 +131,7 @@ class PartyServiceTest extends IntegrationTestSupport {
         // given
         Long userId = 1L;
         PartyCreateRequest request = PartyCreateRequest.of("title", "선착순", "남자만",
-                List.of("10대", "20대"), 1L, 10L, List.of(), 1L,  "message");
+                List.of("10대", "20대"), 1L, 10L, List.of(), 1L, "message");
 
         // when
         partyService.createParty(userId, request);
@@ -167,6 +174,95 @@ class PartyServiceTest extends IntegrationTestSupport {
 
         // then
         assertThat(result.presignedUrl()).isEqualTo(responseUrl);
+    }
+
+    @DisplayName("직관팟을 수정할 수 있다.")
+    @Test
+    void updateParty() {
+        // given
+        Long userId = 1L;
+        Long writerId = 1L;
+        Long matchId = 1L;
+
+        Party party = partyRepository.save(Party.create("title2", "16일 경기 같이 보실 분~", 1L, 15L,
+                PartyGender.FEMALE, PartyJoinMethod.RESERVATION, writerId, matchId).assignChatRoom("TEST-CHATROOM"));
+
+        Long partyId = party.getId();
+        PartyIdRequest idRequest = PartyIdRequest.of(partyId);
+
+        PartyUpdateRequest updateRequest = PartyUpdateRequest.of("title2", writerId, "선착순", "남자만", List.of("10대", "20대"),
+                1L, 10L, List.of("newUrl"), "message");
+
+        partyAgeRepository.saveAll(List.of(PartyAge.create(party, 10)));
+        partyThumbnailUrlRepository.saveAll(List.of(PartyThumbnailUrl.create(party, "url1"), PartyThumbnailUrl.create(party, "url2")));
+        partyJoinRepository.saveAll(List.of(PartyJoin.create(2L, party, PartyJoinRequestStatus.WAIT, "참여 희망합니다!")));
+
+        // when
+        PartyUpdateResponse response = partyService.updateParty(userId, idRequest, updateRequest);
+
+        // then
+        assertThat(response.partyId()).isEqualTo(partyId);
+
+        Party result = partyRepository.findAll().get(0);
+        assertThat(result).extracting("id", "title", "partyJoinMethod", "partyGender", "minimumParticipants",
+                        "maximumParticipants", "writerId", "matchId", "chatRoomId", "text")
+                .containsExactly(partyId, "title2", PartyJoinMethod.FIRST_COME, PartyGender.MALE, 1L,
+                        10L, writerId, matchId, "TEST-CHATROOM", "message");
+
+        List<PartyAge> ageResult = partyAgeRepository.findAll();
+        assertThat(ageResult).hasSize(2)
+                .extracting("age").containsExactly(10, 20);
+
+        List<PartyThumbnailUrl> thumbnailResult = partyThumbnailUrlRepository.findAll();
+        assertThat(thumbnailResult).hasSize(1)
+                .extracting("thumbnailUrl")
+                .containsExactly("newUrl");
+    }
+
+    @DisplayName("직관팟 작성자가 아니면 직관팟을 수정할 수 없다.")
+    @Test
+    void updateParty_checkWriterOrNot() {
+        Long userId = 1L;
+        Long writerId = 2L;
+        Long matchId = 1L;
+        Party party = partyRepository.save(Party.create("title2", "16일 경기 같이 보실 분~", 1L, 15L,
+                PartyGender.FEMALE, PartyJoinMethod.RESERVATION, writerId, matchId).assignChatRoom("TEST-CHATROOM"));
+
+        PartyIdRequest idRequest = PartyIdRequest.of(party.getId());
+        PartyUpdateRequest updateRequest = PartyUpdateRequest.of("title2", writerId, "선착순", "남자만", List.of("10대", "20대"),
+                1L, 10L, List.of("url"), "message");
+
+        partyAgeRepository.saveAll(List.of(PartyAge.create(party, 10)));
+        partyThumbnailUrlRepository.saveAll(List.of(PartyThumbnailUrl.create(party, "url1"), PartyThumbnailUrl.create(party, "url2")));
+        partyJoinRepository.saveAll(List.of(PartyJoin.create(2L, party, PartyJoinRequestStatus.WAIT, "참여 희망합니다!")));
+
+        // when // then
+        assertThatThrownBy(() -> partyService.updateParty(userId, idRequest, updateRequest))
+                .isInstanceOf(PartyException.NotPartyWriterException.class)
+                .hasMessage("직관팟 작성자가 아니면 수정할 수 없습니다!");
+    }
+
+    @DisplayName("존재하지 않는 직관팟을 수정할 수 없다.")
+    @Test
+    void updateParty_NOT_EXIST_PARTY() {
+        Long userId = 1L;
+        Long writerId = 1L;
+        Long matchId = 1L;
+        PartyUpdateRequest updateRequest = PartyUpdateRequest.of("title2", writerId, "선착순", "남자만", List.of("10대", "20대"),
+                1L, 10L, List.of("url"), "message");
+
+        Party party = partyRepository.save(Party.create("title2", "16일 경기 같이 보실 분~", 1L, 15L,
+                PartyGender.FEMALE, PartyJoinMethod.RESERVATION, writerId, matchId).assignChatRoom("TEST-CHATROOM"));
+
+        partyAgeRepository.saveAll(List.of(PartyAge.create(party, 10)));
+        partyThumbnailUrlRepository.saveAll(List.of(PartyThumbnailUrl.create(party, "url1"), PartyThumbnailUrl.create(party, "url2")));
+        partyJoinRepository.saveAll(List.of(PartyJoin.create(2L, party, PartyJoinRequestStatus.WAIT, "참여 희망합니다!")));
+
+        // when // then
+        Long invalidPartyId = partyRepository.findAll().get(0).getId() + 1;
+        assertThatThrownBy(() -> partyService.updateParty(userId, PartyIdRequest.of(invalidPartyId), updateRequest))
+                .isInstanceOf(PartyException.NotFoundException.class)
+                .hasMessage("잘못된 직관팟 번호입니다!");
     }
 
 }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
직관팟 수정 기능 구현했습니다. 아래는 request와 response format 입니다! 
```
{
   "title":"title",
   "writerId":1,
   "partyJoinMethod":"선착순",
   "partyGender":"남자만",
   "ageGroup":[
      "10대",
      "20대"
   ],
   "minimumParticipants":1,
   "maximumParticipants":10,
   "thumbnailUrl":[
      "http://image.com"
   ],
   "message":"message"
}
```

```
{
   "partyId":1
}
```

---

## 🔗 관련 이슈
- closes #30 

---

## 💡 추가 사항
**직관팟 조회/상세 조회 response에서 `writerId` 가 추가되었습니다!!!** 
S3Client 통해 이미지 삭제 기능 method 추가했습니다!
인덱싱 및 soft delete 측은 직관팟 삭제 구현하면서 하겠습니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 파티 정보 수정 API가 추가되어 사용자가 기존 파티 정보를 업데이트할 수 있습니다.
  - 파티 상세 및 목록 응답에 작성자 ID(writerId) 정보가 포함됩니다.
  - S3 이미지 삭제 기능이 추가되었습니다.

- **버그 수정**
  - 파티 관련 예외 처리 범위가 확장되어, 존재하지 않는 파티 접근 시 명확한 오류 메시지가 제공됩니다.

- **개선 및 변경**
  - 파티 생성/수정 시 썸네일 URL을 리스트 형태로 입력할 수 있습니다.
  - 환경설정 파일에서 민감 정보가 환경 변수로 대체되어 보안이 강화되었습니다.
  - Sentry 설정이 운영 및 개발 환경에서만 활성화됩니다.

- **테스트**
  - 파티 수정 기능에 대한 상세 검증 및 예외 상황 테스트가 추가되었습니다.
  - 파티 응답의 작성자 ID 필드에 대한 검증이 보강되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->