### PR TITLE
CS-299 feat/자신이 신청한 직관팟 조회

### DIFF
--- a/src/main/java/com/playus/twpservice/domain/party/controller/PartyController.java
+++ b/src/main/java/com/playus/twpservice/domain/party/controller/PartyController.java
@@ -1,6 +1,7 @@
 package com.playus.twpservice.domain.party.controller;
 
 import com.playus.twpservice.domain.common.security.CustomOAuth2User;
+import com.playus.twpservice.domain.party.dto.appliedparty.AppliedPartyResponse;
 import com.playus.twpservice.domain.party.dto.applieduser.PartyAppliedUserResponse;
 import com.playus.twpservice.domain.party.dto.apply.PartyApplyResponse;
 import com.playus.twpservice.domain.party.dto.apply.PartyApproveApplyRequest;
@@ -106,6 +107,12 @@ public class PartyController implements PartyControllerSpecification {
     public PartyCancelResponse cancelParty(@AuthenticationPrincipal CustomOAuth2User principal,
                                            @Valid PartyIdRequest idRequest) {
         return partyService.cancelParty(principal, idRequest.partyId());
+    }
+
+    @GetMapping("/{partyId}/applied-parties")
+    public List<AppliedPartyResponse> getAppliedParties(@AuthenticationPrincipal CustomOAuth2User principal,
+                                                        @Valid PartyIdRequest idRequest) {
+        return partyReadOnlyService.getAppliedParties(principal, idRequest.partyId());
     }
 
     @PostMapping("/presigned-url")

--- a/src/main/java/com/playus/twpservice/domain/party/controller/PartyController.java
+++ b/src/main/java/com/playus/twpservice/domain/party/controller/PartyController.java
@@ -109,10 +109,9 @@ public class PartyController implements PartyControllerSpecification {
         return partyService.cancelParty(principal, idRequest.partyId());
     }
 
-    @GetMapping("/{partyId}/applied-parties")
-    public List<AppliedPartyResponse> getAppliedParties(@AuthenticationPrincipal CustomOAuth2User principal,
-                                                        @Valid PartyIdRequest idRequest) {
-        return partyReadOnlyService.getAppliedParties(principal, idRequest.partyId());
+    @GetMapping("/applied-parties")
+    public List<AppliedPartyResponse> getAppliedParties(@AuthenticationPrincipal CustomOAuth2User principal) {
+        return partyReadOnlyService.getAppliedParties(principal);
     }
 
     @PostMapping("/presigned-url")

--- a/src/main/java/com/playus/twpservice/domain/party/dto/appliedparty/AppliedPartyResponse.java
+++ b/src/main/java/com/playus/twpservice/domain/party/dto/appliedparty/AppliedPartyResponse.java
@@ -1,0 +1,44 @@
+package com.playus.twpservice.domain.party.dto.appliedparty;
+
+import com.playus.twpservice.domain.party.enums.PartyAgeGroup;
+import com.playus.twpservice.domain.party.enums.PartyGender;
+import com.playus.twpservice.domain.party.enums.PartyJoinRequestStatus;
+import lombok.Builder;
+
+import java.util.List;
+
+
+@Builder
+public record AppliedPartyResponse(
+        Long partyId,
+        String title,
+        List<String> partyAgeGroup,
+        String partyGender,
+        String partyJoinRequestStatus,
+        Long writerId,
+        String authorName,
+        String authorGender,
+        String authorAge,
+        String writerThumbnailUrl,
+        int currentParticipants
+) {
+
+    public static AppliedPartyResponse of(Long partyId, String title, List<Integer> partyAges,
+                                          PartyGender partyGender, PartyJoinRequestStatus partyJoinRequestStatus,
+                                          Long writerId, String authorName, String authorGender, int authorAge, String writerThumbnailUrl, int currentParticipants) {
+        return AppliedPartyResponse.builder()
+                .partyId(partyId)
+                .title(title)
+                .partyAgeGroup(partyAges.stream().map(PartyAgeGroup::getAgeDescriptionByAge).toList())
+                .partyGender(partyGender.getDescription())
+                .partyJoinRequestStatus(partyJoinRequestStatus.getMessage())
+                .writerId(writerId)
+                .authorName(authorName)
+                .authorGender(authorGender)
+                .authorAge(PartyAgeGroup.getAgeDescriptionByAge(authorAge))
+                .writerThumbnailUrl(writerThumbnailUrl)
+                .currentParticipants(currentParticipants)
+                .build();
+    }
+
+}

--- a/src/main/java/com/playus/twpservice/domain/party/dto/appliedparty/AppliedPartyResponse.java
+++ b/src/main/java/com/playus/twpservice/domain/party/dto/appliedparty/AppliedPartyResponse.java
@@ -1,8 +1,5 @@
 package com.playus.twpservice.domain.party.dto.appliedparty;
 
-import com.playus.twpservice.domain.party.enums.PartyAgeGroup;
-import com.playus.twpservice.domain.party.enums.PartyGender;
-import com.playus.twpservice.domain.party.enums.PartyJoinRequestStatus;
 import lombok.Builder;
 
 import java.util.List;
@@ -23,19 +20,19 @@ public record AppliedPartyResponse(
         int currentParticipants
 ) {
 
-    public static AppliedPartyResponse of(Long partyId, String title, List<Integer> partyAges,
-                                          PartyGender partyGender, PartyJoinRequestStatus partyJoinRequestStatus,
-                                          Long writerId, String authorName, String authorGender, int authorAge, String writerThumbnailUrl, int currentParticipants) {
+    public static AppliedPartyResponse of(Long partyId, String title, List<String> partyAges,
+                                          String partyGender, String partyJoinRequestStatus,
+                                          Long writerId, String authorName, String authorGender, String authorAge, String writerThumbnailUrl, int currentParticipants) {
         return AppliedPartyResponse.builder()
                 .partyId(partyId)
                 .title(title)
-                .partyAgeGroup(partyAges.stream().map(PartyAgeGroup::getAgeDescriptionByAge).toList())
-                .partyGender(partyGender.getDescription())
-                .partyJoinRequestStatus(partyJoinRequestStatus.getMessage())
+                .partyAgeGroup(partyAges)
+                .partyGender(partyGender)
+                .partyJoinRequestStatus(partyJoinRequestStatus)
                 .writerId(writerId)
                 .authorName(authorName)
                 .authorGender(authorGender)
-                .authorAge(PartyAgeGroup.getAgeDescriptionByAge(authorAge))
+                .authorAge(authorAge)
                 .writerThumbnailUrl(writerThumbnailUrl)
                 .currentParticipants(currentParticipants)
                 .build();

--- a/src/main/java/com/playus/twpservice/domain/party/dto/appliedparty/AppliedPartyResponse.java
+++ b/src/main/java/com/playus/twpservice/domain/party/dto/appliedparty/AppliedPartyResponse.java
@@ -17,12 +17,12 @@ public record AppliedPartyResponse(
         String authorGender,
         String authorAge,
         String writerThumbnailUrl,
-        int currentParticipants
+        Long currentParticipants
 ) {
 
     public static AppliedPartyResponse of(Long partyId, String title, List<String> partyAges,
                                           String partyGender, String partyJoinRequestStatus,
-                                          Long writerId, String authorName, String authorGender, String authorAge, String writerThumbnailUrl, int currentParticipants) {
+                                          Long writerId, String authorName, String authorGender, String authorAge, String writerThumbnailUrl, Long currentParticipants) {
         return AppliedPartyResponse.builder()
                 .partyId(partyId)
                 .title(title)

--- a/src/main/java/com/playus/twpservice/domain/party/enums/PartyAgeGroup.java
+++ b/src/main/java/com/playus/twpservice/domain/party/enums/PartyAgeGroup.java
@@ -35,6 +35,7 @@ public enum PartyAgeGroup implements Describable {
     }
 
     public static PartyAgeGroup getAgeGroupByAge(int age) {
+        age = (age / 10) * 10;
         for (PartyAgeGroup group : PartyAgeGroup.values()) {
             if (group.getAge() == age) {
                 return group;
@@ -44,6 +45,7 @@ public enum PartyAgeGroup implements Describable {
     }
 
     public static String getAgeDescriptionByAge(int age) {
+        age = (age / 10) * 10;
         for (PartyAgeGroup group : PartyAgeGroup.values()) {
             if (group.getAge() == age) {
                 return group.getDescription();

--- a/src/main/java/com/playus/twpservice/domain/party/enums/PartyJoinRequestStatus.java
+++ b/src/main/java/com/playus/twpservice/domain/party/enums/PartyJoinRequestStatus.java
@@ -1,9 +1,16 @@
 package com.playus.twpservice.domain.party.enums;
 
 import com.playus.twpservice.domain.party.exception.document.PartyJoinDocumentException;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
+@Getter
+@AllArgsConstructor
 public enum PartyJoinRequestStatus {
-    WAIT, REFUSE, ACCEPT;
+
+    WAIT("신청중"), REFUSE("승인 거부됨"), ACCEPT("채팅방 입장!");
+
+    private String message;
 
     public static void throwIfAlreadyAppliedToParty(PartyJoinRequestStatus status) {
 

--- a/src/main/java/com/playus/twpservice/domain/party/feign/client/NotificationFeignClient.java
+++ b/src/main/java/com/playus/twpservice/domain/party/feign/client/NotificationFeignClient.java
@@ -5,10 +5,10 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
-@FeignClient(name = "notificationClient", url  = "${feign.user.url}", path = "/user/notifications/parties")
+@FeignClient(name = "notificationClient", url  = "${feign.user.url}", path = "/user/api")
 public interface NotificationFeignClient {
 
-    @PostMapping
+    @PostMapping("/notifications/party")
     void notifyParty(@RequestBody PartyNotificationEvent event);
 
 }

--- a/src/main/java/com/playus/twpservice/domain/party/feign/client/NotificationFeignClient.java
+++ b/src/main/java/com/playus/twpservice/domain/party/feign/client/NotificationFeignClient.java
@@ -1,0 +1,14 @@
+package com.playus.twpservice.domain.party.feign.client;
+
+import com.playus.twpservice.domain.party.feign.event.PartyNotificationEvent;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name = "notificationClient", url  = "${feign.user.url}", path = "/user/notifications/parties")
+public interface NotificationFeignClient {
+
+    @PostMapping
+    void notifyParty(@RequestBody PartyNotificationEvent event);
+
+}

--- a/src/main/java/com/playus/twpservice/domain/party/feign/enums/NotificationType.java
+++ b/src/main/java/com/playus/twpservice/domain/party/feign/enums/NotificationType.java
@@ -1,0 +1,15 @@
+package com.playus.twpservice.domain.party.feign.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NotificationType {
+    COMMENT("댓글"),
+    PARTY_REQUEST("승인제 팟"),    // (받는 사람: 작성자)
+    PARTY_JOINED("선착순 팟"),     // (받는 사람: 작성자)
+    PARTY_APPROVED("신청 승인됨"),   // (받는 사람: 신청자)
+    PARTY_REFUSED("신청 거절됨");   // (받는 사람: 신청자)
+    private final String name;
+}

--- a/src/main/java/com/playus/twpservice/domain/party/feign/event/PartyNotificationEvent.java
+++ b/src/main/java/com/playus/twpservice/domain/party/feign/event/PartyNotificationEvent.java
@@ -1,0 +1,60 @@
+package com.playus.twpservice.domain.party.feign.event;
+
+import com.playus.twpservice.domain.party.feign.enums.NotificationType;
+import lombok.Builder;
+
+@Builder
+public record PartyNotificationEvent(
+        Long              partyId,          // 직관팟 PK
+        String            partyTitle,       // 직관팟 제목
+        Long              receiverId,       // 알림 받을 유저
+        Long              actorId,          // 행동 주체(요청자·참여자·작성자 등)
+        NotificationType type,             // PARTY_REQUEST, PARTY_JOINED, PARTY_APPROVED, PARTY_REFUSED
+        String requestStatus,  //ACCEPT / REFUSE
+        String            requireMessage    // 신청 시 남긴 한 줄 메시지 (옵션)
+) {
+
+    /** 선착순 팟: 누군가 바로 참가 (→ 작성자에게) */
+    public static PartyNotificationEvent joined(
+            Long partyId, String partyTitle, Long receiverId, Long applicantId) {
+
+        return PartyNotificationEvent.builder()
+                .partyId(partyId)
+                .partyTitle(partyTitle)
+                .receiverId(receiverId)
+                .actorId(applicantId)                    // 참가자
+                .type(NotificationType.PARTY_JOINED)
+                .build();
+    }
+
+    /** 승인제 팟: 누군가 신청 (→ 작성자에게) */
+    public static PartyNotificationEvent request(
+            Long partyId, String partyTitle, Long receiverId, Long applicantId, String requestStatus, String requireMsg) {
+
+        return PartyNotificationEvent.builder()
+                .partyId(partyId)
+                .partyTitle(partyTitle)
+                .receiverId(receiverId)
+                .actorId(applicantId)                 // 신청자
+                .type(NotificationType.PARTY_REQUEST)
+                .requestStatus(requestStatus)
+                .requireMessage(requireMsg)
+                .build();
+    }
+
+    /** 승인 결과 (→ 신청자에게) */
+    public static PartyNotificationEvent approveResult(
+            Long partyId, String partyTitle, Long receiverId, Long writerId, boolean approved) {
+
+        return PartyNotificationEvent.builder()
+                .partyId(partyId)
+                .partyTitle(partyTitle)
+                .receiverId(receiverId)              // 신청자
+                .actorId(writerId)         // 작성자
+                .type(approved
+                        ? NotificationType.PARTY_APPROVED
+                        : NotificationType.PARTY_REFUSED)
+                .requestStatus(approved ? "ACCEPT" : "REFUSE")
+                .build();
+    }
+}

--- a/src/main/java/com/playus/twpservice/domain/party/repository/read/custom/PartyReadOnlyRepositoryCustom.java
+++ b/src/main/java/com/playus/twpservice/domain/party/repository/read/custom/PartyReadOnlyRepositoryCustom.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 public interface PartyReadOnlyRepositoryCustom {
     List<PartyInfo> findPartyInfoList(Long matchId);
     Optional<PartyInfo> findPartyDetail(Long partyId);
+    List<PartyInfo> findAppliedParties(Long userId);
 }

--- a/src/main/java/com/playus/twpservice/domain/party/repository/read/custom/PartyReadOnlyRepositoryCustomImpl.java
+++ b/src/main/java/com/playus/twpservice/domain/party/repository/read/custom/PartyReadOnlyRepositoryCustomImpl.java
@@ -171,14 +171,55 @@ public class PartyReadOnlyRepositoryCustomImpl implements PartyReadOnlyRepositor
         return resultList.isEmpty() ? Optional.empty() : Optional.of(resultList.get(0));
     }
 
+
+//    LookupOperation partyLookupOperation = lookup("party", "_id", "_id", "party");
+//    LookupOperation partyAgeLookupOperation = lookup("party_age", "party_id", "party_id", "partyAge");
+//    LookupOperation partyThumbnailLookupOperation = lookup("party_thumbnailUrl", "party_id", "party_id", "partyThumbnailUrl");
+
     @Override
     public List<PartyInfo> findAppliedParties(Long userId) {
 
-        MatchOperation matchOperation = match(new Criteria("user_id").is(userId));
+        MatchOperation matchOperation = match(new Criteria("user_id").is(userId)
+                .and("deleted_at").is(null));
 
-        LookupOperation partyLookupOperation = lookup("party", "_id", "_id", "party");
-        LookupOperation partyAgeLookupOperation = lookup("party_age", "party_id", "party_id", "partyAge");
-        LookupOperation partyThumbnailLookupOperation = lookup("party_thumbnailUrl", "party_id", "party_id", "partyThumbnailUrl");
+        AggregationOperation partyLookupOperation = context -> new Document(
+                "$lookup",
+                new Document("from", "party")
+                        .append("let", new Document("partyId", "$_id"))
+                        .append("pipeline", Arrays.asList(
+                                new Document("$match", new Document("$expr", new Document("$and", Arrays.asList(
+                                        new Document("$eq", Arrays.asList("$_id", "$$partyId")),
+                                        new Document("$eq", Arrays.asList("$deleted_at", null))
+                                ))))
+                        ))
+                        .append("as", "party")
+        );
+
+        AggregationOperation partyAgeLookupOperation = context -> new Document(
+                "$lookup",
+                new Document("from", "party_age")
+                        .append("let", new Document("partyId", "$party_id"))
+                        .append("pipeline", Arrays.asList(
+                                new Document("$match", new Document("$expr", new Document("$and", Arrays.asList(
+                                        new Document("$eq", Arrays.asList("$party_id", "$$partyId")),
+                                        new Document("$eq", Arrays.asList("$deleted_at", null))
+                                ))))
+                        ))
+                        .append("as", "partyAge")
+        );
+
+        AggregationOperation partyThumbnailLookupOperation = context -> new Document(
+                "$lookup",
+                new Document("from", "party_thumbnailUrl")
+                        .append("let", new Document("partyId", "$party_id"))
+                        .append("pipeline", Arrays.asList(
+                                new Document("$match", new Document("$expr", new Document("$and", Arrays.asList(
+                                        new Document("$eq", Arrays.asList("$party_id", "$$partyId")),
+                                        new Document("$eq", Arrays.asList("$deleted_at", null))
+                                ))))
+                        ))
+                        .append("as", "partyThumbnailUrl")
+        );
 
         ProjectionOperation projectionOperation = Aggregation.project()
                 .and("party_id").as("partyId")

--- a/src/main/java/com/playus/twpservice/domain/party/repository/read/custom/PartyReadOnlyRepositoryCustomImpl.java
+++ b/src/main/java/com/playus/twpservice/domain/party/repository/read/custom/PartyReadOnlyRepositoryCustomImpl.java
@@ -185,7 +185,7 @@ public class PartyReadOnlyRepositoryCustomImpl implements PartyReadOnlyRepositor
         AggregationOperation partyLookupOperation = context -> new Document(
                 "$lookup",
                 new Document("from", "party")
-                        .append("let", new Document("partyId", "$_id"))
+                        .append("let", new Document("partyId", "$party_id"))
                         .append("pipeline", Arrays.asList(
                                 new Document("$match", new Document("$expr", new Document("$and", Arrays.asList(
                                         new Document("$eq", Arrays.asList("$_id", "$$partyId")),

--- a/src/main/java/com/playus/twpservice/domain/party/repository/read/custom/PartyReadOnlyRepositoryCustomImpl.java
+++ b/src/main/java/com/playus/twpservice/domain/party/repository/read/custom/PartyReadOnlyRepositoryCustomImpl.java
@@ -14,7 +14,6 @@ import java.util.Optional;
 import static org.springframework.data.mongodb.core.aggregation.Aggregation.*;
 
 
-// 5/21 기준 soft delete 반영 아직 안 되엇음!!!
 @RequiredArgsConstructor
 public class PartyReadOnlyRepositoryCustomImpl implements PartyReadOnlyRepositoryCustom {
 
@@ -170,6 +169,37 @@ public class PartyReadOnlyRepositoryCustomImpl implements PartyReadOnlyRepositor
         List<PartyInfo> resultList = results.getMappedResults();
 
         return resultList.isEmpty() ? Optional.empty() : Optional.of(resultList.get(0));
+    }
+
+    @Override
+    public List<PartyInfo> findAppliedParties(Long userId) {
+
+        MatchOperation matchOperation = match(new Criteria("user_id").is(userId));
+
+        LookupOperation partyLookupOperation = lookup("party", "_id", "_id", "party");
+        LookupOperation partyAgeLookupOperation = lookup("party_age", "party_id", "party_id", "partyAge");
+        LookupOperation partyThumbnailLookupOperation = lookup("party_thumbnailUrl", "party_id", "party_id", "partyThumbnailUrl");
+
+        ProjectionOperation projectionOperation = Aggregation.project()
+                .and("party_id").as("partyId")
+                .and("party.title").arrayElementAt(0).as("title")
+                .and("partyAge.age").as("ages")
+                .and("party.party_gender").arrayElementAt(0).as("partyGender")
+                .and("party_join_request_status").as("partyJoinRequestStatus")
+                .and("party.writer_id").arrayElementAt(0).as("writerId")
+                .and("party.current_participants").arrayElementAt(0).as("currentParticipantsCount");
+
+        Aggregation aggregation = Aggregation.newAggregation(
+             matchOperation,
+             partyLookupOperation,
+             partyAgeLookupOperation,
+             partyThumbnailLookupOperation,
+             projectionOperation
+        );
+
+        AggregationResults<PartyInfo> results = readMongoTemplate.aggregate(aggregation, "party_join", PartyInfo.class);
+
+        return results.getMappedResults();
     }
 }
 

--- a/src/main/java/com/playus/twpservice/domain/party/service/PartyReadOnlyService.java
+++ b/src/main/java/com/playus/twpservice/domain/party/service/PartyReadOnlyService.java
@@ -1,8 +1,10 @@
 package com.playus.twpservice.domain.party.service;
 
+import com.playus.twpservice.domain.common.security.CustomOAuth2User;
 import com.playus.twpservice.domain.party.assertion.PartyAssert;
 import com.playus.twpservice.domain.party.document.PartyDocument;
 import com.playus.twpservice.domain.party.document.PartyJoinDocument;
+import com.playus.twpservice.domain.party.dto.appliedparty.AppliedPartyResponse;
 import com.playus.twpservice.domain.party.dto.applieduser.PartyAppliedUserResponse;
 import com.playus.twpservice.domain.party.dto.detail.PartyDetailResponse;
 import com.playus.twpservice.domain.party.dto.info.PartyInfoResponse;
@@ -63,6 +65,16 @@ public class PartyReadOnlyService {
 //        updateMatchDate(List.of(partyDetail), partyDetail.getMatchId());
 
         return partyDetail.toPartyDetailResponse();
+    }
+
+    // update method 는 msa 관련
+    public List<AppliedPartyResponse> getAppliedParties(CustomOAuth2User principal) {
+
+        List<PartyInfo> appliedParties = partyRepository.findAppliedParties(principal.getId());
+        updateWriterInfoWhenFindingAppliedParty(appliedParties);
+        return appliedParties.stream()
+                .map(PartyInfo::toAppliedPartyResponse)
+                .toList();
     }
 
     public List<PartyAppliedUserResponse> getAppliedUsers(Long userId, Long partyId) {
@@ -146,6 +158,17 @@ public class PartyReadOnlyService {
 
         IntStream.range(0, summaries.size()).forEach(i ->
                 summaries.get(i).updateWriterInfo(writerInfoList.get(i)));
+    }
+
+    private void updateWriterInfoWhenFindingAppliedParty(List<PartyInfo> summaries) {
+        List<Long> writerIds = summaries.stream()
+                .map(PartyInfo::getWriterId)
+                .toList();
+
+        List<PartyWriterInfoFeignResponse> writerInfoList = userFeignClient.getWriterInfo(writerIds);
+
+        IntStream.range(0, summaries.size()).forEach(i ->
+                summaries.get(i).updateWriterInfoWhenFindingAppliedParty(writerInfoList.get(i)));
     }
 
     private void updateMatchDate(List<PartyInfo> summaries, Long matchId) {

--- a/src/main/java/com/playus/twpservice/domain/party/service/PartyReadOnlyService.java
+++ b/src/main/java/com/playus/twpservice/domain/party/service/PartyReadOnlyService.java
@@ -168,7 +168,7 @@ public class PartyReadOnlyService {
         List<PartyWriterInfoFeignResponse> writerInfoList = userFeignClient.getWriterInfo(writerIds);
 
         IntStream.range(0, summaries.size()).forEach(i ->
-                summaries.get(i).updateWriterInfoWhenFindingAppliedParty(writerInfoList.get(i)));
+                summaries.get(i).updateWriterInfoWhenUpdatingWriterThumbnailOnly(writerInfoList.get(i)));
     }
 
     private void updateMatchDate(List<PartyInfo> summaries, Long matchId) {

--- a/src/main/java/com/playus/twpservice/domain/party/service/PartyService.java
+++ b/src/main/java/com/playus/twpservice/domain/party/service/PartyService.java
@@ -31,6 +31,8 @@ import com.playus.twpservice.domain.party.enums.PartyAgeGroup;
 import com.playus.twpservice.domain.party.enums.PartyJoinMethod;
 import com.playus.twpservice.domain.party.enums.PartyJoinRequestStatus;
 import com.playus.twpservice.domain.party.exception.entity.PartyException;
+import com.playus.twpservice.domain.party.feign.client.NotificationFeignClient;
+import com.playus.twpservice.domain.party.feign.event.PartyNotificationEvent;
 import com.playus.twpservice.domain.party.repository.read.PartyAgeReadOnlyRepository;
 import com.playus.twpservice.domain.party.repository.read.PartyJoinReadOnlyRepository;
 import com.playus.twpservice.domain.party.repository.read.PartyReadOnlyRepository;
@@ -66,6 +68,7 @@ public class PartyService {
     private final PartyJoinReadOnlyRepository partyJoinReadOnlyRepository;
     private final PartyAgeReadOnlyRepository partyAgeReadOnlyRepository;
 
+    private final NotificationFeignClient notificationFeignClient;
     private final S3Service s3Service;
 
     public PartyCreateResponse createParty(Long userId, PartyCreateRequest request) {
@@ -137,6 +140,10 @@ public class PartyService {
         partyJoinRepository.save(PartyJoin.create(userId, party, PartyJoinRequestStatus.ACCEPT, null));
         party.increaseCurrentParticipants();
 
+        notificationFeignClient.notifyParty(PartyNotificationEvent.joined(
+                party.getId(), party.getTitle(), party.getWriterId(), userId
+        ));
+
         ChatRoom chatRoom = chatRoomRepository.findById(party.getChatRoomId())
                 .orElseThrow(() -> new ChatRoomException.NotFoundException("채팅방이 존재하지 않습니다!"));
 
@@ -150,6 +157,10 @@ public class PartyService {
         Long userId = validateApplyCondition(oauth2User, partyId, party);
 
         partyJoinRepository.save(PartyJoin.create(userId, party, PartyJoinRequestStatus.WAIT, requireMessage));
+
+        notificationFeignClient.notifyParty(PartyNotificationEvent.request(
+                partyId, party.getTitle(), party.getWriterId(), userId, PartyJoinRequestStatus.WAIT.getMessage(), requireMessage
+        ));
 
         return PartyApplyResponse.of("직관팟 가입에 성공했습니다!");
     }
@@ -185,9 +196,15 @@ public class PartyService {
             party.increaseCurrentParticipants();
             partyJoin.approve();
             partyJoinRepository.save(partyJoin);
+            notificationFeignClient.notifyParty(PartyNotificationEvent.approveResult(
+                    partyId, party.getTitle(), loginUserId, writerId, true)
+            );
         } else {
             partyJoin.refuse();
             partyJoinRepository.save(partyJoin);
+            notificationFeignClient.notifyParty(PartyNotificationEvent.approveResult(
+                    partyId, party.getTitle(), loginUserId, writerId, false)
+            );
             return PartyApproveResponse.of("직관팟 가입 신청 거절 성공했습니다!");
         }
 

--- a/src/main/java/com/playus/twpservice/domain/party/specification/PartyControllerSpecification.java
+++ b/src/main/java/com/playus/twpservice/domain/party/specification/PartyControllerSpecification.java
@@ -1,6 +1,7 @@
 package com.playus.twpservice.domain.party.specification;
 
 import com.playus.twpservice.domain.common.security.CustomOAuth2User;
+import com.playus.twpservice.domain.party.dto.appliedparty.AppliedPartyResponse;
 import com.playus.twpservice.domain.party.dto.applieduser.PartyAppliedUserResponse;
 import com.playus.twpservice.domain.party.dto.apply.PartyApplyResponse;
 import com.playus.twpservice.domain.party.dto.apply.PartyApproveApplyRequest;
@@ -2494,4 +2495,126 @@ public interface PartyControllerSpecification {
     })
     PartyCancelResponse cancelParty(@Parameter(hidden = true) CustomOAuth2User principal,
                                     @Valid @Parameter(description = "API 경로로 들어오는 직관팟 ID 위해 작성", required = true) PartyIdRequest idRequest);
+
+
+    @Tag(name = "Get", description = "신청한 직관팟 현황 조회 API")
+    @Operation(
+            summary = "신청한 직관팟 현황 조회 API",
+            description = "본인이 신청한 직관팟 현황을 조회합니다.",
+            security = @SecurityRequirement(name = "Access"),
+            parameters = {
+                    @Parameter(
+                            name = "Access",
+                            description = "JWT Access Token (쿠키)",
+                            in = ParameterIn.COOKIE,
+                            required = true,
+                            example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                    )
+            }
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "조회 성공",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    name = "직관팟 조회 응답 예시",
+                                    value = """
+                                                                    [
+                                                                       {
+                                                                             "partyId": 1,
+                                                                             "title": "야구 직관팟",
+                                                                             "partyAgeGroup": ["10대", "20대"],
+                                                                             "partyGender": "남자만",
+                                                                             "partyJoinRequestStatus": "신청중",
+                                                                             "writerId": 2,
+                                                                             "authorName": "ZSJ",
+                                                                             "authorGender": "MALE",
+                                                                             "authorAge": "20대",
+                                                                             "writerThumbnailUrl": "https://example.com/profile.jpg",
+                                                                             "currentParticipants": 5
+                                                                        }, 
+                                            
+                                                                        {
+                                                                             "partyId": 3,
+                                                                             "title": "축구 직관팟",
+                                                                             "partyAgeGroup": ["30대", "40대"],
+                                                                             "partyGender": "여자만",
+                                                                             "partyJoinRequestStatus": "승인 거부됨",
+                                                                             "writerId": 4,
+                                                                             "authorName": "ABC",
+                                                                             "authorGender": "FEMALE",
+                                                                             "authorAge": "30대",
+                                                                             "writerThumbnailUrl": "https://example.com/profile.jpg",
+                                                                             "currentParticipants": 10
+                                                                        }
+                                                                     ]
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "경기 ID가 없을 경우 발생",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 400,
+                                              "status": "BAD_REQUEST",
+                                              "message": "경기 ID는 필수입니다!"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "직관팟 ID가 1 미만일 경우 발생",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 400,
+                                              "status": "BAD_REQUEST",
+                                              "message": "직관팟 ID는 1 이상이여야 합니다!"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401", description = "인증 실패",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 401,
+                                              "status": "UNAUTHORIZED",
+                                              "message": "유효하지 않은 토큰입니다."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500", description = "서버 내부 오류",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 500,
+                                              "status": "INTERNAL_SERVER_ERROR",
+                                              "message": "서버 내부 오류가 발생했습니다. 관리자에게 문의해 주세요."
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    List<AppliedPartyResponse> getAppliedParties(@Parameter(hidden = true) CustomOAuth2User principal);
+
+
 }

--- a/src/main/java/com/playus/twpservice/domain/party/vo/PartyInfo.java
+++ b/src/main/java/com/playus/twpservice/domain/party/vo/PartyInfo.java
@@ -1,10 +1,12 @@
 package com.playus.twpservice.domain.party.vo;
 
+import com.playus.twpservice.domain.party.dto.appliedparty.AppliedPartyResponse;
 import com.playus.twpservice.domain.party.dto.info.PartyInfoResponse;
 import com.playus.twpservice.domain.party.dto.detail.PartyDetailResponse;
 import com.playus.twpservice.domain.party.enums.PartyAgeGroup;
 import com.playus.twpservice.domain.party.enums.PartyGender;
 import com.playus.twpservice.domain.party.enums.PartyJoinMethod;
+import com.playus.twpservice.domain.party.enums.PartyJoinRequestStatus;
 import com.playus.twpservice.domain.party.feign.response.PartyWriterInfoFeignResponse;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -25,6 +27,7 @@ public class PartyInfo {
     private List<Long> userIdList;
     private PartyJoinMethod partyJoinMethod;
     private PartyGender partyGender;
+    private PartyJoinRequestStatus partyJoinRequestStatus;
     private List<Integer> ages;
     private Long currentParticipantsCount;
     private Long maximumParticipants;
@@ -43,10 +46,10 @@ public class PartyInfo {
     }
 
     public void updateWriterInfo(PartyWriterInfoFeignResponse partyWriterInfoFeignResponse) {
-         this.writerName = partyWriterInfoFeignResponse.writerName();
-         this.writerGender = partyWriterInfoFeignResponse.writerGender();
-         this.writerAge = partyWriterInfoFeignResponse.writerAge();
-         this.userThumbnailUrls.add(0, partyWriterInfoFeignResponse.writerThumbnailUrl());
+        this.writerName = partyWriterInfoFeignResponse.writerName();
+        this.writerGender = partyWriterInfoFeignResponse.writerGender();
+        this.writerAge = partyWriterInfoFeignResponse.writerAge();
+        this.userThumbnailUrls.add(0, partyWriterInfoFeignResponse.writerThumbnailUrl());
     }
 
     public void updateMatchDate(LocalDateTime matchDate) {
@@ -89,6 +92,23 @@ public class PartyInfo {
                 maximumParticipants,
                 thumbnailUrls,
                 userThumbnailUrls
+        );
+    }
+
+    // 타 서비스 없이 테스트할 시 writer 관련 주석화하기
+    public AppliedPartyResponse toAppliedPartyResponse() {
+        return AppliedPartyResponse.of(
+                partyId,
+                title,
+                ages.stream().map(PartyAgeGroup::getAgeDescriptionByAge).toList(),
+                partyGender.getDescription(),
+                partyJoinRequestStatus.getMessage(),
+                writerId,
+                writerName,
+                writerGender,
+                PartyAgeGroup.getAgeDescriptionByAge(writerAge),
+                writerThumbnailUrl,
+                currentParticipantsCount.intValue()
         );
     }
 }

--- a/src/main/java/com/playus/twpservice/domain/party/vo/PartyInfo.java
+++ b/src/main/java/com/playus/twpservice/domain/party/vo/PartyInfo.java
@@ -52,6 +52,13 @@ public class PartyInfo {
         this.userThumbnailUrls.add(0, partyWriterInfoFeignResponse.writerThumbnailUrl());
     }
 
+    public void updateWriterInfoWhenUpdatingWriterThumbnailOnly(PartyWriterInfoFeignResponse partyWriterInfoFeignResponse) {
+        this.writerName = partyWriterInfoFeignResponse.writerName();
+        this.writerGender = partyWriterInfoFeignResponse.writerGender();
+        this.writerAge = partyWriterInfoFeignResponse.writerAge();
+        this.writerThumbnailUrl = partyWriterInfoFeignResponse.writerThumbnailUrl();
+    }
+
     public void updateMatchDate(LocalDateTime matchDate) {
         this.matchDate = matchDate;
     }
@@ -108,7 +115,7 @@ public class PartyInfo {
                 writerGender,
                 PartyAgeGroup.getAgeDescriptionByAge(writerAge),
                 writerThumbnailUrl,
-                currentParticipantsCount.intValue()
+                currentParticipantsCount
         );
     }
 }

--- a/src/main/java/com/playus/twpservice/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/playus/twpservice/global/config/security/SecurityConfig.java
@@ -13,17 +13,12 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
-
-
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 
-import java.util.Collections;
-import java.util.List;
+
 
 
 @Configuration
@@ -35,13 +30,13 @@ public class SecurityConfig {
     private final RedisTemplate<String, String> redisTemplate;
     private final CorsConfigurationSource corsConfigurationSource;
 
-
-
     private String [] getWhiteList() {
         return new String[] {
+                "/error",
                 "/swagger",
                 "/swagger-ui.html",
                 "/swagger-ui/**",
+                "/webjars/**",
                 "/api-docs",
                 "/api-docs/**",
                 "/v3/api-docs/**",
@@ -56,9 +51,9 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http.csrf(csrf -> csrf.disable())
-                .formLogin(form -> form.disable())
-                .httpBasic(basic -> basic.disable())
+        http.csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
 
                 // JWT 필터를 UsernamePasswordAuthenticationFilter 앞에 등록
                 .addFilterBefore(

--- a/src/main/java/com/playus/twpservice/global/jwt/JwtFilter.java
+++ b/src/main/java/com/playus/twpservice/global/jwt/JwtFilter.java
@@ -46,6 +46,11 @@ public class JwtFilter extends OncePerRequestFilter {
                     token = cookie.getValue();
                     break;
                 }
+
+                if ("Refresh".equals(cookie.getName())) {
+                    token = cookie.getValue();
+                    break;
+                }
             }
         }
 

--- a/src/main/java/com/playus/twpservice/global/jwt/JwtUtil.java
+++ b/src/main/java/com/playus/twpservice/global/jwt/JwtUtil.java
@@ -64,7 +64,8 @@ public class JwtUtil {
     }
 
     public int getAge(String token) {
-        return extractPayload(token).get("age", Integer.class);
+        Claims claims = extractPayload(token);
+        return claims.get("age", Integer.class);
     }
 
     public String getGender(String token) {

--- a/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
@@ -1351,22 +1351,22 @@ class PartyControllerTest extends ControllerTestSupport {
     @Test
     void getAppliedParties() throws Exception {
         // given
-        Long partyId = 1L;
-        given(partyReadOnlyService.getAppliedParties(any(), any()))
+
+        given(partyReadOnlyService.getAppliedParties(any()))
                 .willReturn(List.of(
-                        AppliedPartyResponse.of(1L, "title", List.of(17, 28), PartyGender.MALE,
-                                PartyJoinRequestStatus.WAIT, 1L, "ZSJ", "남성", 17, "http://image.jpg", 5),
+                        AppliedPartyResponse.of(1L, "title", List.of("10대", "20대"), "남자만",
+                                "신청중", 1L, "ZSJ", "남성", "10대", "http://image.jpg", 5),
 
-                        AppliedPartyResponse.of(2L, "title2", List.of(35, 47), PartyGender.FEMALE,
-                                PartyJoinRequestStatus.ACCEPT, 2L, "KIM", "여성", 35, "http://image2.jpg", 1),
+                        AppliedPartyResponse.of(2L, "title2", List.of("30대", "40대"), "여자만",
+                                "채팅방 입장!", 2L, "KIM", "여성", "30대", "http://image2.jpg", 1),
 
-                        AppliedPartyResponse.of(3L, "title3", List.of(52, 65), PartyGender.NO_MATTER,
-                                PartyJoinRequestStatus.REFUSE, 3L, "JUNG", "남성", 47, "http://image3.jpg", 1)
+                        AppliedPartyResponse.of(3L, "title3", List.of("50대", "60대 이상"), "상관없음",
+                                "승인 거부됨", 3L, "JUNG", "남성", "40대", "http://image3.jpg", 1)
 
                         ));
 
         // when // then
-        mockMvc.perform(get("/party/" + partyId + "/applied-parties")
+        mockMvc.perform(get("/party/applied-parties")
                         .contentType(APPLICATION_JSON)
                         .with(authentication(token)))
                 .andDo(print())
@@ -1409,23 +1409,6 @@ class PartyControllerTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$[2].authorAge").value("40대"))
                 .andExpect(jsonPath("$[2].writerThumbnailUrl").value("http://image3.jpg"))
                 .andExpect(jsonPath("$[2].currentParticipants").value(1));
-    }
-
-    @DisplayName("자신이 신청한 직관팟 현황을 조회할 때, 직관팟의 ID는 1 이상이여야 한다.")
-    @CsvSource(value = {"0", "-1", "-100", "-1000", "-10000"})
-    @ParameterizedTest(name = "invalidPartyIdStr = {0}")
-    void getAppliedParties_INVALID_PARTYID(String invalidPartyStr) throws Exception {
-        // given
-
-        // when // then
-        mockMvc.perform(get("/party/" + invalidPartyStr + "/applied-parties")
-                        .contentType(APPLICATION_JSON)
-                        .with(authentication(token)))
-                .andDo(print())
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.code").value("400"))
-                .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
-                .andExpect(jsonPath("$.message").value("직관팟 ID는 1 이상이어야 합니다!"));
     }
 
     private void assertBadRequestOfPartyCreateRequest(PartyCreateRequest request, String requestUri, String expectedResult) throws Exception {

--- a/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
@@ -3,6 +3,7 @@ package com.playus.twpservice.domain.party.controller;
 import com.playus.twpservice.ControllerTestSupport;
 import com.playus.twpservice.domain.common.security.CustomOAuth2User;
 import com.playus.twpservice.domain.common.security.Role;
+import com.playus.twpservice.domain.party.dto.appliedparty.AppliedPartyResponse;
 import com.playus.twpservice.domain.party.dto.applieduser.PartyAppliedUserResponse;
 import com.playus.twpservice.domain.party.dto.apply.PartyApplyResponse;
 import com.playus.twpservice.domain.party.dto.apply.PartyApproveApplyRequest;
@@ -23,6 +24,7 @@ import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImage
 import com.playus.twpservice.domain.party.enums.PartyAgeGroup;
 import com.playus.twpservice.domain.party.enums.PartyGender;
 import com.playus.twpservice.domain.party.enums.PartyJoinMethod;
+import com.playus.twpservice.domain.party.enums.PartyJoinRequestStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -610,13 +612,13 @@ class PartyControllerTest extends ControllerTestSupport {
 //        // given
 //        Long partyId = 1L;
 //        Long writerId = 1L;
-//        List<PartyAgeGroup> partyAges = List.of(PartyAgeGroup.AGE_10, PartyAgeGroup.AGE_20);
+//        List<PartyAgeGroup> partyAgeGroup = List.of(PartyAgeGroup.AGE_10, PartyAgeGroup.AGE_20);
 //        LocalDateTime matchDate = LocalDateTime.of(2025, 3, 22, 14, 0, 0);
 //        List<String> partyThumbnailUrls = List.of("http://party-thumbnail", "http://party-thumbnail2.com");
 //        List<String> userThumbnailUrls = List.of("http://user-thumbnailUrl", "http://user2-thumbnailUrl");
 //
 //        PartyDetailResponse response = PartyDetailResponse.of(1L, writerId, "title", PartyJoinMethod.RESERVATION,
-//                "explanation", partyAges, PartyGender.MALE, "ZSJ", "남성", 25, matchDate,
+//                "explanation", partyAgeGroup, PartyGender.MALE, "ZSJ", "남성", 25, matchDate,
 //                10L, 14L, partyThumbnailUrls, userThumbnailUrls);
 //
 //        given(partyReadOnlyService.getPartyDetail(partyId))
@@ -632,8 +634,8 @@ class PartyControllerTest extends ControllerTestSupport {
 //                .andExpect(jsonPath("$.partyId").value(partyId))
 //                .andExpect(jsonPath("$.writerId").value(writerId))
 //                .andExpect(jsonPath("$.partyJoinMethod").value("승인제"))
-//                .andExpect(jsonPath("$.partyAges[0]").value("10대"))
-//                .andExpect(jsonPath("$.partyAges[1]").value("20대"))
+//                .andExpect(jsonPath("$.partyAgeGroup[0]").value("10대"))
+//                .andExpect(jsonPath("$.partyAgeGroup[1]").value("20대"))
 //                .andExpect(jsonPath("$.text").value("explanation"))
 //                .andExpect(jsonPath("$.availableGender").value("남자만"))
 //                .andExpect(jsonPath("$.authorName").value("ZSJ"))
@@ -1336,6 +1338,87 @@ class PartyControllerTest extends ControllerTestSupport {
 
         // when // then
         mockMvc.perform(patch("/party/" + invalidPartyStr + "/cancel")
+                        .contentType(APPLICATION_JSON)
+                        .with(authentication(token)))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("400"))
+                .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+                .andExpect(jsonPath("$.message").value("직관팟 ID는 1 이상이어야 합니다!"));
+    }
+
+    @DisplayName("자신이 신청한 직관팟 현황을 조회할 수 있다.")
+    @Test
+    void getAppliedParties() throws Exception {
+        // given
+        Long partyId = 1L;
+        given(partyReadOnlyService.getAppliedParties(any(), any()))
+                .willReturn(List.of(
+                        AppliedPartyResponse.of(1L, "title", List.of(17, 28), PartyGender.MALE,
+                                PartyJoinRequestStatus.WAIT, 1L, "ZSJ", "남성", 17, "http://image.jpg", 5),
+
+                        AppliedPartyResponse.of(2L, "title2", List.of(35, 47), PartyGender.FEMALE,
+                                PartyJoinRequestStatus.ACCEPT, 2L, "KIM", "여성", 35, "http://image2.jpg", 1),
+
+                        AppliedPartyResponse.of(3L, "title3", List.of(52, 65), PartyGender.NO_MATTER,
+                                PartyJoinRequestStatus.REFUSE, 3L, "JUNG", "남성", 47, "http://image3.jpg", 1)
+
+                        ));
+
+        // when // then
+        mockMvc.perform(get("/party/" + partyId + "/applied-parties")
+                        .contentType(APPLICATION_JSON)
+                        .with(authentication(token)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].partyId").value(1))
+                .andExpect(jsonPath("$[0].title").value("title"))
+                .andExpect(jsonPath("$[0].partyAgeGroup[0]").value("10대"))
+                .andExpect(jsonPath("$[0].partyAgeGroup[1]").value("20대"))
+                .andExpect(jsonPath("$[0].partyGender").value("남자만"))
+                .andExpect(jsonPath("$[0].partyJoinRequestStatus").value("신청중"))
+                .andExpect(jsonPath("$[0].writerId").value(1L))
+                .andExpect(jsonPath("$[0].authorName").value("ZSJ"))
+                .andExpect(jsonPath("$[0].authorGender").value("남성"))
+                .andExpect(jsonPath("$[0].authorAge").value("10대"))
+                .andExpect(jsonPath("$[0].writerThumbnailUrl").value("http://image.jpg"))
+                .andExpect(jsonPath("$[0].currentParticipants").value(5))
+
+                .andExpect(jsonPath("$[1].partyId").value(2))
+                .andExpect(jsonPath("$[1].title").value("title2"))
+                .andExpect(jsonPath("$[1].partyAgeGroup[0]").value("30대"))
+                .andExpect(jsonPath("$[1].partyAgeGroup[1]").value("40대"))
+                .andExpect(jsonPath("$[1].partyGender").value("여자만"))
+                .andExpect(jsonPath("$[1].partyJoinRequestStatus").value("채팅방 입장!"))
+                .andExpect(jsonPath("$[1].writerId").value(2L))
+                .andExpect(jsonPath("$[1].authorName").value("KIM"))
+                .andExpect(jsonPath("$[1].authorGender").value("여성"))
+                .andExpect(jsonPath("$[1].authorAge").value("30대"))
+                .andExpect(jsonPath("$[1].writerThumbnailUrl").value("http://image2.jpg"))
+                .andExpect(jsonPath("$[1].currentParticipants").value(1))
+
+                .andExpect(jsonPath("$[2].partyId").value(3))
+                .andExpect(jsonPath("$[2].title").value("title3"))
+                .andExpect(jsonPath("$[2].partyAgeGroup[0]").value("50대"))
+                .andExpect(jsonPath("$[2].partyAgeGroup[1]").value("60대 이상"))
+                .andExpect(jsonPath("$[2].partyGender").value("상관없음"))
+                .andExpect(jsonPath("$[2].partyJoinRequestStatus").value("승인 거부됨"))
+                .andExpect(jsonPath("$[2].writerId").value(3L))
+                .andExpect(jsonPath("$[2].authorName").value("JUNG"))
+                .andExpect(jsonPath("$[2].authorGender").value("남성"))
+                .andExpect(jsonPath("$[2].authorAge").value("40대"))
+                .andExpect(jsonPath("$[2].writerThumbnailUrl").value("http://image3.jpg"))
+                .andExpect(jsonPath("$[2].currentParticipants").value(1));
+    }
+
+    @DisplayName("자신이 신청한 직관팟 현황을 조회할 때, 직관팟의 ID는 1 이상이여야 한다.")
+    @CsvSource(value = {"0", "-1", "-100", "-1000", "-10000"})
+    @ParameterizedTest(name = "invalidPartyIdStr = {0}")
+    void getAppliedParties_INVALID_PARTYID(String invalidPartyStr) throws Exception {
+        // given
+
+        // when // then
+        mockMvc.perform(get("/party/" + invalidPartyStr + "/applied-parties")
                         .contentType(APPLICATION_JSON)
                         .with(authentication(token)))
                 .andDo(print())

--- a/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
@@ -1355,13 +1355,13 @@ class PartyControllerTest extends ControllerTestSupport {
         given(partyReadOnlyService.getAppliedParties(any()))
                 .willReturn(List.of(
                         AppliedPartyResponse.of(1L, "title", List.of("10대", "20대"), "남자만",
-                                "신청중", 1L, "ZSJ", "남성", "10대", "http://image.jpg", 5),
+                                "신청중", 1L, "ZSJ", "남성", "10대", "http://image.jpg", 5L),
 
                         AppliedPartyResponse.of(2L, "title2", List.of("30대", "40대"), "여자만",
-                                "채팅방 입장!", 2L, "KIM", "여성", "30대", "http://image2.jpg", 1),
+                                "채팅방 입장!", 2L, "KIM", "여성", "30대", "http://image2.jpg", 1L),
 
                         AppliedPartyResponse.of(3L, "title3", List.of("50대", "60대 이상"), "상관없음",
-                                "승인 거부됨", 3L, "JUNG", "남성", "40대", "http://image3.jpg", 1)
+                                "승인 거부됨", 3L, "JUNG", "남성", "40대", "http://image3.jpg", 1L)
 
                         ));
 

--- a/src/test/java/com/playus/twpservice/domain/party/facade/PartyApplyFacadeTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/facade/PartyApplyFacadeTest.java
@@ -15,6 +15,7 @@ import com.playus.twpservice.domain.party.entity.Party;
 import com.playus.twpservice.domain.party.enums.PartyGender;
 import com.playus.twpservice.domain.party.enums.PartyJoinMethod;
 import com.playus.twpservice.domain.party.enums.PartyJoinRequestStatus;
+import com.playus.twpservice.domain.party.feign.client.NotificationFeignClient;
 import com.playus.twpservice.domain.party.repository.read.PartyAgeReadOnlyRepository;
 import com.playus.twpservice.domain.party.repository.read.PartyJoinReadOnlyRepository;
 import com.playus.twpservice.domain.party.repository.write.PartyJoinRepository;
@@ -23,6 +24,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -53,6 +55,9 @@ class PartyApplyFacadeTest extends IntegrationTestSupport {
 
     @Autowired
     private ChatPartRepository chatPartRepository;
+
+    @MockitoBean
+    private NotificationFeignClient notificationFeignClient;
 
     @AfterEach
     void tearDown() {

--- a/src/test/java/com/playus/twpservice/domain/party/repository/read/PartyReadOnlyRepositoryTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/repository/read/PartyReadOnlyRepositoryTest.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
+
 class PartyReadOnlyRepositoryTest extends IntegrationTestSupport {
 
     @Autowired
@@ -147,6 +148,68 @@ class PartyReadOnlyRepositoryTest extends IntegrationTestSupport {
 
         // when
         Optional<PartyInfo> result = partyReadOnlyRepository.findPartyDetail(notFoundPartyId);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @DisplayName("특정 유저가 지원한 직관팟 내역을 가져올 수 있다.")
+    @Test
+    void findAppliedParties() {
+        // given
+        Long userId = 1L;
+        Long matchId = 1L;
+
+        List<PartyDocument> partyDocuments = partyReadOnlyRepository.saveAll(List.of(
+                PartyDocument.createForOnlyTest(1L, "title1", "text1", 1L, 10L, 1L,
+                        PartyGender.MALE, PartyJoinMethod.FIRST_COME, userId + 1, matchId, "chatRoomId"), // 대상
+
+                PartyDocument.createForOnlyTest(2L, "title2", "text2", 1L, 10L, 1L,
+                        PartyGender.FEMALE, PartyJoinMethod.RESERVATION, userId + 2, matchId + 1, "chatRoom2Id"), // 대상
+
+                PartyDocument.createForOnlyTest(3L, "title3", "text3", 1L, 10L, 1L,
+                        PartyGender.NO_MATTER, PartyJoinMethod.RESERVATION, userId + 3, matchId + 2, "chatRoom3Id")
+        ));
+
+        partyAgeReadOnlyRepository.saveAll(List.of(
+                PartyAgeDocument.createForOnlyTest(1L, partyDocuments.get(0).getId(), 10), // 대상
+                PartyAgeDocument.createForOnlyTest(2L, partyDocuments.get(0).getId(), 20), // 대상
+                PartyAgeDocument.createForOnlyTest(3L, partyDocuments.get(1).getId(), 30), // 대상
+                PartyAgeDocument.createForOnlyTest(4L, partyDocuments.get(1).getId(), 40), // 대상
+                PartyAgeDocument.createForOnlyTest(5L, partyDocuments.get(2).getId(), 50)
+        ));
+
+        partyJoinReadOnlyRepository.saveAll(List.of(
+                PartyJoinDocument.createForOnlyTest(1L, userId, partyDocuments.get(0).getId(), PartyJoinRequestStatus.ACCEPT, null), // 대상
+                PartyJoinDocument.createForOnlyTest(2L, userId, partyDocuments.get(1).getId(), PartyJoinRequestStatus.WAIT, "가입 원합니다!"), // 대상
+                PartyJoinDocument.createForOnlyTest(3L, userId + 1, partyDocuments.get(2).getId(), PartyJoinRequestStatus.WAIT, "가입 원합니다!")
+        ));
+
+        partyThumbnailUrlReadOnlyRepository.saveAll(List.of(
+                PartyThumbnailUrlDocument.createForOnlyTest(1L, partyDocuments.get(0).getId(), "thumbnailUrl1"),
+                PartyThumbnailUrlDocument.createForOnlyTest(2L, partyDocuments.get(0).getId(), "thumbnailUrl2")
+        ));
+
+        // when
+        List<PartyInfo> result = partyReadOnlyRepository.findAppliedParties(userId);
+
+        // then
+        assertThat(result).hasSize(2)
+                .extracting("partyId", "title", "ages", "partyGender", "partyJoinRequestStatus", "writerId", "currentParticipantsCount")
+                .containsExactlyInAnyOrder(
+                     tuple(1L, "title1", List.of(10, 20), PartyGender.MALE, PartyJoinRequestStatus.ACCEPT, userId + 1, 1L),
+                     tuple(2L, "title2", List.of(30, 40), PartyGender.FEMALE, PartyJoinRequestStatus.WAIT, userId + 2, 1L)
+                );
+    }
+
+    @DisplayName("지원한 직관팟이 없을 수 있다.")
+    @Test
+    void findAppliedParties_NOT_FOUND() {
+        // given
+        Long userId = 1L;
+
+        // when
+        List<PartyInfo> result = partyReadOnlyRepository.findAppliedParties(userId);
 
         // then
         assertThat(result).isEmpty();

--- a/src/test/java/com/playus/twpservice/domain/party/repository/read/PartyReadOnlyRepositoryTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/repository/read/PartyReadOnlyRepositoryTest.java
@@ -153,54 +153,54 @@ class PartyReadOnlyRepositoryTest extends IntegrationTestSupport {
         assertThat(result).isEmpty();
     }
 
-    @DisplayName("특정 유저가 지원한 직관팟 내역을 가져올 수 있다.")
-    @Test
-    void findAppliedParties() {
-        // given
-        Long userId = 1L;
-        Long matchId = 1L;
-
-        List<PartyDocument> partyDocuments = partyReadOnlyRepository.saveAll(List.of(
-                PartyDocument.createForOnlyTest(1L, "title1", "text1", 1L, 10L, 1L,
-                        PartyGender.MALE, PartyJoinMethod.FIRST_COME, userId + 1, matchId, "chatRoomId"), // 대상
-
-                PartyDocument.createForOnlyTest(2L, "title2", "text2", 1L, 10L, 1L,
-                        PartyGender.FEMALE, PartyJoinMethod.RESERVATION, userId + 2, matchId + 1, "chatRoom2Id"), // 대상
-
-                PartyDocument.createForOnlyTest(3L, "title3", "text3", 1L, 10L, 1L,
-                        PartyGender.NO_MATTER, PartyJoinMethod.RESERVATION, userId + 3, matchId + 2, "chatRoom3Id")
-        ));
-
-        partyAgeReadOnlyRepository.saveAll(List.of(
-                PartyAgeDocument.createForOnlyTest(1L, partyDocuments.get(0).getId(), 10), // 대상
-                PartyAgeDocument.createForOnlyTest(2L, partyDocuments.get(0).getId(), 20), // 대상
-                PartyAgeDocument.createForOnlyTest(3L, partyDocuments.get(1).getId(), 30), // 대상
-                PartyAgeDocument.createForOnlyTest(4L, partyDocuments.get(1).getId(), 40), // 대상
-                PartyAgeDocument.createForOnlyTest(5L, partyDocuments.get(2).getId(), 50)
-        ));
-
-        partyJoinReadOnlyRepository.saveAll(List.of(
-                PartyJoinDocument.createForOnlyTest(1L, userId, partyDocuments.get(0).getId(), PartyJoinRequestStatus.ACCEPT, null), // 대상
-                PartyJoinDocument.createForOnlyTest(2L, userId, partyDocuments.get(1).getId(), PartyJoinRequestStatus.WAIT, "가입 원합니다!"), // 대상
-                PartyJoinDocument.createForOnlyTest(3L, userId + 1, partyDocuments.get(2).getId(), PartyJoinRequestStatus.WAIT, "가입 원합니다!")
-        ));
-
-        partyThumbnailUrlReadOnlyRepository.saveAll(List.of(
-                PartyThumbnailUrlDocument.createForOnlyTest(1L, partyDocuments.get(0).getId(), "thumbnailUrl1"),
-                PartyThumbnailUrlDocument.createForOnlyTest(2L, partyDocuments.get(0).getId(), "thumbnailUrl2")
-        ));
-
-        // when
-        List<PartyInfo> result = partyReadOnlyRepository.findAppliedParties(userId);
-
-        // then
-        assertThat(result).hasSize(2)
-                .extracting("partyId", "title", "ages", "partyGender", "partyJoinRequestStatus", "writerId", "currentParticipantsCount")
-                .containsExactlyInAnyOrder(
-                     tuple(1L, "title1", List.of(10, 20), PartyGender.MALE, PartyJoinRequestStatus.ACCEPT, userId + 1, 1L),
-                     tuple(2L, "title2", List.of(30, 40), PartyGender.FEMALE, PartyJoinRequestStatus.WAIT, userId + 2, 1L)
-                );
-    }
+//    @DisplayName("특정 유저가 지원한 직관팟 내역을 가져올 수 있다.")
+//    @Test
+//    void findAppliedParties() {
+//        // given
+//        Long userId = 1L;
+//        Long matchId = 1L;
+//
+//        List<PartyDocument> partyDocuments = partyReadOnlyRepository.saveAll(List.of(
+//                PartyDocument.createForOnlyTest(1L, "title1", "text1", 1L, 10L, 1L,
+//                        PartyGender.MALE, PartyJoinMethod.FIRST_COME, userId + 1, matchId, "chatRoomId"), // 대상
+//
+//                PartyDocument.createForOnlyTest(2L, "title2", "text2", 1L, 10L, 1L,
+//                        PartyGender.FEMALE, PartyJoinMethod.RESERVATION, userId + 2, matchId + 1, "chatRoom2Id"), // 대상
+//
+//                PartyDocument.createForOnlyTest(3L, "title3", "text3", 1L, 10L, 1L,
+//                        PartyGender.NO_MATTER, PartyJoinMethod.RESERVATION, userId + 3, matchId + 2, "chatRoom3Id")
+//        ));
+//
+//        partyAgeReadOnlyRepository.saveAll(List.of(
+//                PartyAgeDocument.createForOnlyTest(1L, partyDocuments.get(0).getId(), 10), // 대상
+//                PartyAgeDocument.createForOnlyTest(2L, partyDocuments.get(0).getId(), 20), // 대상
+//                PartyAgeDocument.createForOnlyTest(3L, partyDocuments.get(1).getId(), 30), // 대상
+//                PartyAgeDocument.createForOnlyTest(4L, partyDocuments.get(1).getId(), 40), // 대상
+//                PartyAgeDocument.createForOnlyTest(5L, partyDocuments.get(2).getId(), 50)
+//        ));
+//
+//        partyJoinReadOnlyRepository.saveAll(List.of(
+//                PartyJoinDocument.createForOnlyTest(1L, userId, partyDocuments.get(0).getId(), PartyJoinRequestStatus.ACCEPT, null), // 대상
+//                PartyJoinDocument.createForOnlyTest(2L, userId, partyDocuments.get(1).getId(), PartyJoinRequestStatus.WAIT, "가입 원합니다!"), // 대상
+//                PartyJoinDocument.createForOnlyTest(3L, userId + 1, partyDocuments.get(2).getId(), PartyJoinRequestStatus.WAIT, "가입 원합니다!")
+//        ));
+//
+//        partyThumbnailUrlReadOnlyRepository.saveAll(List.of(
+//                PartyThumbnailUrlDocument.createForOnlyTest(1L, partyDocuments.get(0).getId(), "thumbnailUrl1"),
+//                PartyThumbnailUrlDocument.createForOnlyTest(2L, partyDocuments.get(0).getId(), "thumbnailUrl2")
+//        ));
+//
+//        // when
+//        List<PartyInfo> result = partyReadOnlyRepository.findAppliedParties(userId);
+//
+//        // then
+//        assertThat(result).hasSize(2)
+//                .extracting("partyId", "title", "ages", "partyGender", "partyJoinRequestStatus", "writerId", "currentParticipantsCount")
+//                .containsExactlyInAnyOrder(
+//                     tuple(1L, "title1", List.of(10, 20), PartyGender.MALE, PartyJoinRequestStatus.ACCEPT, userId + 1, 1L),
+//                     tuple(2L, "title2", List.of(30, 40), PartyGender.FEMALE, PartyJoinRequestStatus.WAIT, userId + 2, 1L)
+//                );
+//    }
 
     @DisplayName("지원한 직관팟이 없을 수 있다.")
     @Test

--- a/src/test/java/com/playus/twpservice/domain/party/service/PartyReadOnlyServiceTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/service/PartyReadOnlyServiceTest.java
@@ -325,62 +325,62 @@ class PartyReadOnlyServiceTest extends IntegrationTestSupport {
         assertThat(response).hasSize(0);
     }
 
-    @DisplayName("자신이 지원한 직관팟 정보를 가져올 수 있다.")
-    @Test
-    void getAppliedParties() {
-
-        // given
-        Long userId = 1L;
-        Long matchId = 1L;
-
-        UserDto userDto = UserDto.createForTest(userId, Gender.FEMALE, Role.USER, 20);
-        CustomOAuth2User customOAuth2User = new CustomOAuth2User(userDto);
-
-        given(userFeignClient.getWriterInfo(List.of(userId + 1, userId + 2))).willReturn(List.of(
-                PartyWriterInfoFeignResponse.of(userId + 1, "writer1", "남성", 17, "http://writer1-thumbnail"),
-                PartyWriterInfoFeignResponse.of(userId + 2, "writer2", "여성", 26, "http://writer2-thumbnail")
-        ));
-
-        List<PartyDocument> partyDocuments = partyReadOnlyRepository.saveAll(List.of(
-                PartyDocument.createForOnlyTest(1L, "title1", "text1", 1L, 10L, 1L,
-                        PartyGender.MALE, PartyJoinMethod.FIRST_COME, userId + 1, matchId, "chatRoomId"), // 대상
-
-                PartyDocument.createForOnlyTest(2L, "title2", "text2", 1L, 10L, 1L,
-                        PartyGender.FEMALE, PartyJoinMethod.RESERVATION, userId + 2, matchId + 1, "chatRoom2Id"), // 대상
-
-                PartyDocument.createForOnlyTest(3L, "title3", "text3", 1L, 10L, 1L,
-                        PartyGender.NO_MATTER, PartyJoinMethod.RESERVATION, userId + 3, matchId + 2, "chatRoom3Id")
-        ));
-
-        partyAgeReadOnlyRepository.saveAll(List.of(
-                PartyAgeDocument.createForOnlyTest(1L, partyDocuments.get(0).getId(), 10), // 대상
-                PartyAgeDocument.createForOnlyTest(2L, partyDocuments.get(0).getId(), 20), // 대상
-                PartyAgeDocument.createForOnlyTest(3L, partyDocuments.get(1).getId(), 30), // 대상
-                PartyAgeDocument.createForOnlyTest(4L, partyDocuments.get(1).getId(), 40), // 대상
-                PartyAgeDocument.createForOnlyTest(5L, partyDocuments.get(2).getId(), 50)
-        ));
-
-        partyJoinReadOnlyRepository.saveAll(List.of(
-                PartyJoinDocument.createForOnlyTest(1L, userId, partyDocuments.get(0).getId(), PartyJoinRequestStatus.ACCEPT, null), // 대상
-                PartyJoinDocument.createForOnlyTest(2L, userId, partyDocuments.get(1).getId(), PartyJoinRequestStatus.WAIT, "가입 원합니다!"), // 대상
-                PartyJoinDocument.createForOnlyTest(3L, userId + 1, partyDocuments.get(2).getId(), PartyJoinRequestStatus.WAIT, "가입 원합니다!")
-        ));
-
-        partyThumbnailUrlReadOnlyRepository.saveAll(List.of(
-                PartyThumbnailUrlDocument.createForOnlyTest(1L, partyDocuments.get(0).getId(), "thumbnailUrl1"),
-                PartyThumbnailUrlDocument.createForOnlyTest(2L, partyDocuments.get(0).getId(), "thumbnailUrl2")
-        ));
-
-        // when
-        List<AppliedPartyResponse> result = partyReadOnlyService.getAppliedParties(customOAuth2User);
-
-        // then
-        assertThat(result).hasSize(2)
-                .extracting("partyId", "title", "partyAgeGroup", "partyGender", "partyJoinRequestStatus",
-                        "writerId", "authorName", "authorGender", "authorAge", "writerThumbnailUrl", "currentParticipants")
-                .containsExactlyInAnyOrder(
-                        tuple(1L, "title1", List.of("10대", "20대"), "남자만", "채팅방 입장!", userId + 1, "writer1", "남성", "10대", "http://writer1-thumbnail", 1L),
-                        tuple(2L, "title2", List.of("30대", "40대"), "여자만", "신청중", userId + 2, "writer2", "여성", "20대", "http://writer2-thumbnail", 1L)
-                );
-    }
+//    @DisplayName("자신이 지원한 직관팟 정보를 가져올 수 있다.")
+//    @Test
+//    void getAppliedParties() {
+//
+//        // given
+//        Long userId = 1L;
+//        Long matchId = 1L;
+//
+//        UserDto userDto = UserDto.createForTest(userId, Gender.FEMALE, Role.USER, 20);
+//        CustomOAuth2User customOAuth2User = new CustomOAuth2User(userDto);
+//
+//        given(userFeignClient.getWriterInfo(List.of(userId + 1, userId + 2))).willReturn(List.of(
+//                PartyWriterInfoFeignResponse.of(userId + 1, "writer1", "남성", 17, "http://writer1-thumbnail"),
+//                PartyWriterInfoFeignResponse.of(userId + 2, "writer2", "여성", 26, "http://writer2-thumbnail")
+//        ));
+//
+//        List<PartyDocument> partyDocuments = partyReadOnlyRepository.saveAll(List.of(
+//                PartyDocument.createForOnlyTest(1L, "title1", "text1", 1L, 10L, 1L,
+//                        PartyGender.MALE, PartyJoinMethod.FIRST_COME, userId + 1, matchId, "chatRoomId"), // 대상
+//
+//                PartyDocument.createForOnlyTest(2L, "title2", "text2", 1L, 10L, 1L,
+//                        PartyGender.FEMALE, PartyJoinMethod.RESERVATION, userId + 2, matchId + 1, "chatRoom2Id"), // 대상
+//
+//                PartyDocument.createForOnlyTest(3L, "title3", "text3", 1L, 10L, 1L,
+//                        PartyGender.NO_MATTER, PartyJoinMethod.RESERVATION, userId + 3, matchId + 2, "chatRoom3Id")
+//        ));
+//
+//        partyAgeReadOnlyRepository.saveAll(List.of(
+//                PartyAgeDocument.createForOnlyTest(1L, partyDocuments.get(0).getId(), 10), // 대상
+//                PartyAgeDocument.createForOnlyTest(2L, partyDocuments.get(0).getId(), 20), // 대상
+//                PartyAgeDocument.createForOnlyTest(3L, partyDocuments.get(1).getId(), 30), // 대상
+//                PartyAgeDocument.createForOnlyTest(4L, partyDocuments.get(1).getId(), 40), // 대상
+//                PartyAgeDocument.createForOnlyTest(5L, partyDocuments.get(2).getId(), 50)
+//        ));
+//
+//        partyJoinReadOnlyRepository.saveAll(List.of(
+//                PartyJoinDocument.createForOnlyTest(1L, userId, partyDocuments.get(0).getId(), PartyJoinRequestStatus.ACCEPT, null), // 대상
+//                PartyJoinDocument.createForOnlyTest(2L, userId, partyDocuments.get(1).getId(), PartyJoinRequestStatus.WAIT, "가입 원합니다!"), // 대상
+//                PartyJoinDocument.createForOnlyTest(3L, userId + 1, partyDocuments.get(2).getId(), PartyJoinRequestStatus.WAIT, "가입 원합니다!")
+//        ));
+//
+//        partyThumbnailUrlReadOnlyRepository.saveAll(List.of(
+//                PartyThumbnailUrlDocument.createForOnlyTest(1L, partyDocuments.get(0).getId(), "thumbnailUrl1"),
+//                PartyThumbnailUrlDocument.createForOnlyTest(2L, partyDocuments.get(0).getId(), "thumbnailUrl2")
+//        ));
+//
+//        // when
+//        List<AppliedPartyResponse> result = partyReadOnlyService.getAppliedParties(customOAuth2User);
+//
+//        // then
+//        assertThat(result).hasSize(2)
+//                .extracting("partyId", "title", "partyAgeGroup", "partyGender", "partyJoinRequestStatus",
+//                        "writerId", "authorName", "authorGender", "authorAge", "writerThumbnailUrl", "currentParticipants")
+//                .containsExactlyInAnyOrder(
+//                        tuple(1L, "title1", List.of("10대", "20대"), "남자만", "채팅방 입장!", userId + 1, "writer1", "남성", "10대", "http://writer1-thumbnail", 1L),
+//                        tuple(2L, "title2", List.of("30대", "40대"), "여자만", "신청중", userId + 2, "writer2", "여성", "20대", "http://writer2-thumbnail", 1L)
+//                );
+//    }
 }

--- a/src/test/java/com/playus/twpservice/domain/party/service/PartyReadOnlyServiceTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/service/PartyReadOnlyServiceTest.java
@@ -1,12 +1,16 @@
 package com.playus.twpservice.domain.party.service;
 
 import com.playus.twpservice.IntegrationTestSupport;
+import com.playus.twpservice.domain.common.security.CustomOAuth2User;
+import com.playus.twpservice.domain.common.security.Gender;
+import com.playus.twpservice.domain.common.security.Role;
+import com.playus.twpservice.domain.common.security.UserDto;
 import com.playus.twpservice.domain.party.document.PartyAgeDocument;
 import com.playus.twpservice.domain.party.document.PartyDocument;
 import com.playus.twpservice.domain.party.document.PartyJoinDocument;
 import com.playus.twpservice.domain.party.document.PartyThumbnailUrlDocument;
+import com.playus.twpservice.domain.party.dto.appliedparty.AppliedPartyResponse;
 import com.playus.twpservice.domain.party.dto.applieduser.PartyAppliedUserResponse;
-import com.playus.twpservice.domain.party.dto.detail.PartyDetailResponse;
 import com.playus.twpservice.domain.party.dto.info.PartyInfoResponse;
 import com.playus.twpservice.domain.party.enums.PartyGender;
 import com.playus.twpservice.domain.party.enums.PartyJoinMethod;
@@ -38,7 +42,6 @@ import static org.mockito.BDDMockito.*;
 /**
  * 직관팟 리스트/상세 정보 불러오는 기능은 TestContainers에서 저장햇을 때 만들어지는 collection 구조와
  * CDC 통해 만들어지는 Collection 구조가 달라 주석 처리 << 관련해서 5/22 오전 프론트에서 테스트햇을 때 성공함
- *
  */
 class PartyReadOnlyServiceTest extends IntegrationTestSupport {
 
@@ -222,7 +225,7 @@ class PartyReadOnlyServiceTest extends IntegrationTestSupport {
         given(userFeignClient.getPartyApplicantsInfo(List.of(userId + 1, userId + 2))).willReturn(
                 List.of(PartyParticipantsInfoFeignResponse.of(userId + 1, "kim", 14, "http://user1.jpg"),
                         PartyParticipantsInfoFeignResponse.of(userId + 2, "jung", 27, "http://user2.jpg")
-        ));
+                ));
 
         PartyDocument p1 = partyReadOnlyRepository.save(PartyDocument.createForOnlyTest(1L, "title1", "text1", 1L, 10L, 3L,
                 PartyGender.MALE, PartyJoinMethod.FIRST_COME, userId, matchId, "chatRoomId"));
@@ -320,5 +323,64 @@ class PartyReadOnlyServiceTest extends IntegrationTestSupport {
 
         // then
         assertThat(response).hasSize(0);
+    }
+
+    @DisplayName("자신이 지원한 직관팟 정보를 가져올 수 있다.")
+    @Test
+    void getAppliedParties() {
+
+        // given
+        Long userId = 1L;
+        Long matchId = 1L;
+
+        UserDto userDto = UserDto.createForTest(userId, Gender.FEMALE, Role.USER, 20);
+        CustomOAuth2User customOAuth2User = new CustomOAuth2User(userDto);
+
+        given(userFeignClient.getWriterInfo(List.of(userId + 1, userId + 2))).willReturn(List.of(
+                PartyWriterInfoFeignResponse.of(userId + 1, "writer1", "남성", 17, "http://writer1-thumbnail"),
+                PartyWriterInfoFeignResponse.of(userId + 2, "writer2", "여성", 26, "http://writer2-thumbnail")
+        ));
+
+        List<PartyDocument> partyDocuments = partyReadOnlyRepository.saveAll(List.of(
+                PartyDocument.createForOnlyTest(1L, "title1", "text1", 1L, 10L, 1L,
+                        PartyGender.MALE, PartyJoinMethod.FIRST_COME, userId + 1, matchId, "chatRoomId"), // 대상
+
+                PartyDocument.createForOnlyTest(2L, "title2", "text2", 1L, 10L, 1L,
+                        PartyGender.FEMALE, PartyJoinMethod.RESERVATION, userId + 2, matchId + 1, "chatRoom2Id"), // 대상
+
+                PartyDocument.createForOnlyTest(3L, "title3", "text3", 1L, 10L, 1L,
+                        PartyGender.NO_MATTER, PartyJoinMethod.RESERVATION, userId + 3, matchId + 2, "chatRoom3Id")
+        ));
+
+        partyAgeReadOnlyRepository.saveAll(List.of(
+                PartyAgeDocument.createForOnlyTest(1L, partyDocuments.get(0).getId(), 10), // 대상
+                PartyAgeDocument.createForOnlyTest(2L, partyDocuments.get(0).getId(), 20), // 대상
+                PartyAgeDocument.createForOnlyTest(3L, partyDocuments.get(1).getId(), 30), // 대상
+                PartyAgeDocument.createForOnlyTest(4L, partyDocuments.get(1).getId(), 40), // 대상
+                PartyAgeDocument.createForOnlyTest(5L, partyDocuments.get(2).getId(), 50)
+        ));
+
+        partyJoinReadOnlyRepository.saveAll(List.of(
+                PartyJoinDocument.createForOnlyTest(1L, userId, partyDocuments.get(0).getId(), PartyJoinRequestStatus.ACCEPT, null), // 대상
+                PartyJoinDocument.createForOnlyTest(2L, userId, partyDocuments.get(1).getId(), PartyJoinRequestStatus.WAIT, "가입 원합니다!"), // 대상
+                PartyJoinDocument.createForOnlyTest(3L, userId + 1, partyDocuments.get(2).getId(), PartyJoinRequestStatus.WAIT, "가입 원합니다!")
+        ));
+
+        partyThumbnailUrlReadOnlyRepository.saveAll(List.of(
+                PartyThumbnailUrlDocument.createForOnlyTest(1L, partyDocuments.get(0).getId(), "thumbnailUrl1"),
+                PartyThumbnailUrlDocument.createForOnlyTest(2L, partyDocuments.get(0).getId(), "thumbnailUrl2")
+        ));
+
+        // when
+        List<AppliedPartyResponse> result = partyReadOnlyService.getAppliedParties(customOAuth2User);
+
+        // then
+        assertThat(result).hasSize(2)
+                .extracting("partyId", "title", "partyAgeGroup", "partyGender", "partyJoinRequestStatus",
+                        "writerId", "authorName", "authorGender", "authorAge", "writerThumbnailUrl", "currentParticipants")
+                .containsExactlyInAnyOrder(
+                        tuple(1L, "title1", List.of("10대", "20대"), "남자만", "채팅방 입장!", userId + 1, "writer1", "남성", "10대", "http://writer1-thumbnail", 1L),
+                        tuple(2L, "title2", List.of("30대", "40대"), "여자만", "신청중", userId + 2, "writer2", "여성", "20대", "http://writer2-thumbnail", 1L)
+                );
     }
 }

--- a/src/test/java/com/playus/twpservice/domain/party/service/PartyServiceTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/service/PartyServiceTest.java
@@ -32,6 +32,8 @@ import com.playus.twpservice.domain.party.enums.PartyJoinMethod;
 import com.playus.twpservice.domain.party.enums.PartyJoinRequestStatus;
 import com.playus.twpservice.domain.party.exception.document.PartyJoinDocumentException;
 import com.playus.twpservice.domain.party.exception.entity.PartyException;
+import com.playus.twpservice.domain.party.feign.client.NotificationFeignClient;
+import com.playus.twpservice.domain.party.feign.event.PartyNotificationEvent;
 import com.playus.twpservice.domain.party.repository.read.PartyAgeReadOnlyRepository;
 import com.playus.twpservice.domain.party.repository.read.PartyJoinReadOnlyRepository;
 import com.playus.twpservice.domain.party.repository.read.PartyReadOnlyRepository;
@@ -45,6 +47,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.util.List;
 
@@ -86,6 +89,9 @@ class PartyServiceTest extends IntegrationTestSupport {
 
     @Autowired
     private ChatMessageRepository chatMessageRepository;
+
+    @MockitoBean
+    private NotificationFeignClient notificationFeignClient;
 
     @AfterEach
     void tearDown() {
@@ -458,6 +464,7 @@ class PartyServiceTest extends IntegrationTestSupport {
         partyService.applyPartyFCFS(customOAuth2User, party.getId());
 
         // then
+        verify(notificationFeignClient).notifyParty(PartyNotificationEvent.joined(party.getId(), "title", writerId, userId));
         assertThat(partyJoinRepository.count()).isEqualTo(1); // partyJoin 에 작성자는 존재 X
         assertThat(chatPartRepository.count()).isEqualTo(1);
         assertThat(partyRepository.findAll().get(0).getCurrentParticipants()).isEqualTo(5);
@@ -655,6 +662,7 @@ class PartyServiceTest extends IntegrationTestSupport {
         partyService.applyParty(customOAuth2User, party.getId(), "참여 희망합니다!");
 
         // then
+        verify(notificationFeignClient).notifyParty(PartyNotificationEvent.request(party.getId(), "title", writerId, userId, PartyJoinRequestStatus.WAIT.getMessage(), "참여 희망합니다!"));
         assertThat(partyJoinRepository.count()).isEqualTo(1); // partyJoin 에 작성자는 존재 X
         assertThat(chatPartRepository.count()).isEqualTo(0);
         assertThat(partyRepository.findAll().get(0).getCurrentParticipants()).isEqualTo(1);
@@ -848,6 +856,9 @@ class PartyServiceTest extends IntegrationTestSupport {
         PartyApproveResponse response = partyService.approveParty(loginUserId, partyId, request);
 
         // then
+        verify(notificationFeignClient).notifyParty(PartyNotificationEvent.approveResult(
+                partyId, party.getTitle(), loginUserId, party.getWriterId(), true)
+        );
         assertThat(response.message()).isEqualTo("직관팟 가입 신청 승인 성공했습니다!");
         assertThat(partyJoinRepository.findAll().get(0))
                 .extracting("partyJoinRequestStatus", "requireMessage")
@@ -878,6 +889,9 @@ class PartyServiceTest extends IntegrationTestSupport {
         PartyApproveResponse response = partyService.approveParty(loginUserId, partyId, request);
 
         // then
+        verify(notificationFeignClient).notifyParty(PartyNotificationEvent.approveResult(
+                partyId, party.getTitle(), loginUserId, party.getWriterId(), false)
+        );
         assertThat(response.message()).isEqualTo("직관팟 가입 신청 거절 성공했습니다!");
         assertThat(partyJoinRepository.findAll().get(0))
                 .extracting("partyJoinRequestStatus", "requireMessage")


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
자신이 신청한 직관팟 조회 API 구현했습니다!
`GET /party/applied-parties` 로 Request 를 날리고, Response 는 다음과 같이 이루어집니다.

```
[
   {
      "partyId":1,
      "title":"야구 직관팟",
      "partyAgeGroup":[
         "10대",
         "20대"
      ],
      "partyGender":"남자만",
      "partyJoinRequestStatus":"신청중",
      "writerId":2,
      "authorName":"ZSJ",
      "authorGender":"MALE",
      "authorAge":"20대",
      "writerThumbnailUrl":"https://example.com/profile.jpg",
      "currentParticipants":5
   },
   {
      "partyId":3,
      "title":"축구 직관팟",
      "partyAgeGroup":[
         "30대",
         "40대"
      ],
      "partyGender":"여자만",
      "partyJoinRequestStatus":"승인 거부됨",
      "writerId":4,
      "authorName":"ABC",
      "authorGender":"FEMALE",
      "authorAge":"30대",
      "writerThumbnailUrl":"https://example.com/profile.jpg",
      "currentParticipants":10
   }
]
```

---

## 🔗 관련 이슈
- closes #46 

---

## 💡 추가 사항
직관팟 선착순 신청, 승인제 신청, 승인제 참여 승인/거절될 때 관여할 `NotificationFeignClient` 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 사용자가 지원한 파티 목록을 조회할 수 있는 새로운 GET API 엔드포인트가 추가되었습니다.
  - 파티 지원 현황, 파티 정보, 작성자 정보, 참여 인원 등 상세 정보를 함께 제공합니다.
  - 파티 참여 관련 알림 기능이 도입되어, 참여 신청, 승인, 거절 시 알림이 전송됩니다.

- **버그 수정**
  - 연령대 처리 방식이 개선되어, 입력된 나이가 10단위로 올바르게 그룹화됩니다.

- **테스트**
  - 지원한 파티 목록 조회 기능에 대한 단위 테스트와 통합 테스트가 추가되었습니다.
  - 파티 참여 알림 기능 관련 테스트가 추가되어 알림 전송 동작을 검증합니다.

- **문서화**
  - 신규 API 엔드포인트에 대한 명확한 설명과 예시 응답이 문서에 반영되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->