### PR TITLE
CS-289 feat/직관팟 탈퇴

### DIFF
--- a/src/main/java/com/playus/twpservice/domain/party/assertion/PartyAssert.java
+++ b/src/main/java/com/playus/twpservice/domain/party/assertion/PartyAssert.java
@@ -3,6 +3,7 @@ package com.playus.twpservice.domain.party.assertion;
 import com.playus.twpservice.domain.common.security.Gender;
 import com.playus.twpservice.domain.party.entity.Party;
 import com.playus.twpservice.domain.party.enums.PartyAgeGroup;
+import com.playus.twpservice.domain.party.enums.PartyJoinRequestStatus;
 import org.springframework.util.Assert;
 
 import java.util.List;
@@ -40,6 +41,16 @@ public class PartyAssert extends Assert {
         // 400
         if (!partyAgeGroupList.contains(userAgeGroup)) {
             throw new NotAllowedPartyConditionException("직관팟 나이에 맞지 않습니다!");
+        }
+    }
+
+    public static void isApplicantOfParty(PartyJoinRequestStatus partyJoinRequestStatus) {
+        if (partyJoinRequestStatus == PartyJoinRequestStatus.WAIT) {
+            throw new NotAllowedPartyJoinRequestStatusException("대기 상태인 유저는 직관팟 신청을 취소해주세요!");
+        }
+
+        if (partyJoinRequestStatus == PartyJoinRequestStatus.REFUSE) {
+            throw new NotAllowedPartyJoinRequestStatusException("직관팟 참여가 이미 거절되었습니다!");
         }
     }
 }

--- a/src/main/java/com/playus/twpservice/domain/party/assertion/PartyAssert.java
+++ b/src/main/java/com/playus/twpservice/domain/party/assertion/PartyAssert.java
@@ -44,7 +44,7 @@ public class PartyAssert extends Assert {
         }
     }
 
-    public static void isApplicantOfParty(PartyJoinRequestStatus partyJoinRequestStatus) {
+    public static void isAcceptedUser(PartyJoinRequestStatus partyJoinRequestStatus) {
         if (partyJoinRequestStatus == PartyJoinRequestStatus.WAIT) {
             throw new NotAllowedPartyJoinRequestStatusException("대기 상태인 유저는 직관팟 신청을 취소해주세요!");
         }

--- a/src/main/java/com/playus/twpservice/domain/party/controller/PartyController.java
+++ b/src/main/java/com/playus/twpservice/domain/party/controller/PartyController.java
@@ -14,6 +14,7 @@ import com.playus.twpservice.domain.party.dto.info.PartyInfoResponse;
 import com.playus.twpservice.domain.party.dto.create.PartyCreateRequest;
 import com.playus.twpservice.domain.party.dto.create.PartyCreateResponse;
 import com.playus.twpservice.domain.common.request.PartyIdRequest;
+import com.playus.twpservice.domain.party.dto.leave.PartyLeaveResponse;
 import com.playus.twpservice.domain.party.dto.update.PartyUpdateRequest;
 import com.playus.twpservice.domain.party.dto.update.PartyUpdateResponse;
 import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageRequest;
@@ -92,6 +93,12 @@ public class PartyController implements PartyControllerSpecification {
     public List<PartyAppliedUserResponse> getAppliedUsers(@AuthenticationPrincipal CustomOAuth2User principal,
                                                           @Valid PartyIdRequest idRequest) {
         return partyReadOnlyService.getAppliedUsers(principal.getId(), idRequest.partyId());
+    }
+
+    @PostMapping("/{partyId}/leave")
+    public PartyLeaveResponse leaveParty(@AuthenticationPrincipal CustomOAuth2User principal,
+                                         @Valid PartyIdRequest idRequest) {
+        return partyService.leaveParty(principal, idRequest.partyId());
     }
 
     @PostMapping("/presigned-url")

--- a/src/main/java/com/playus/twpservice/domain/party/dto/leave/PartyLeaveResponse.java
+++ b/src/main/java/com/playus/twpservice/domain/party/dto/leave/PartyLeaveResponse.java
@@ -1,0 +1,14 @@
+package com.playus.twpservice.domain.party.dto.leave;
+
+import lombok.Builder;
+
+@Builder
+public record PartyLeaveResponse(
+        String message
+) {
+    public static PartyLeaveResponse of (String message) {
+        return PartyLeaveResponse.builder()
+                .message(message)
+                .build();
+    }
+}

--- a/src/main/java/com/playus/twpservice/domain/party/entity/Party.java
+++ b/src/main/java/com/playus/twpservice/domain/party/entity/Party.java
@@ -98,8 +98,20 @@ public class Party extends BaseTimeEntity {
         this.currentParticipants++;
     }
 
+    public void decreaseCurrentMember() {
+        if (this.currentParticipants <= this.minimumParticipants) {
+            throw new InsufficientPartyParticipantsException("직관팟 정원이 부족합니다!");
+        }
+        this.currentParticipants--;
+    }
+
     public Party assignChatRoom(String chatRoomId) {
         this.chatRoomId = chatRoomId;
+        return this;
+    }
+
+    public Party setCurrentParticipantsForOnlyTest(Long currentParticipants) {
+        this.currentParticipants = currentParticipants;
         return this;
     }
 
@@ -115,10 +127,5 @@ public class Party extends BaseTimeEntity {
                 .writerId(writerId)
                 .matchId(matchId)
                 .build();
-    }
-
-    public Party setCurrentParticipantsForOnlyTest(Long currentParticipants) {
-        this.currentParticipants = currentParticipants;
-        return this;
     }
 }

--- a/src/main/java/com/playus/twpservice/domain/party/exception/entity/PartyException.java
+++ b/src/main/java/com/playus/twpservice/domain/party/exception/entity/PartyException.java
@@ -20,10 +20,26 @@ public abstract class PartyException {
         }
     }
 
+    public static class ApplicantNotFoundException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+
+        public ApplicantNotFoundException(String message) {
+            super(message);
+        }
+    }
+
     public static class ExceedPartyParticipantsException extends RuntimeException {
         private static final long serialVersionUID = 1L;
 
         public ExceedPartyParticipantsException(String message) {
+            super(message);
+        }
+    }
+
+    public static class InsufficientPartyParticipantsException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+
+        public InsufficientPartyParticipantsException(String message) {
             super(message);
         }
     }
