### PR TITLE
CS-282 feat/직관팟 승인 여부 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ dependencies {
 	implementation 'io.micrometer:micrometer-registry-prometheus'
 
 	// Object Storage
-	implementation 'software.amazon.awssdk:s3:2.20.45'
+	implementation 'software.amazon.awssdk:s3:2.31.45'
 
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/playus/twpservice/domain/party/assertion/PartyAssert.java
+++ b/src/main/java/com/playus/twpservice/domain/party/assertion/PartyAssert.java
@@ -9,18 +9,21 @@ import static com.playus.twpservice.domain.party.exception.entity.PartyException
 
 public class PartyAssert extends Assert {
 
+    // 400
     public static void isLoginUserWriter(Long userId, Long writerId, String message) {
         if (!Objects.equals(userId, writerId)) {
             throw new NotPartyWriterException(message);
         }
     }
 
+    // 400
     public static void isParticipatedPartyAsWriter(Long userId, Long writerId, String message) {
         if (Objects.equals(userId, writerId)) {
             throw new NotPartyWriterException(message);
         }
     }
 
+    // 409
     public static void isAppliableParty(Party party) {
         if (party.getCurrentParticipants() >= party.getMaximumParticipants()) {
             throw new ExceedPartyParticipantsException("직관팟 정원이 초과되었습니다!");

--- a/src/main/java/com/playus/twpservice/domain/party/controller/PartyController.java
+++ b/src/main/java/com/playus/twpservice/domain/party/controller/PartyController.java
@@ -3,6 +3,8 @@ package com.playus.twpservice.domain.party.controller;
 import com.playus.twpservice.domain.common.security.CustomOAuth2User;
 import com.playus.twpservice.domain.party.dto.apply.PartyApplyResponse;
 import com.playus.twpservice.domain.party.dto.apply.PartyApproveApplyRequest;
+import com.playus.twpservice.domain.party.dto.approve.PartyApproveRequest;
+import com.playus.twpservice.domain.party.dto.approve.PartyApproveResponse;
 import com.playus.twpservice.domain.party.dto.delete.PartyDeleteResponse;
 import com.playus.twpservice.domain.party.dto.detail.PartyDetailRequest;
 import com.playus.twpservice.domain.party.dto.detail.PartyDetailResponse;
@@ -76,6 +78,13 @@ public class PartyController implements PartyControllerSpecification {
     public PartyApplyResponse applyParty(@AuthenticationPrincipal CustomOAuth2User principal, @Valid PartyIdRequest idRequest,
                                          @Valid @RequestBody PartyApproveApplyRequest request) {
         return partyService.applyParty(principal.getId(), idRequest.partyId(), request.requireMessage());
+    }
+
+    @PatchMapping("/{partyId}/approve")
+    public PartyApproveResponse approveParty(@AuthenticationPrincipal CustomOAuth2User principal,
+                                             @Valid PartyIdRequest idRequest,
+                                             @Valid @RequestBody PartyApproveRequest request) {
+        return partyService.approveParty(principal.getId(), idRequest.partyId(), request);
     }
 
     @PostMapping("/presigned-url")

--- a/src/main/java/com/playus/twpservice/domain/party/dto/approve/PartyApproveRequest.java
+++ b/src/main/java/com/playus/twpservice/domain/party/dto/approve/PartyApproveRequest.java
@@ -1,0 +1,24 @@
+package com.playus.twpservice.domain.party.dto.approve;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+@Builder
+public record PartyApproveRequest (
+
+        @NotNull(message = "지원자 ID는 필수입니다!")
+        @Min(value = 1, message = "지원자 ID는 1 이상이여야 합니다!")
+        Long applicantUserId,
+
+        @NotNull(message = "승인 여부는 필수입니다!")
+        Boolean isApproved
+) {
+
+    public static PartyApproveRequest of(Long applicantUserId, Boolean isApproved) {
+        return PartyApproveRequest.builder()
+                .applicantUserId(applicantUserId)
+                .isApproved(isApproved)
+                .build();
+    }
+}

--- a/src/main/java/com/playus/twpservice/domain/party/dto/approve/PartyApproveResponse.java
+++ b/src/main/java/com/playus/twpservice/domain/party/dto/approve/PartyApproveResponse.java
@@ -1,0 +1,14 @@
+package com.playus.twpservice.domain.party.dto.approve;
+
+import lombok.Builder;
+
+@Builder
+public record PartyApproveResponse(
+        String message
+) {
+    public static PartyApproveResponse of(String message) {
+        return PartyApproveResponse.builder()
+                .message(message)
+                .build();
+    }
+}

--- a/src/main/java/com/playus/twpservice/domain/party/entity/PartyJoin.java
+++ b/src/main/java/com/playus/twpservice/domain/party/entity/PartyJoin.java
@@ -58,4 +58,12 @@ public class PartyJoin extends BaseTimeEntity {
                 .requireMessage(requireMessage)
                 .build();
     }
+
+    public void approve() {
+        this.partyJoinRequestStatus = PartyJoinRequestStatus.ACCEPT;
+    }
+
+    public void refuse() {
+        this.partyJoinRequestStatus = PartyJoinRequestStatus.REFUSE;
+    }
 }

--- a/src/main/java/com/playus/twpservice/domain/party/exception/entity/PartyException.java
+++ b/src/main/java/com/playus/twpservice/domain/party/exception/entity/PartyException.java
@@ -1,5 +1,7 @@
 package com.playus.twpservice.domain.party.exception.entity;
 
+import java.io.Serial;
+
 public abstract class PartyException {
 
     public static class NotPartyWriterException extends RuntimeException {
@@ -22,6 +24,16 @@ public abstract class PartyException {
         private static final long serialVersionUID = 1L;
 
         public ExceedPartyParticipantsException(String message) {
+            super(message);
+        }
+    }
+
+    public static class InvalidApproveRequestToPartyException extends RuntimeException {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
+
+        public InvalidApproveRequestToPartyException(String message) {
             super(message);
         }
     }

--- a/src/main/java/com/playus/twpservice/domain/party/repository/read/custom/PartyReadOnlyRepositoryCustom.java
+++ b/src/main/java/com/playus/twpservice/domain/party/repository/read/custom/PartyReadOnlyRepositoryCustom.java
@@ -6,6 +6,6 @@ import java.util.List;
 import java.util.Optional;
 
 public interface PartyReadOnlyRepositoryCustom {
-    List<PartyInfo> findPartyInfo(Long matchId);
+    List<PartyInfo> findPartyInfoList(Long matchId);
     Optional<PartyInfo> findPartyDetail(Long partyId);
 }

--- a/src/main/java/com/playus/twpservice/domain/party/repository/read/custom/PartyReadOnlyRepositoryCustom.java
+++ b/src/main/java/com/playus/twpservice/domain/party/repository/read/custom/PartyReadOnlyRepositoryCustom.java
@@ -7,5 +7,5 @@ import java.util.Optional;
 
 public interface PartyReadOnlyRepositoryCustom {
     List<PartyInfo> findPartyInfo(Long matchId);
-    Optional<PartyInfo> findPartyDetailBy(Long partyId);
+    Optional<PartyInfo> findPartyDetail(Long partyId);
 }

--- a/src/main/java/com/playus/twpservice/domain/party/repository/read/custom/PartyReadOnlyRepositoryCustom.java
+++ b/src/main/java/com/playus/twpservice/domain/party/repository/read/custom/PartyReadOnlyRepositoryCustom.java
@@ -6,6 +6,6 @@ import java.util.List;
 import java.util.Optional;
 
 public interface PartyReadOnlyRepositoryCustom {
-    List<PartyInfo> findPartyInfoBy(Long matchId);
+    List<PartyInfo> findPartyInfo(Long matchId);
     Optional<PartyInfo> findPartyDetailBy(Long partyId);
 }

--- a/src/main/java/com/playus/twpservice/domain/party/repository/read/custom/PartyReadOnlyRepositoryCustomImpl.java
+++ b/src/main/java/com/playus/twpservice/domain/party/repository/read/custom/PartyReadOnlyRepositoryCustomImpl.java
@@ -59,7 +59,7 @@ public class PartyReadOnlyRepositoryCustomImpl implements PartyReadOnlyRepositor
     }
 
     @Override
-    public Optional<PartyInfo> findPartyDetailBy(Long partyId) {
+    public Optional<PartyInfo> findPartyDetail(Long partyId) {
         MatchOperation matchOperation = match(new Criteria("_id").is(partyId));
 
         LookupOperation partyAgeLookupOperation = lookup("party_age", "_id", "party_id", "partyAge");

--- a/src/main/java/com/playus/twpservice/domain/party/repository/read/custom/PartyReadOnlyRepositoryCustomImpl.java
+++ b/src/main/java/com/playus/twpservice/domain/party/repository/read/custom/PartyReadOnlyRepositoryCustomImpl.java
@@ -24,7 +24,7 @@ public class PartyReadOnlyRepositoryCustomImpl implements PartyReadOnlyRepositor
      * @return
      */
     @Override
-    public List<PartyInfo> findPartyInfoBy(Long matchId) {
+    public List<PartyInfo> findPartyInfo(Long matchId) {
 
         MatchOperation matchOperation = match(new Criteria("match_id").is(matchId));
 

--- a/src/main/java/com/playus/twpservice/domain/party/repository/read/custom/PartyReadOnlyRepositoryCustomImpl.java
+++ b/src/main/java/com/playus/twpservice/domain/party/repository/read/custom/PartyReadOnlyRepositoryCustomImpl.java
@@ -24,7 +24,7 @@ public class PartyReadOnlyRepositoryCustomImpl implements PartyReadOnlyRepositor
      * @return
      */
     @Override
-    public List<PartyInfo> findPartyInfo(Long matchId) {
+    public List<PartyInfo> findPartyInfoList(Long matchId) {
 
         MatchOperation matchOperation = match(new Criteria("match_id").is(matchId));
 

--- a/src/main/java/com/playus/twpservice/domain/party/repository/write/PartyJoinRepository.java
+++ b/src/main/java/com/playus/twpservice/domain/party/repository/write/PartyJoinRepository.java
@@ -5,9 +5,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.Optional;
+
 public interface PartyJoinRepository extends JpaRepository<PartyJoin, Long> {
 
     @Modifying
     @Query("UPDATE PartyJoin p SET p.deletedAt = CURRENT_TIMESTAMP WHERE p.party.id = :partyId")
     void deleteByPartyId(Long partyId);
+
+    @Query("SELECT p FROM PartyJoin p WHERE p.party.id = :partyId AND p.userId = :userId")
+    Optional<PartyJoin> findByPartyIdAndUserId(Long partyId, Long userId);
 }

--- a/src/main/java/com/playus/twpservice/domain/party/service/PartyReadOnlyService.java
+++ b/src/main/java/com/playus/twpservice/domain/party/service/PartyReadOnlyService.java
@@ -40,7 +40,7 @@ public class PartyReadOnlyService {
     }
 
     public PartyDetailResponse getPartyDetail(Long partyId) {
-        PartyInfo partyDetail = partyRepository.findPartyDetailBy(partyId)
+        PartyInfo partyDetail = partyRepository.findPartyDetail(partyId)
                 .orElseThrow(() -> new PartyDocumentException.NotFoundException("직관팟이 존재하지 않습니다!"));
 
         updateUserThumbnailUrls(List.of(partyDetail));

--- a/src/main/java/com/playus/twpservice/domain/party/service/PartyReadOnlyService.java
+++ b/src/main/java/com/playus/twpservice/domain/party/service/PartyReadOnlyService.java
@@ -28,13 +28,13 @@ public class PartyReadOnlyService {
 
     public List<PartyInfoResponse> getPartyInfoListByMatchId(Long matchId) {
 
-        List<PartyInfo> partySummaryList = partyRepository.findPartyInfoBy(matchId);
+        List<PartyInfo> partyInfoList = partyRepository.findPartyInfo(matchId);
 
-        updateUserThumbnailUrls(partySummaryList);
-        updateWriterInfo(partySummaryList);
-        updateMatchDate(partySummaryList, matchId);
+        updateUserThumbnailUrls(partyInfoList);
+        updateWriterInfo(partyInfoList);
+        updateMatchDate(partyInfoList, matchId);
 
-        return partySummaryList.stream()
+        return partyInfoList.stream()
                 .map(PartyInfo::toResponse)
                 .toList();
     }

--- a/src/main/java/com/playus/twpservice/domain/party/service/PartyReadOnlyService.java
+++ b/src/main/java/com/playus/twpservice/domain/party/service/PartyReadOnlyService.java
@@ -28,7 +28,7 @@ public class PartyReadOnlyService {
 
     public List<PartyInfoResponse> getPartyInfoListByMatchId(Long matchId) {
 
-        List<PartyInfo> partyInfoList = partyRepository.findPartyInfo(matchId);
+        List<PartyInfo> partyInfoList = partyRepository.findPartyInfoList(matchId);
 
         updateUserThumbnailUrls(partyInfoList);
         updateWriterInfo(partyInfoList);

--- a/src/main/java/com/playus/twpservice/domain/party/service/PartyService.java
+++ b/src/main/java/com/playus/twpservice/domain/party/service/PartyService.java
@@ -183,6 +183,7 @@ public class PartyService {
         // 4. isApproved 가 false 일 경우 PartyJoin refused 로 바꾸고 response return
         //                  true 일 경우 PartyJoin approved 로 바꿈
         if (request.isApproved()) {
+            party.increaseCurrentParticipants();
             partyJoin.approve();
             partyJoinRepository.save(partyJoin);
         } else {

--- a/src/main/java/com/playus/twpservice/domain/party/service/PartyService.java
+++ b/src/main/java/com/playus/twpservice/domain/party/service/PartyService.java
@@ -191,7 +191,7 @@ public class PartyService {
             return PartyApproveResponse.of("직관팟 가입 신청 거절 성공했습니다!");
         }
 
-        // 5. partyId와 user 가진 ChatRoom 저장
+        // 5. partyId와 user 가진 ChatPart 저장
         ChatRoom chatRoom = chatRoomRepository.findById(party.getChatRoomId())
                 .orElseThrow(() -> new ChatRoomException.NotFoundException("채팅방이 존재하지 않습니다!"));
         chatPartRepository.save(ChatPart.create(applicantUserId, chatRoom.getId()));

--- a/src/main/java/com/playus/twpservice/domain/party/service/PartyService.java
+++ b/src/main/java/com/playus/twpservice/domain/party/service/PartyService.java
@@ -9,6 +9,8 @@ import com.playus.twpservice.domain.chat.repository.ChatRoomRepository;
 import com.playus.twpservice.domain.party.assertion.PartyAssert;
 import com.playus.twpservice.domain.party.document.PartyDocument;
 import com.playus.twpservice.domain.party.dto.apply.PartyApplyResponse;
+import com.playus.twpservice.domain.party.dto.approve.PartyApproveRequest;
+import com.playus.twpservice.domain.party.dto.approve.PartyApproveResponse;
 import com.playus.twpservice.domain.party.dto.create.PartyCreateRequest;
 import com.playus.twpservice.domain.party.dto.create.PartyCreateResponse;
 import com.playus.twpservice.domain.party.dto.delete.PartyDeleteResponse;
@@ -22,7 +24,10 @@ import com.playus.twpservice.domain.party.entity.PartyAge;
 import com.playus.twpservice.domain.party.entity.PartyJoin;
 import com.playus.twpservice.domain.party.entity.PartyThumbnailUrl;
 import com.playus.twpservice.domain.party.enums.PartyAgeGroup;
+import com.playus.twpservice.domain.party.enums.PartyJoinMethod;
 import com.playus.twpservice.domain.party.enums.PartyJoinRequestStatus;
+import com.playus.twpservice.domain.party.exception.document.PartyDocumentException;
+import com.playus.twpservice.domain.party.exception.entity.PartyException;
 import com.playus.twpservice.domain.party.repository.read.PartyJoinReadOnlyRepository;
 import com.playus.twpservice.domain.party.repository.read.PartyReadOnlyRepository;
 import com.playus.twpservice.domain.party.repository.write.PartyAgeRepository;
@@ -114,6 +119,7 @@ public class PartyService {
         return PartyDeleteResponse.of(partyId);
     }
 
+    // user 쪽 merge 되면 나이, 성별 검증 로직 추가하기!
     public void applyPartyFCFS(Long userId, Long partyId) {
         Party party = partyRepository.findById(partyId)
                 .orElseThrow(() -> new NotFoundException("직관팟이 존재하지 않습니다!"));
@@ -133,6 +139,7 @@ public class PartyService {
         chatPartRepository.save(ChatPart.create(userId, chatRoom.getId()));
     }
 
+    // user 쪽 merge 되면 나이, 성별 검증 로직 추가하기!
     public PartyApplyResponse applyParty(Long userId, Long partyId, String requireMessage) {
         Party party = partyRepository.findById(partyId)
                 .orElseThrow(() -> new NotFoundException("직관팟이 존재하지 않습니다!"));
@@ -144,18 +151,53 @@ public class PartyService {
         PartyAssert.isAppliableParty(party);
 
         partyJoinRepository.save(PartyJoin.create(userId, party, PartyJoinRequestStatus.WAIT, requireMessage));
-        party.increaseCurrentParticipants();
-
-        ChatRoom chatRoom = chatRoomRepository.findById(party.getChatRoomId())
-                .orElseThrow(() -> new ChatRoomException.NotFoundException("채팅방이 존재하지 않습니다!"));
-
-        chatPartRepository.save(ChatPart.create(userId, chatRoom.getId()));
 
         return PartyApplyResponse.of("직관팟 가입에 성공했습니다!");
     }
 
     public PresignedUrlForSaveImageResponse generatePresignedUrlForSaveImage(PresignedUrlForSaveImageRequest request) {
         return new PresignedUrlForSaveImageResponse(s3Service.generatePresignedUrl(request.imageFileName()));
+    }
+
+    // 나이, 성별 검증은 이전 승인제 직관팟 신청에서 검증함!
+    public PartyApproveResponse approveParty(Long loginUserId, Long partyId, PartyApproveRequest request) {
+
+        // 1. 직관팟 불러오기
+        Party party = partyRepository.findById(partyId)
+                .orElseThrow(() -> new NotFoundException("직관팟이 존재하지 않습니다!"));
+
+        if (party.getPartyJoinMethod() == PartyJoinMethod.FIRST_COME) {
+            throw new PartyException.InvalidApproveRequestToPartyException("선착순 모집인 직관팟에는 승인 요청을 보낼 수 없습니다!");
+        }
+
+        Long writerId = party.getWriterId();
+        Long applicantUserId = request.applicantUserId();
+
+        // 2. 로그인한 유저가 직관팟 작성자가 맞는지 확인 (작성자 아니면 승인 불가!)
+        PartyAssert.isLoginUserWriter(loginUserId, writerId, "작성자가 아니면 승인할 수 없습니다!");
+
+        // 3. partyId와 applicantUserId 가진 PartyJoin 가져오기
+        PartyJoin partyJoin = partyJoinRepository.findByPartyIdAndUserId(partyId, applicantUserId)
+                .orElseThrow(() -> new NotFoundException("직관팟 지원자가 아닙니다!"));
+
+        // 4. isApproved 가 false 일 경우 PartyJoin refused 로 바꾸고 response return
+        //                  true 일 경우 PartyJoin approved 로 바꿈
+        if (request.isApproved()) {
+            partyJoin.approve();
+            partyJoinRepository.save(partyJoin);
+        } else {
+            partyJoin.refuse();
+            partyJoinRepository.save(partyJoin);
+            return PartyApproveResponse.of("직관팟 가입 신청 거절 성공했습니다!");
+        }
+
+        // 5. partyId와 user 가진 ChatRoom 저장
+        ChatRoom chatRoom = chatRoomRepository.findById(party.getChatRoomId())
+                .orElseThrow(() -> new ChatRoomException.NotFoundException("채팅방이 존재하지 않습니다!"));
+        chatPartRepository.save(ChatPart.create(applicantUserId, chatRoom.getId()));
+
+        // 6. response return
+        return PartyApproveResponse.of("직관팟 가입 신청 승인 성공했습니다!");
     }
 
 
@@ -212,4 +254,6 @@ public class PartyService {
                         PartyJoinRequestStatus.throwIfAlreadyAppliedToParty(partyJoinDocument.getPartyJoinRequestStatus())
                 );
     }
+
+
 }

--- a/src/main/java/com/playus/twpservice/domain/party/specification/PartyControllerSpecification.java
+++ b/src/main/java/com/playus/twpservice/domain/party/specification/PartyControllerSpecification.java
@@ -1705,7 +1705,7 @@ public interface PartyControllerSpecification {
 
     @Tag(name = "Patch", description = "방장으로서 승인제 직관팟 신청 유저 승인 API")
     @Operation(
-            summary = "",
+            summary = "승인제 직관팟 신청 승인/거절",
             description = "직관팟 신청자에 대해 승인 여부를 결정합니다.",
             security = @SecurityRequirement(name = "Access"),
             parameters = {
@@ -1714,7 +1714,7 @@ public interface PartyControllerSpecification {
                             description = "JWT Access Token (쿠키)",
                             in = ParameterIn.COOKIE,
                             required = true,
-                            example = ""
+                            example = "abcd"
                     ),
                     @Parameter(
                             name = "partyId",

--- a/src/main/java/com/playus/twpservice/domain/party/specification/PartyControllerSpecification.java
+++ b/src/main/java/com/playus/twpservice/domain/party/specification/PartyControllerSpecification.java
@@ -1952,21 +1952,6 @@ public interface PartyControllerSpecification {
                     )
             ),
             @ApiResponse(
-                    responseCode = "409", description = "이미 가입 (혹은 대기) 상태인 직관팟에 다시 신청할 경우 발생",
-                    content = @Content(
-                            mediaType = APPLICATION_JSON_VALUE,
-                            examples = @ExampleObject(
-                                    value = """
-                                            {
-                                              "code": 409,
-                                              "status": "CONFLICT",
-                                              "message": "이미 가입된 직관팟입니다!"
-                                            }
-                                            """
-                            )
-                    )
-            ),
-            @ApiResponse(
                     responseCode = "500", description = "서버 내부 오류",
                     content = @Content(
                             mediaType = APPLICATION_JSON_VALUE,

--- a/src/main/java/com/playus/twpservice/domain/party/specification/PartyControllerSpecification.java
+++ b/src/main/java/com/playus/twpservice/domain/party/specification/PartyControllerSpecification.java
@@ -1877,7 +1877,7 @@ public interface PartyControllerSpecification {
                     )
             ),
             @ApiResponse(
-                    responseCode = "403", description = "거절된 사용자가 다시 지원하려는 경우 발생",
+                    responseCode = "401", description = "거절된 사용자가 다시 지원하려는 경우 발생",
                     content = @Content(
                             mediaType = APPLICATION_JSON_VALUE,
                             examples = @ExampleObject(

--- a/src/main/java/com/playus/twpservice/domain/party/specification/PartyControllerSpecification.java
+++ b/src/main/java/com/playus/twpservice/domain/party/specification/PartyControllerSpecification.java
@@ -3,6 +3,8 @@ package com.playus.twpservice.domain.party.specification;
 import com.playus.twpservice.domain.common.security.CustomOAuth2User;
 import com.playus.twpservice.domain.party.dto.apply.PartyApplyResponse;
 import com.playus.twpservice.domain.party.dto.apply.PartyApproveApplyRequest;
+import com.playus.twpservice.domain.party.dto.approve.PartyApproveRequest;
+import com.playus.twpservice.domain.party.dto.approve.PartyApproveResponse;
 import com.playus.twpservice.domain.party.dto.create.PartyCreateRequest;
 import com.playus.twpservice.domain.party.dto.create.PartyCreateResponse;
 import com.playus.twpservice.domain.party.dto.delete.PartyDeleteResponse;
@@ -28,6 +30,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
 import java.util.List;
 
@@ -530,12 +533,12 @@ public interface PartyControllerSpecification {
             security = @SecurityRequirement(name = "Access"),
             parameters = {
                     @Parameter(
-                    name = "Access",
-                    description = "JWT Access Token (쿠키)",
-                    in = ParameterIn.COOKIE,
-                    required = true,
-                    example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
-            ),
+                            name = "Access",
+                            description = "JWT Access Token (쿠키)",
+                            in = ParameterIn.COOKIE,
+                            required = true,
+                            example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                    ),
                     @Parameter(
                             name = "matchId",
                             description = "경기 ID",
@@ -1331,7 +1334,6 @@ public interface PartyControllerSpecification {
                                     @Valid @Parameter(description = "API 경로로 들어오는 직관팟 ID 위해 작성", required = true) PartyIdRequest idRequest);
 
 
-
     @Tag(name = "Post", description = "직관팟 선착순 신청 API")
     @Operation(
             summary = "직관팟 선착순 신청",
@@ -1699,4 +1701,288 @@ public interface PartyControllerSpecification {
     PartyApplyResponse applyParty(@Parameter(hidden = true) CustomOAuth2User principal,
                                   @Valid @Parameter(description = "API 경로로 들어오는 직관팟 ID 위해 작성", required = true) PartyIdRequest idRequest,
                                   @Valid @Parameter(description = "직관팟 신청 시 방장에게 보여줄 requireMessage 작성") PartyApproveApplyRequest request);
+
+
+    @Tag(name = "Patch", description = "방장으로서 승인제 직관팟 신청 유저 승인 API")
+    @Operation(
+            summary = "",
+            description = "직관팟 신청자에 대해 승인 여부를 결정합니다.",
+            security = @SecurityRequirement(name = "Access"),
+            parameters = {
+                    @Parameter(
+                            name = "Access",
+                            description = "JWT Access Token (쿠키)",
+                            in = ParameterIn.COOKIE,
+                            required = true,
+                            example = ""
+                    ),
+                    @Parameter(
+                            name = "partyId",
+                            in = ParameterIn.PATH,
+                            description = "직관팟 ID",
+                            required = true,
+                            example = "1"
+                    )
+            },
+            requestBody = @RequestBody(
+                    required = true,
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    name = "승인제 직관팟 승인 여부 결정",
+                                    value = """
+                                            {
+                                              "applicantUserId": 1,
+                                              "isApproved" : true
+                                            }
+                                            """
+                            )
+                    )
+            )
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "승인",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    name = "승인제 직관팟 승인 응답 예시",
+                                    value = """
+                                            {
+                                              "message": "직관팟 가입 신청 승인 성공했습니다!"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "200", description = "거부",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    name = "승인제 직관팟 거부 응답 예시",
+                                    value = """
+                                            {
+                                              "message": "직관팟 가입 신청 거절 성공했습니다!"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+
+            @ApiResponse(
+                    responseCode = "400", description = "직관팟 ID가 1 미만일 경우 발생",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 400,
+                                              "status": "BAD_REQUEST",
+                                              "message": "직관팟 ID는 1 이상이여야 합니다!"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "지원자 ID가 비어있는 경우 발생",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 400,
+                                              "status": "BAD_REQUEST",
+                                              "message": "지원자 ID는 필수입니다!"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "지원자 ID가 1 미만일 경우 발생",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 400,
+                                              "status": "BAD_REQUEST",
+                                              "message": "지원자 ID는 1 이상이여야 합니다!"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "지원자 승인 여부가 비어있을 때 발생",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 400,
+                                              "status": "BAD_REQUEST",
+                                              "message": "승인 여부는 필수입니다!"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+
+            @ApiResponse(
+                    responseCode = "400", description = "선착순 직관팟에 승인 요청 보낼 시 발생",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 400,
+                                              "status": "BAD_REQUEST",
+                                              "message": "선착순 모집인 직관팟에는 승인 요청을 보낼 수 없습니다!"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "직관팟 방장이 아닌 사람이 승인 API 날릴 시 발생",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 400,
+                                              "status": "BAD_REQUEST",
+                                              "message": "작성자가 아니면 승인할 수 없습니다!"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401", description = "인증 실패",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 401,
+                                              "status": "UNAUTHORIZED",
+                                              "message": "유효하지 않은 토큰입니다."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403", description = "거절된 사용자가 다시 지원하려는 경우 발생",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 401,
+                                              "status": "UNAUTHORIZED",
+                                              "message": "신청이 거절되었으면 다시 지원할 수 없습니다!"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404", description = "직관팟 ID로 직관팟을 찾을 수 없는 경우 발생",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 404,
+                                              "status": "NOT_FOUND",
+                                              "message": "직관팟이 존재하지 않습니다!"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404", description = "이전에 지원한 기록이 없는 경우 발생",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 404,
+                                              "status": "NOT_FOUND",
+                                              "message": "직관팟 지원자가 아닙니다!"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404", description = "채팅방을 찾을 수 없을 때 발생",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 404,
+                                              "status": "NOT_FOUND",
+                                              "message": "채팅방이 존재하지 않습니다!"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "409", description = "직관팟 정원이 초과될 경우 발생",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 409,
+                                              "status": "CONFLICT",
+                                              "message": "직관팟 정원이 초과되었습니다!"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "409", description = "이미 가입 (혹은 대기) 상태인 직관팟에 다시 신청할 경우 발생",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 409,
+                                              "status": "CONFLICT",
+                                              "message": "이미 가입된 직관팟입니다!"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500", description = "서버 내부 오류",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 500,
+                                              "status": "INTERNAL_SERVER_ERROR",
+                                              "message": "서버 내부 오류가 발생했습니다. 관리자에게 문의해 주세요."
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    PartyApproveResponse approveParty(@Parameter(hidden = true) CustomOAuth2User principal,
+                                      @Valid @Parameter(description = "API 경로로 들어오는 직관팟 ID 위해 작성", required = true) PartyIdRequest idRequest,
+                                      @Valid @Parameter(description = "방장이 승인할 userId와 승인 여부 작성") PartyApproveRequest request);
 }

--- a/src/main/java/com/playus/twpservice/global/exception/ExceptionAdvice.java
+++ b/src/main/java/com/playus/twpservice/global/exception/ExceptionAdvice.java
@@ -45,6 +45,16 @@ public class ExceptionAdvice {
         return ErrorResponse.badRequestError(errorMessage);
     }
 
+    @ResponseStatus(BAD_REQUEST)
+    @ExceptionHandler({
+            PartyException.InvalidApproveRequestToPartyException.class
+    })
+    public ErrorResponse handleInvalidApproveRequestException(Exception e) {
+        String errorMessage = e.getMessage();
+        log.warn(errorMessage);
+        return ErrorResponse.badRequestError(errorMessage);
+    }
+
     @ResponseStatus(FORBIDDEN)
     @ExceptionHandler({
             PartyJoinDocumentException.RefusedApplyUserException.class

--- a/src/main/java/com/playus/twpservice/global/exception/ExceptionAdvice.java
+++ b/src/main/java/com/playus/twpservice/global/exception/ExceptionAdvice.java
@@ -47,7 +47,8 @@ public class ExceptionAdvice {
 
     @ResponseStatus(BAD_REQUEST)
     @ExceptionHandler({
-            PartyException.InvalidApproveRequestToPartyException.class
+            PartyException.InvalidApproveRequestToPartyException.class,
+            PartyException.NotPartyWriterException.class
     })
     public ErrorResponse handleInvalidApproveRequestException(Exception e) {
         String errorMessage = e.getMessage();

--- a/src/main/java/com/playus/twpservice/global/s3/S3Config.java
+++ b/src/main/java/com/playus/twpservice/global/s3/S3Config.java
@@ -8,6 +8,7 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 import java.net.URI;
@@ -48,6 +49,9 @@ public class S3Config {
                                 AwsBasicCredentials.create(accessKey, secretKey)
                         )
                 )
+                .serviceConfiguration(S3Configuration.builder()
+                        .pathStyleAccessEnabled(true)
+                        .build())
                 .region(Region.of("kr-central-2"))
                 .build();
     }

--- a/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
@@ -1,10 +1,13 @@
 package com.playus.twpservice.domain.party.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.playus.twpservice.ControllerTestSupport;
 import com.playus.twpservice.domain.common.security.CustomOAuth2User;
 import com.playus.twpservice.domain.common.security.Role;
 import com.playus.twpservice.domain.party.dto.apply.PartyApplyResponse;
 import com.playus.twpservice.domain.party.dto.apply.PartyApproveApplyRequest;
+import com.playus.twpservice.domain.party.dto.approve.PartyApproveRequest;
+import com.playus.twpservice.domain.party.dto.approve.PartyApproveResponse;
 import com.playus.twpservice.domain.party.dto.delete.PartyDeleteResponse;
 import com.playus.twpservice.domain.party.dto.detail.PartyDetailResponse;
 import com.playus.twpservice.domain.party.dto.info.PartyInfoResponse;
@@ -44,7 +47,7 @@ class PartyControllerTest extends ControllerTestSupport {
 
     Long userId = 1L;
     List<String> thumbnailUrl = List.of("http://image.com");
-//    UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(userId, null, List.of(new SimpleGrantedAuthority("USER")));
+//    UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(applicantUserId, null, List.of(new SimpleGrantedAuthority("USER")));
 
     private UsernamePasswordAuthenticationToken token;
 
@@ -1124,6 +1127,111 @@ class PartyControllerTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.code").value("400"))
                 .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
                 .andExpect(jsonPath("$.message").value("직관팟 ID는 1 이상이어야 합니다!"));
+    }
+
+    @DisplayName("직관팟을 승인할 수 있다.")
+    @Test
+    void approveParty() throws Exception {
+        // given
+        Long partyId = 1L;
+        PartyApproveRequest request = PartyApproveRequest.of(1L, Boolean.TRUE);
+        PartyApproveResponse response = PartyApproveResponse.of("직관팟 가입 신청 승인 성공했습니다!");
+        given(partyService.approveParty(any(Long.class), any(Long.class), any(PartyApproveRequest.class)))
+                .willReturn(response);
+
+        // when // then
+        mockMvc.perform(patch("/party/" + partyId + "/approve")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(APPLICATION_JSON)
+                        .with(authentication(token)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("직관팟 가입 신청 승인 성공했습니다!"));
+    }
+
+    @DisplayName("직관팟을 승인할 때 직관팟의 ID는 1 이상이여야 한다.")
+    @CsvSource(value = {"0", "-1", "-100", "-1000", "-10000"})
+    @ParameterizedTest(name = "invalidPartyIdStr = {0}")
+    void approveParty_INVALID_PARTYID(String invalidPartyStr) throws Exception {
+        // given
+        PartyApproveRequest request = PartyApproveRequest.of(1L, Boolean.TRUE);
+
+        // when // then
+        mockMvc.perform(patch("/party/" + invalidPartyStr + "/approve")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(APPLICATION_JSON)
+                        .with(authentication(token)))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("400"))
+                .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+                .andExpect(jsonPath("$.message").value("직관팟 ID는 1 이상이어야 합니다!"));
+    }
+
+    @DisplayName("직관팟을 승인할 때 지원자의 ID는 필수이다.")
+    @Test
+    void approveParty_EMPTY_APPLICANT_ID() throws Exception {
+        // given
+        Long partyId = 1L;
+        PartyApproveRequest request = PartyApproveRequest.of(null, Boolean.TRUE);
+        PartyApproveResponse response = PartyApproveResponse.of("직관팟 가입 신청 승인 성공했습니다!");
+        given(partyService.approveParty(any(Long.class), any(Long.class), any(PartyApproveRequest.class)))
+                .willReturn(response);
+
+        // when // then
+        mockMvc.perform(patch("/party/" + partyId + "/approve")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(APPLICATION_JSON)
+                        .with(authentication(token)))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("400"))
+                .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+                .andExpect(jsonPath("$.message").value("지원자 ID는 필수입니다!"));
+    }
+
+    @DisplayName("직관팟을 승인할 때 지원자의 ID는 1 이상이여야 한다.")
+    @Test
+    void approveParty_NEGATIVE_APPLICANT() throws Exception {
+        // given
+        Long partyId = 1L;
+        PartyApproveRequest request = PartyApproveRequest.of(null, Boolean.TRUE);
+        PartyApproveResponse response = PartyApproveResponse.of("직관팟 가입 신청 승인 성공했습니다!");
+        given(partyService.approveParty(any(Long.class), any(Long.class), any(PartyApproveRequest.class)))
+                .willReturn(response);
+
+        // when // then
+        mockMvc.perform(patch("/party/" + partyId + "/approve")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(APPLICATION_JSON)
+                        .with(authentication(token)))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("400"))
+                .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+                .andExpect(jsonPath("$.message").value("지원자 ID는 필수입니다!"));
+    }
+
+    @DisplayName("직관팟을 승인할 때 승인 여부는 필수이다")
+    @Test
+    void approveParty_EMPTY_IS_APPROVED() throws Exception {
+        // given
+        Long partyId = 1L;
+        PartyApproveRequest request = PartyApproveRequest.of(1L, null);
+        PartyApproveResponse response = PartyApproveResponse.of("직관팟 가입 신청 승인 성공했습니다!");
+        given(partyService.approveParty(any(Long.class), any(Long.class), any(PartyApproveRequest.class)))
+                .willReturn(response);
+
+        // when // then
+        mockMvc.perform(patch("/party/" + partyId + "/approve")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(APPLICATION_JSON)
+                        .with(authentication(token)))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("400"))
+                .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+                .andExpect(jsonPath("$.message").value("승인 여부는 필수입니다!"));
     }
 
     private void assertBadRequestOfPartyCreateRequest(PartyCreateRequest request, String requestUri, String expectedResult) throws Exception {

--- a/src/test/java/com/playus/twpservice/domain/party/repository/read/PartyReadOnlyRepositoryTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/repository/read/PartyReadOnlyRepositoryTest.java
@@ -71,7 +71,7 @@ class PartyReadOnlyRepositoryTest extends IntegrationTestSupport {
         partyJoinReadOnlyRepository.saveAll(List.of(pj1, pj2));
 
         // when
-        List<PartyInfo> result = partyReadOnlyRepository.findPartyInfoBy(matchId);
+        List<PartyInfo> result = partyReadOnlyRepository.findPartyInfo(matchId);
 
         // then
         assertThat(result).hasSize(2)
@@ -90,7 +90,7 @@ class PartyReadOnlyRepositoryTest extends IntegrationTestSupport {
         Long matchId = 1L;
 
         // when
-        List<PartyInfo> result = partyReadOnlyRepository.findPartyInfoBy(matchId);
+        List<PartyInfo> result = partyReadOnlyRepository.findPartyInfo(matchId);
 
         // then
         assertThat(result).isEmpty();

--- a/src/test/java/com/playus/twpservice/domain/party/repository/read/PartyReadOnlyRepositoryTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/repository/read/PartyReadOnlyRepositoryTest.java
@@ -124,7 +124,7 @@ class PartyReadOnlyRepositoryTest extends IntegrationTestSupport {
         partyJoinReadOnlyRepository.saveAll(List.of(pj1, pj2));
 
         // when
-        Optional<PartyInfo> result = partyReadOnlyRepository.findPartyDetailBy(partyId);
+        Optional<PartyInfo> result = partyReadOnlyRepository.findPartyDetail(partyId);
 
         // then
         assertThat(result).isPresent();
@@ -146,7 +146,7 @@ class PartyReadOnlyRepositoryTest extends IntegrationTestSupport {
         Long notFoundPartyId = 5L;
 
         // when
-        Optional<PartyInfo> result = partyReadOnlyRepository.findPartyDetailBy(notFoundPartyId);
+        Optional<PartyInfo> result = partyReadOnlyRepository.findPartyDetail(notFoundPartyId);
 
         // then
         assertThat(result).isEmpty();

--- a/src/test/java/com/playus/twpservice/domain/party/repository/read/PartyReadOnlyRepositoryTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/repository/read/PartyReadOnlyRepositoryTest.java
@@ -71,7 +71,7 @@ class PartyReadOnlyRepositoryTest extends IntegrationTestSupport {
         partyJoinReadOnlyRepository.saveAll(List.of(pj1, pj2));
 
         // when
-        List<PartyInfo> result = partyReadOnlyRepository.findPartyInfo(matchId);
+        List<PartyInfo> result = partyReadOnlyRepository.findPartyInfoList(matchId);
 
         // then
         assertThat(result).hasSize(2)
@@ -90,7 +90,7 @@ class PartyReadOnlyRepositoryTest extends IntegrationTestSupport {
         Long matchId = 1L;
 
         // when
-        List<PartyInfo> result = partyReadOnlyRepository.findPartyInfo(matchId);
+        List<PartyInfo> result = partyReadOnlyRepository.findPartyInfoList(matchId);
 
         // then
         assertThat(result).isEmpty();

--- a/src/test/java/com/playus/twpservice/domain/party/service/PartyServiceTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/service/PartyServiceTest.java
@@ -10,6 +10,8 @@ import com.playus.twpservice.domain.chat.repository.ChatPartRepository;
 import com.playus.twpservice.domain.chat.repository.ChatRoomRepository;
 import com.playus.twpservice.domain.party.document.PartyDocument;
 import com.playus.twpservice.domain.party.document.PartyJoinDocument;
+import com.playus.twpservice.domain.party.dto.approve.PartyApproveRequest;
+import com.playus.twpservice.domain.party.dto.approve.PartyApproveResponse;
 import com.playus.twpservice.domain.party.dto.create.PartyCreateRequest;
 import com.playus.twpservice.domain.party.dto.create.PartyCreateResponse;
 import com.playus.twpservice.domain.common.request.PartyIdRequest;
@@ -25,6 +27,7 @@ import com.playus.twpservice.domain.party.entity.PartyThumbnailUrl;
 import com.playus.twpservice.domain.party.enums.PartyGender;
 import com.playus.twpservice.domain.party.enums.PartyJoinMethod;
 import com.playus.twpservice.domain.party.enums.PartyJoinRequestStatus;
+import com.playus.twpservice.domain.party.exception.document.PartyDocumentException;
 import com.playus.twpservice.domain.party.exception.document.PartyJoinDocumentException;
 import com.playus.twpservice.domain.party.exception.entity.PartyException;
 import com.playus.twpservice.domain.party.repository.read.PartyJoinReadOnlyRepository;
@@ -536,7 +539,7 @@ class PartyServiceTest extends IntegrationTestSupport {
         ChatRoom chatRoom = chatRoomRepository.save(ChatRoom.create("CHATROOM-1"));
 
         Party party = partyRepository.save(Party.create("title", "설명", 1L, 10L,
-                PartyGender.FEMALE, PartyJoinMethod.FIRST_COME, writerId, matchId)
+                        PartyGender.FEMALE, PartyJoinMethod.FIRST_COME, writerId, matchId)
                 .assignChatRoom(chatRoom.getId()).setCurrentParticipantsForOnlyTest(10L));
 
         partyJoinReadOnlyRepository.saveAll(List.of(
@@ -599,8 +602,8 @@ class PartyServiceTest extends IntegrationTestSupport {
 
         // then
         assertThat(partyJoinRepository.count()).isEqualTo(1); // partyJoin 에 작성자는 존재 X
-        assertThat(chatPartRepository.count()).isEqualTo(1);
-        assertThat(partyRepository.findAll().get(0).getCurrentParticipants()).isEqualTo(2);
+        assertThat(chatPartRepository.count()).isEqualTo(0);
+        assertThat(partyRepository.findAll().get(0).getCurrentParticipants()).isEqualTo(1);
 
         assertThat(partyJoinRepository.findAll().get(0))
                 .extracting("partyJoinRequestStatus", "requireMessage")
@@ -703,8 +706,8 @@ class PartyServiceTest extends IntegrationTestSupport {
 
         // then
         assertThat(partyJoinRepository.count()).isEqualTo(1); // partyJoin 에 작성자는 존재 X
-        assertThat(chatPartRepository.count()).isEqualTo(1);
-        assertThat(partyRepository.findAll().get(0).getCurrentParticipants()).isEqualTo(2);
+        assertThat(chatPartRepository.count()).isEqualTo(0);
+        assertThat(partyRepository.findAll().get(0).getCurrentParticipants()).isEqualTo(1);
 
         assertThat(partyJoinRepository.findAll().get(0))
                 .extracting("partyJoinRequestStatus", "requireMessage")
@@ -753,24 +756,152 @@ class PartyServiceTest extends IntegrationTestSupport {
                 .hasMessage("직관팟 정원이 초과되었습니다!");
     }
 
-    @DisplayName("존재하지 않는 승인제 채팅방에는 들어갈 수 없다.")
+    @DisplayName("승인제 직관팟에 대한 참여 요청을 승인할 수 있다.")
     @Test
-    void applyParty_INVALID_CHATROOM() {
-
+    void approveParty() {
         // given
-        Long writerId = 1L;
-        Long matchId = 1L;
-        Long userId = 5L;
+        Long loginUserId = 1L;
+        Long applicantUserId = 2L;
+        PartyApproveRequest request = PartyApproveRequest.of(applicantUserId, true);
 
         ChatRoom chatRoom = chatRoomRepository.save(ChatRoom.create("CHATROOM-1"));
-
         Party party = partyRepository.save(Party.create("title", "설명", 1L, 10L,
-                PartyGender.FEMALE, PartyJoinMethod.RESERVATION, writerId, matchId).assignChatRoom(chatRoom.getId() + "a"));
+                PartyGender.MALE, PartyJoinMethod.RESERVATION, loginUserId, 1L).assignChatRoom(chatRoom.getId()));
+        Long partyId = party.getId();
 
+        partyJoinRepository.saveAll(List.of(
+           PartyJoin.create(applicantUserId, party, PartyJoinRequestStatus.WAIT, "참여 희망합니다!")
+        ));
+
+        // when
+        PartyApproveResponse response = partyService.approveParty(loginUserId, partyId, request);
+
+        // then
+        assertThat(response.message()).isEqualTo("직관팟 가입 신청 승인 성공했습니다!");
+        assertThat(partyJoinRepository.findAll().get(0))
+                .extracting("partyJoinRequestStatus", "requireMessage")
+                .containsExactly(PartyJoinRequestStatus.ACCEPT, "참여 희망합니다!");
+        assertThat(chatPartRepository.findAll().get(0))
+                .extracting("userId", "chatRoomId")
+                .containsExactly(applicantUserId, chatRoom.getId());
+    }
+
+    @DisplayName("승인제 직관팟에 대한 참여 요청을 거절할 수 있다.")
+    @Test
+    void approveParty_REFUSE() {
+        // given
+        Long loginUserId = 1L;
+        Long applicantUserId = 2L;
+        PartyApproveRequest request = PartyApproveRequest.of(applicantUserId, false);
+
+        ChatRoom chatRoom = chatRoomRepository.save(ChatRoom.create("CHATROOM-1"));
+        Party party = partyRepository.save(Party.create("title", "설명", 1L, 10L,
+                PartyGender.MALE, PartyJoinMethod.RESERVATION, loginUserId, 1L).assignChatRoom(chatRoom.getId()));
+        Long partyId = party.getId();
+
+        partyJoinRepository.saveAll(List.of(
+                PartyJoin.create(applicantUserId, party, PartyJoinRequestStatus.WAIT, "참여 희망합니다!")
+        ));
+
+        // when
+        PartyApproveResponse response = partyService.approveParty(loginUserId, partyId, request);
+
+        // then
+        assertThat(response.message()).isEqualTo("직관팟 가입 신청 거절 성공했습니다!");
+        assertThat(partyJoinRepository.findAll().get(0))
+                .extracting("partyJoinRequestStatus", "requireMessage")
+                .containsExactly(PartyJoinRequestStatus.REFUSE, "참여 희망합니다!");
+        assertThat(chatPartRepository.count()).isZero();
+    }
+
+    @DisplayName("존재하지 않는 승인제 직관팟에 대해서는 승인 요청을 날릴 수 없다..")
+    @Test
+    void approveParty_NOT_FOUND() {
+        // given
+        Long loginUserId = 1L;
+        Long applicantUserId = 2L;
+        PartyApproveRequest request = PartyApproveRequest.of(applicantUserId, true);
+
+        ChatRoom chatRoom = chatRoomRepository.save(ChatRoom.create("CHATROOM-1"));
+        Party party = partyRepository.save(Party.create("title", "설명", 1L, 10L,
+                PartyGender.MALE, PartyJoinMethod.RESERVATION, loginUserId, 1L).assignChatRoom(chatRoom.getId()));
+        partyJoinRepository.saveAll(List.of(
+                PartyJoin.create(applicantUserId, party, PartyJoinRequestStatus.WAIT, "참여 희망합니다!")
+        ));
 
         // when // then
-        assertThatThrownBy(() -> partyService.applyParty(userId, party.getId(), "참여 희망합니다!"))
-                .isInstanceOf(ChatRoomException.NotFoundException.class)
-                .hasMessage("채팅방이 존재하지 않습니다!");
+        assertThatThrownBy(() -> partyService.approveParty(loginUserId, party.getId() + 1, request))
+                .isInstanceOf(PartyException.NotFoundException.class)
+                .hasMessage("직관팟이 존재하지 않습니다!");
     }
+
+    @DisplayName("선착순 직관팟에 대해 승인 요청을 날릴 수 없다.")
+    @Test
+    void approveParty_NOT_FCFS() {
+        // given
+        Long loginUserId = 1L;
+        Long applicantUserId = 2L;
+        PartyApproveRequest request = PartyApproveRequest.of(applicantUserId, true);
+
+        ChatRoom chatRoom = chatRoomRepository.save(ChatRoom.create("CHATROOM-1"));
+        Party party = partyRepository.save(Party.create("title", "설명", 1L, 10L,
+                PartyGender.MALE, PartyJoinMethod.FIRST_COME, loginUserId, 1L).assignChatRoom(chatRoom.getId()));
+        Long partyId = party.getId();
+
+        partyJoinRepository.saveAll(List.of(
+                PartyJoin.create(applicantUserId, party, PartyJoinRequestStatus.WAIT, "참여 희망합니다!")
+        ));
+
+        // when // then
+        assertThatThrownBy(() -> partyService.approveParty(loginUserId, partyId, request))
+                .isInstanceOf(PartyException.InvalidApproveRequestToPartyException.class)
+                .hasMessage("선착순 모집인 직관팟에는 승인 요청을 보낼 수 없습니다!");
+    }
+
+    @DisplayName("오직 작성자만 직관팟에 대해 승인할 수 있습니다.")
+    @Test
+    void approveParty_ONLY_WRITER_CAN_APPROVE() {
+        // given
+        Long loginUserId = 1L;
+        Long applicantUserId = 2L;
+        PartyApproveRequest request = PartyApproveRequest.of(applicantUserId, true);
+
+        ChatRoom chatRoom = chatRoomRepository.save(ChatRoom.create("CHATROOM-1"));
+        Party party = partyRepository.save(Party.create("title", "설명", 1L, 10L,
+                PartyGender.MALE, PartyJoinMethod.RESERVATION, loginUserId + 1, 1L).assignChatRoom(chatRoom.getId()));
+        Long partyId = party.getId();
+
+        partyJoinRepository.saveAll(List.of(
+                PartyJoin.create(applicantUserId, party, PartyJoinRequestStatus.WAIT, "참여 희망합니다!")
+        ));
+
+        // when // then
+        assertThatThrownBy(() -> partyService.approveParty(loginUserId, partyId, request))
+                .isInstanceOf(PartyException.NotPartyWriterException.class)
+                .hasMessage("작성자가 아니면 승인할 수 없습니다!");
+    }
+
+    @DisplayName("직관팟 지원자가 아닌 경우에는 승인할 수 없다.")
+    @Test
+    void approveParty_NOT_APPLICANT() {
+        // given
+        Long loginUserId = 1L;
+        Long applicantUserId = 2L;
+        PartyApproveRequest request = PartyApproveRequest.of(applicantUserId, true);
+
+        ChatRoom chatRoom = chatRoomRepository.save(ChatRoom.create("CHATROOM-1"));
+        Party party = partyRepository.save(Party.create("title", "설명", 1L, 10L,
+                PartyGender.MALE, PartyJoinMethod.RESERVATION, loginUserId, 1L).assignChatRoom(chatRoom.getId()));
+        Long partyId = party.getId();
+
+        partyJoinRepository.saveAll(List.of(
+                PartyJoin.create(applicantUserId + 1, party, PartyJoinRequestStatus.WAIT, "참여 희망합니다!")
+        ));
+
+        // when // then
+        assertThatThrownBy(() -> partyService.approveParty(loginUserId, partyId, request))
+                .isInstanceOf(PartyException.NotFoundException.class)
+                .hasMessage("직관팟 지원자가 아닙니다!");
+    }
+
 }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
직관팟 승인 여부 변경 API 구현햇습니다. 관련해서는 API 명세서 참고해주세요.

---

## 🔗 관련 이슈
- closes #37 

---

## 💡 추가 사항
Presigned URL 백엔드 기반에서 되는 거 성공햇고 Slack에 관련해서 올렷습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 파티 리더가 승인제 파티의 참가 신청을 승인 또는 거절할 수 있는 PATCH API 엔드포인트가 추가되었습니다.
  - 승인/거절 요청 및 응답을 위한 새로운 요청 및 응답 객체가 도입되었습니다.
  - 파티 참가 신청 승인 및 거절 처리 기능이 서비스에 추가되었습니다.

- **버그 수정**
  - S3 Presigner의 경로 스타일 접근이 명시적으로 활성화되어 S3 접근 호환성이 개선되었습니다.

- **문서화**
  - 승인/거절 기능에 대한 API 명세가 추가되어 다양한 응답 및 오류 케이스가 문서화되었습니다.

- **테스트**
  - 파티 승인/거절 기능에 대한 컨트롤러 및 서비스 테스트가 추가되어 정상 동작 및 예외 상황이 검증됩니다.
  - 저장소 메서드명 변경에 따른 테스트 코드가 수정되었습니다.

- **기타**
  - AWS SDK S3 버전이 2.31.45로 업데이트되었습니다.
  - 일부 메서드 및 변수명이 일관성 있게 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->