@@ -47,4 +63,16 @@ public abstract class PartyException {
             super(message);
         }
     }
+
+    public static class NotAllowedPartyJoinRequestStatusException extends RuntimeException {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
+
+        public NotAllowedPartyJoinRequestStatusException(String message) {
+            super(message);
+        }
+    }
+
+
 }

--- a/src/main/java/com/playus/twpservice/domain/party/repository/write/PartyJoinRepository.java
+++ b/src/main/java/com/playus/twpservice/domain/party/repository/write/PartyJoinRepository.java
@@ -15,7 +15,4 @@ public interface PartyJoinRepository extends JpaRepository<PartyJoin, Long> {
 
     @Query("SELECT p FROM PartyJoin p WHERE p.party.id = :partyId AND p.userId = :userId")
     Optional<PartyJoin> findByPartyIdAndUserId(Long partyId, Long userId);
-
-    @Query("SELECT p FROM PartyJoin p WHERE p.userId = :userId")
-    Optional<PartyJoin> findByUserId(Long userId);
 }

--- a/src/main/java/com/playus/twpservice/domain/party/repository/write/PartyJoinRepository.java
+++ b/src/main/java/com/playus/twpservice/domain/party/repository/write/PartyJoinRepository.java
@@ -15,4 +15,7 @@ public interface PartyJoinRepository extends JpaRepository<PartyJoin, Long> {
 
     @Query("SELECT p FROM PartyJoin p WHERE p.party.id = :partyId AND p.userId = :userId")
     Optional<PartyJoin> findByPartyIdAndUserId(Long partyId, Long userId);
+
+    @Query("SELECT p FROM PartyJoin p WHERE p.userId = :userId")
+    Optional<PartyJoin> findByUserId(Long userId);
 }

--- a/src/main/java/com/playus/twpservice/domain/party/service/PartyService.java
+++ b/src/main/java/com/playus/twpservice/domain/party/service/PartyService.java
@@ -202,7 +202,7 @@ public class PartyService {
         Long loginUserId = principal.getId();
         PartyAssert.isParticipatedPartyAsWriter(loginUserId, party.getWriterId(), "방장은 직관팟을 삭제해 주세요!");
 
-        PartyJoin partyJoin = partyJoinRepository.findByUserId(loginUserId)
+        PartyJoin partyJoin = partyJoinRepository.findByPartyIdAndUserId(party.getId(), loginUserId)
                 .orElseThrow(() -> new ApplicantNotFoundException("직관팟에 참여한 사람만 탈퇴할 수 있습니다!"));
 
         PartyAssert.isAcceptedUser(partyJoin.getPartyJoinRequestStatus());

--- a/src/main/java/com/playus/twpservice/domain/party/service/PartyService.java
+++ b/src/main/java/com/playus/twpservice/domain/party/service/PartyService.java
@@ -205,7 +205,7 @@ public class PartyService {
         PartyJoin partyJoin = partyJoinRepository.findByUserId(loginUserId)
                 .orElseThrow(() -> new ApplicantNotFoundException("직관팟에 참여한 사람만 탈퇴할 수 있습니다!"));
 
-        PartyAssert.isApplicantOfParty(partyJoin.getPartyJoinRequestStatus());
+        PartyAssert.isAcceptedUser(partyJoin.getPartyJoinRequestStatus());
 
         partyJoinRepository.delete(partyJoin);
         party.decreaseCurrentMember();

--- a/src/main/java/com/playus/twpservice/domain/party/service/PartyService.java
+++ b/src/main/java/com/playus/twpservice/domain/party/service/PartyService.java
@@ -17,6 +17,7 @@ import com.playus.twpservice.domain.party.dto.create.PartyCreateRequest;
 import com.playus.twpservice.domain.party.dto.create.PartyCreateResponse;
 import com.playus.twpservice.domain.party.dto.delete.PartyDeleteResponse;
 import com.playus.twpservice.domain.common.request.PartyIdRequest;
+import com.playus.twpservice.domain.party.dto.leave.PartyLeaveResponse;
 import com.playus.twpservice.domain.party.dto.update.PartyUpdateRequest;
 import com.playus.twpservice.domain.party.dto.update.PartyUpdateResponse;
 import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageRequest;
@@ -194,6 +195,24 @@ public class PartyService {
         return PartyApproveResponse.of("직관팟 가입 신청 승인 성공했습니다!");
     }
 
+    public PartyLeaveResponse leaveParty(CustomOAuth2User principal, Long partyId) {
+        Party party = partyRepository.findById(partyId)
+                .orElseThrow(() -> new NotFoundException("직관팟이 존재하지 않습니다!"));
+
+        Long loginUserId = principal.getId();
+        PartyAssert.isParticipatedPartyAsWriter(loginUserId, party.getWriterId(), "방장은 직관팟을 삭제해 주세요!");
+
+        PartyJoin partyJoin = partyJoinRepository.findByUserId(loginUserId)
+                .orElseThrow(() -> new ApplicantNotFoundException("직관팟에 참여한 사람만 탈퇴할 수 있습니다!"));
+
+        PartyAssert.isApplicantOfParty(partyJoin.getPartyJoinRequestStatus());
+
+        partyJoinRepository.delete(partyJoin);
+        party.decreaseCurrentMember();
+
+        return PartyLeaveResponse.of("직관팟 탈퇴에 성공하셨습니다!");
+    }
+
     private Long validateApplyCondition(CustomOAuth2User oauth2User, Long partyId, Party party) {
         Long userId = oauth2User.getId();
         Gender userGender = oauth2User.getUserDto().getGender();
@@ -265,6 +284,4 @@ public class PartyService {
                         PartyJoinRequestStatus.throwIfAlreadyAppliedToParty(partyJoinDocument.getPartyJoinRequestStatus())
                 );
     }
-
-
 }

--- a/src/main/java/com/playus/twpservice/domain/party/specification/PartyControllerSpecification.java
+++ b/src/main/java/com/playus/twpservice/domain/party/specification/PartyControllerSpecification.java
@@ -14,6 +14,7 @@ import com.playus.twpservice.domain.party.dto.detail.PartyDetailResponse;
 import com.playus.twpservice.domain.party.dto.info.PartyInfoRequest;
 import com.playus.twpservice.domain.party.dto.info.PartyInfoResponse;
 import com.playus.twpservice.domain.common.request.PartyIdRequest;
+import com.playus.twpservice.domain.party.dto.leave.PartyLeaveResponse;
 import com.playus.twpservice.domain.party.dto.update.PartyUpdateRequest;
 import com.playus.twpservice.domain.party.dto.update.PartyUpdateResponse;
 import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageRequest;
@@ -2135,4 +2136,167 @@ public interface PartyControllerSpecification {
     })
     List<PartyAppliedUserResponse> getAppliedUsers(@Parameter(hidden = true) CustomOAuth2User principal,
                                                    @Valid @Parameter(description = "API 경로로 들어오는 직관팟 ID 위해 작성", required = true) PartyIdRequest idRequest);
+
+
+
+    @Tag(name = "Post", description = "직관팟 탈퇴 API")
+    @Operation(
+            summary = "직관팟 탈퇴 API",
+            description = "직관팟 인원 (방장 X) 으로서 참여하고 있는 특정 직관팟에 탈퇴할 수 있다.",
+            security = @SecurityRequirement(name = "Access"),
+            parameters = {
+                    @Parameter(
+                            name = "Access",
+                            description = "JWT Access Token (쿠키)",
+                            in = ParameterIn.COOKIE,
+                            required = true,
+                            example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                    ),
+                    @Parameter(
+                            name = "partyId",
+                            in = ParameterIn.PATH,
+                            description = "직관팟 ID",
+                            required = true,
+                            example = "1"
+                    )
+            }
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "승인",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    name = "직관팟 탈퇴 API 응답 예시",
+                                    value = """
+                                            {
+                                              "message": "직관팟 탈퇴에 성공하셨습니다!"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "직관팟 ID가 1 미만일 경우 발생",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 400,
+                                              "status": "BAD_REQUEST",
+                                              "message": "직관팟 ID는 1 이상이여야 합니다!"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401", description = "인증 실패",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 401,
+                                              "status": "UNAUTHORIZED",
+                                              "message": "유효하지 않은 토큰입니다."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403", description = "직관팟 방장이 직관팟 탈퇴 시도할 경우",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 403,
+                                              "status": "FORBIDDEN",
+                                              "message": "방장은 직관팟을 삭제해 주세요!"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403", description = "직관팟 참여 대기 상태인 유저가 탈퇴 시도할 경우",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 403,
+                                              "status": "FORBIDDEN",
+                                              "message": "대기 상태인 유저는 직관팟 신청을 취소해주세요!"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403", description = "직관팟 참여 거절된 상태인 유저가 탈퇴 시도할 경우",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 403,
+                                              "status": "FORBIDDEN",
+                                              "message": "직관팟 참여가 이미 거절되었습니다!"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404", description = "직관팟 ID로 직관팟을 찾을 수 없는 경우 발생",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 404,
+                                              "status": "NOT_FOUND",
+                                              "message": "직관팟이 존재하지 않습니다!"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404", description = "직관팟에 참여하지 않은 사람이 직관팟 탈퇴하는 경우 발생",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 404,
+                                              "status": "NOT_FOUND",
+                                              "message": "직관팟에 참여한 사람만 탈퇴할 수 있습니다!"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500", description = "서버 내부 오류",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 500,
+                                              "status": "INTERNAL_SERVER_ERROR",
+                                              "message": "서버 내부 오류가 발생했습니다. 관리자에게 문의해 주세요."
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    PartyLeaveResponse leaveParty(@Parameter(hidden = true) CustomOAuth2User principal,
+                                  @Valid @Parameter(description = "API 경로로 들어오는 직관팟 ID 위해 작성", required = true) PartyIdRequest idRequest);
 }

--- a/src/main/java/com/playus/twpservice/global/exception/ExceptionAdvice.java
+++ b/src/main/java/com/playus/twpservice/global/exception/ExceptionAdvice.java
@@ -51,7 +51,8 @@ public class ExceptionAdvice {
     @ExceptionHandler({
             PartyJoinDocumentException.RefusedApplyUserException.class,
             PartyException.NotPartyWriterException.class,
-            PartyException.NotAllowedPartyConditionException.class
+            PartyException.NotAllowedPartyConditionException.class,
+            PartyException.NotAllowedPartyJoinRequestStatusException.class
     })
     public ErrorResponse handleForbiddenException(Exception e) {
         String errorMessage = e.getMessage();
@@ -63,6 +64,7 @@ public class ExceptionAdvice {
             PartyException.NotFoundException.class,
             PartyDocumentException.NotFoundException.class,
             ChatRoomException.NotFoundException.class,
+            PartyException.ApplicantNotFoundException.class
     })
     public ErrorResponse handleNotFoundException(Exception e) {
         String errorMessage = e.getMessage();
@@ -73,6 +75,7 @@ public class ExceptionAdvice {
     @ResponseStatus(CONFLICT)
     @ExceptionHandler({
             PartyException.ExceedPartyParticipantsException.class,
+            PartyException.InsufficientPartyParticipantsException.class,
             PartyJoinDocumentException.DuplicateApplyException.class
     })
     public ErrorResponse handleConflictException(Exception e) {

--- a/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
@@ -15,6 +15,7 @@ import com.playus.twpservice.domain.party.dto.info.PartyInfoResponse;
 import com.playus.twpservice.domain.party.dto.create.PartyCreateRequest;
 import com.playus.twpservice.domain.party.dto.create.PartyCreateResponse;
 import com.playus.twpservice.domain.common.request.PartyIdRequest;
+import com.playus.twpservice.domain.party.dto.leave.PartyLeaveResponse;
 import com.playus.twpservice.domain.party.dto.update.PartyUpdateRequest;
 import com.playus.twpservice.domain.party.dto.update.PartyUpdateResponse;
 import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageRequest;
@@ -1264,6 +1265,40 @@ class PartyControllerTest extends ControllerTestSupport {
 
         // when // then
         mockMvc.perform(get("/party/" + invalidPartyStr + "/approved-applicants")
+                        .contentType(APPLICATION_JSON)
+                        .with(authentication(token)))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("400"))
+                .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+                .andExpect(jsonPath("$.message").value("직관팟 ID는 1 이상이어야 합니다!"));
+    }
+
+    @DisplayName("직관팟을 탈퇴할 수 있다.")
+    @Test
+    void leaveParty() throws Exception {
+        // given
+        Long partyId = 1L;
+        PartyLeaveResponse response = PartyLeaveResponse.of("직관팟 탈퇴에 성공하셨습니다!");
+        given(partyService.leaveParty(any(), any())).willReturn(response);
+
+        // when // then
+        mockMvc.perform(post("/party/" + partyId + "/leave")
+                        .contentType(APPLICATION_JSON)
+                        .with(authentication(token)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("직관팟 탈퇴에 성공하셨습니다!"));
+    }
+
+    @DisplayName("직관팟을 탈퇴할 때 직관팟의 ID는 1 이상이여야 한다.")
+    @CsvSource(value = {"0", "-1", "-100", "-1000", "-10000"})
+    @ParameterizedTest(name = "invalidPartyIdStr = {0}")
+    void leaveParty_INVALID_PARTYID(String invalidPartyStr) throws Exception {
+        // given
+
+        // when // then
+        mockMvc.perform(post("/party/" + invalidPartyStr + "/leave")
                         .contentType(APPLICATION_JSON)
                         .with(authentication(token)))
                 .andDo(print())

--- a/src/test/java/com/playus/twpservice/domain/party/service/PartyServiceTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/service/PartyServiceTest.java
@@ -18,8 +18,8 @@ import com.playus.twpservice.domain.party.dto.create.PartyCreateRequest;
 import com.playus.twpservice.domain.party.dto.create.PartyCreateResponse;
 import com.playus.twpservice.domain.common.request.PartyIdRequest;
 import com.playus.twpservice.domain.party.dto.delete.PartyDeleteResponse;
+import com.playus.twpservice.domain.party.dto.leave.PartyLeaveResponse;
 import com.playus.twpservice.domain.party.dto.update.PartyUpdateRequest;
-import com.playus.twpservice.domain.party.dto.update.PartyUpdateResponse;
 import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageRequest;
 import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageResponse;
 import com.playus.twpservice.domain.party.entity.Party;
@@ -29,7 +29,6 @@ import com.playus.twpservice.domain.party.entity.PartyThumbnailUrl;
 import com.playus.twpservice.domain.party.enums.PartyGender;
 import com.playus.twpservice.domain.party.enums.PartyJoinMethod;
 import com.playus.twpservice.domain.party.enums.PartyJoinRequestStatus;
-import com.playus.twpservice.domain.party.exception.document.PartyDocumentException;
 import com.playus.twpservice.domain.party.exception.document.PartyJoinDocumentException;
 import com.playus.twpservice.domain.party.exception.entity.PartyException;
 import com.playus.twpservice.domain.party.repository.read.PartyAgeReadOnlyRepository;
@@ -46,7 +45,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import java.time.LocalDate;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -823,7 +821,7 @@ class PartyServiceTest extends IntegrationTestSupport {
         Long partyId = party.getId();
 
         partyJoinRepository.saveAll(List.of(
-           PartyJoin.create(applicantUserId, party, PartyJoinRequestStatus.WAIT, "참여 희망합니다!")
+                PartyJoin.create(applicantUserId, party, PartyJoinRequestStatus.WAIT, "참여 희망합니다!")
         ));
 
         // when
@@ -957,4 +955,194 @@ class PartyServiceTest extends IntegrationTestSupport {
                 .hasMessage("직관팟 지원자가 아닙니다!");
     }
 
+    @DisplayName("직관팟을 탈퇴할 수 있다.")
+    @Test
+    void leaveParty() {
+        // given
+        Long userId = 5L;
+        UserDto userDto = UserDto.createForTest(userId, Gender.FEMALE, Role.USER, 20);
+        CustomOAuth2User customOAuth2User = new CustomOAuth2User(userDto);
+        Long writerId = 1L;
+        Long matchId = 1L;
+
+        ChatRoom chatRoom = chatRoomRepository.save(ChatRoom.create("CHATROOM-1"));
+
+        Party party = partyRepository.save(Party.create("title", "설명", 1L, 10L,
+                        PartyGender.FEMALE, PartyJoinMethod.RESERVATION, writerId, matchId)
+                .assignChatRoom(chatRoom.getId()).setCurrentParticipantsForOnlyTest(2L));
+
+        partyJoinRepository.saveAll(
+                List.of(
+                        PartyJoin.create(userId, party, PartyJoinRequestStatus.ACCEPT, "참여 희망합니다!"),
+                        PartyJoin.create(userId + 1, party, PartyJoinRequestStatus.ACCEPT, "참여 원합니다!")
+                )
+        );
+
+        // when
+        PartyLeaveResponse response = partyService.leaveParty(customOAuth2User, party.getId());
+
+        // then
+        assertThat(response.message()).isEqualTo("직관팟 탈퇴에 성공하셨습니다!");
+        assertThat(partyJoinRepository.count()).isEqualTo(1);
+        assertThat(partyRepository.findAll().get(0).getCurrentParticipants()).isEqualTo(1);
+    }
+
+    @DisplayName("존재하지 않는 직관팟에 대해 탈퇴할 수 없다.")
+    @Test
+    void leaveParty_INVALID_PARTY() {
+        // given
+        Long writerId = 1L;
+        Long userId = 5L;
+        UserDto userDto = UserDto.createForTest(userId, Gender.FEMALE, Role.USER, 20);
+        CustomOAuth2User customOAuth2User = new CustomOAuth2User(userDto);
+        Long matchId = 1L;
+
+        ChatRoom chatRoom = chatRoomRepository.save(ChatRoom.create("CHATROOM-1"));
+
+        Party party = partyRepository.save(Party.create("title", "설명", 1L, 10L,
+                        PartyGender.FEMALE, PartyJoinMethod.RESERVATION, writerId, matchId)
+                .assignChatRoom(chatRoom.getId()).setCurrentParticipantsForOnlyTest(2L));
+
+        partyJoinRepository.saveAll(
+                List.of(
+                        PartyJoin.create(writerId, party, PartyJoinRequestStatus.ACCEPT, "참여 원합니다!")
+                )
+        );
+
+        // when // then
+        assertThatThrownBy(() -> partyService.leaveParty(customOAuth2User, party.getId() + 1))
+                .isInstanceOf(PartyException.NotFoundException.class)
+                .hasMessage("직관팟이 존재하지 않습니다!");
+    }
+
+    @DisplayName("직관팟 방장은 직관팟을 탈퇴할 수 없다.")
+    @Test
+    void leaveParty_WRITER_NOT_ALLOWED() {
+        // given
+        Long writerId = 1L;
+        UserDto userDto = UserDto.createForTest(writerId, Gender.FEMALE, Role.USER, 20);
+        CustomOAuth2User customOAuth2User = new CustomOAuth2User(userDto);
+        Long matchId = 1L;
+
+        ChatRoom chatRoom = chatRoomRepository.save(ChatRoom.create("CHATROOM-1"));
+
+        Party party = partyRepository.save(Party.create("title", "설명", 1L, 10L,
+                        PartyGender.FEMALE, PartyJoinMethod.RESERVATION, writerId, matchId)
+                .assignChatRoom(chatRoom.getId()).setCurrentParticipantsForOnlyTest(10L));
+
+        partyJoinRepository.saveAll(
+                List.of(
+                        PartyJoin.create(writerId + 1, party, PartyJoinRequestStatus.ACCEPT, "참여 원합니다!")
+                )
+        );
+
+        // when // then
+        assertThatThrownBy(() -> partyService.leaveParty(customOAuth2User, party.getId()))
+                .isInstanceOf(PartyException.NotPartyWriterException.class)
+                .hasMessage("방장은 직관팟을 삭제해 주세요!");
+    }
+
+    @DisplayName("참여하지 않은 직관팟에 대해 탈퇴할 수 없다.")
+    @Test
+    void leaveParty_NOT_PARTICIPATED() {
+        // given
+        Long userId = 5L;
+        UserDto userDto = UserDto.createForTest(userId, Gender.FEMALE, Role.USER, 20);
+        CustomOAuth2User customOAuth2User = new CustomOAuth2User(userDto);
+        Long writerId = 1L;
+        Long matchId = 1L;
+
+        ChatRoom chatRoom = chatRoomRepository.save(ChatRoom.create("CHATROOM-1"));
+
+        Party party = partyRepository.save(Party.create("title", "설명", 1L, 10L,
+                        PartyGender.FEMALE, PartyJoinMethod.RESERVATION, writerId, matchId)
+                .assignChatRoom(chatRoom.getId()).setCurrentParticipantsForOnlyTest(10L));
+
+
+        // when // then
+        assertThatThrownBy(() -> partyService.leaveParty(customOAuth2User, party.getId()))
+                .isInstanceOf(PartyException.ApplicantNotFoundException.class)
+                .hasMessage("직관팟에 참여한 사람만 탈퇴할 수 있습니다!");
+    }
+
+    @DisplayName("대기 상태인 유저는 직관팟을 탈퇴할 수 없다.")
+    @Test
+    void leaveParty_WAIT_USER_NOT_ALLOWED() {
+        Long writerId = 1L;
+        Long userId = 5L;
+        UserDto userDto = UserDto.createForTest(userId, Gender.FEMALE, Role.USER, 20);
+        CustomOAuth2User customOAuth2User = new CustomOAuth2User(userDto);
+        Long matchId = 1L;
+
+        ChatRoom chatRoom = chatRoomRepository.save(ChatRoom.create("CHATROOM-1"));
+
+        Party party = partyRepository.save(Party.create("title", "설명", 1L, 10L,
+                        PartyGender.FEMALE, PartyJoinMethod.RESERVATION, writerId, matchId)
+                .assignChatRoom(chatRoom.getId()).setCurrentParticipantsForOnlyTest(10L));
+
+        partyJoinRepository.saveAll(
+                List.of(
+                        PartyJoin.create(userId, party, PartyJoinRequestStatus.WAIT, "참여 원합니다!")
+                )
+        );
+
+        // when // then
+        assertThatThrownBy(() -> partyService.leaveParty(customOAuth2User, party.getId()))
+                .isInstanceOf(PartyException.NotAllowedPartyJoinRequestStatusException.class)
+                .hasMessage("대기 상태인 유저는 직관팟 신청을 취소해주세요!");
+    }
+
+    @DisplayName("직관팟 참여가 거절된 유저는 직관팟을 탈퇴할 수 없다.")
+    @Test
+    void leaveParty_REFUSED_NOT_ALLOWED() {
+        Long writerId = 1L;
+        Long userId = 5L;
+        UserDto userDto = UserDto.createForTest(userId, Gender.FEMALE, Role.USER, 20);
+        CustomOAuth2User customOAuth2User = new CustomOAuth2User(userDto);
+        Long matchId = 1L;
+
+        ChatRoom chatRoom = chatRoomRepository.save(ChatRoom.create("CHATROOM-1"));
+
+        Party party = partyRepository.save(Party.create("title", "설명", 1L, 10L,
+                        PartyGender.FEMALE, PartyJoinMethod.RESERVATION, writerId, matchId)
+                .assignChatRoom(chatRoom.getId()).setCurrentParticipantsForOnlyTest(10L));
+
+        partyJoinRepository.saveAll(
+                List.of(
+                        PartyJoin.create(userId, party, PartyJoinRequestStatus.REFUSE, "참여 원합니다!")
+                )
+        );
+
+        // when // then
+        assertThatThrownBy(() -> partyService.leaveParty(customOAuth2User, party.getId()))
+                .isInstanceOf(PartyException.NotAllowedPartyJoinRequestStatusException.class)
+                .hasMessage("직관팟 참여가 이미 거절되었습니다!");
+    }
+
+//    @DisplayName("직관팟 참여가 최소 인원인 경우 직관팟을 탈퇴할 수 없다?")
+//    @Test
+//    void leaveParty_REFUSED_NOT_ALLOWED() {
+//        Long writerId = 1L;
+//        Long userId = 5L;
+//        UserDto userDto = UserDto.createForTest(userId, Gender.FEMALE, Role.USER, 20);
+//        CustomOAuth2User customOAuth2User = new CustomOAuth2User(userDto);
+//        Long matchId = 1L;
+//
+//        ChatRoom chatRoom = chatRoomRepository.save(ChatRoom.create("CHATROOM-1"));
+//
+//        Party party = partyRepository.save(Party.create("title", "설명", 1L, 10L,
+//                        PartyGender.FEMALE, PartyJoinMethod.RESERVATION, writerId, matchId)
+//                .assignChatRoom(chatRoom.getId()).setCurrentParticipantsForOnlyTest(10L));
+//
+//        partyJoinRepository.saveAll(
+//                List.of(
+//                        PartyJoin.create(writerId + 1, party, PartyJoinRequestStatus.REFUSE, "참여 원합니다!")
+//                )
+//        );
+//
+//        // when // then
+//        assertThatThrownBy(() -> partyService.leaveParty(customOAuth2User, party.getId()))
+//                .isInstanceOf(PartyException.NotAllowedPartyJoinRequestStatusException.class)
+//                .hasMessage("직관팟 참여가 이미 거절되었습니다!");
+//    }
 }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
직관팟 탈퇴 기능 구현했습니다! 

---

## 🔗 관련 이슈
- closes #42 

---

## 💡 추가 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 사용자가 파티에서 탈퇴할 수 있는 기능이 추가되었습니다. 이제 파티 참여자는 호스트가 아닌 경우 파티를 자유롭게 떠날 수 있습니다.
- **버그 수정**
  - 파티 탈퇴 시, 대기(WAIT) 또는 거절(REFUSE) 상태의 사용자가 탈퇴를 시도하면 적절한 예외와 메시지가 제공됩니다.
- **문서화**
  - 파티 탈퇴 엔드포인트에 대한 API 명세와 다양한 에러 응답 코드가 추가되었습니다.
- **테스트**
  - 파티 탈퇴 기능에 대한 성공 및 다양한 예외 상황에 대한 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->