### PR TITLE
CS-342 refactor/토큰 블랙리스트 확인 위한 api 호출 추가

### DIFF
--- a/src/main/java/com/playus/twpservice/domain/chat/specification/ChatControllerSpecification.java
+++ b/src/main/java/com/playus/twpservice/domain/chat/specification/ChatControllerSpecification.java
@@ -131,10 +131,10 @@ public interface ChatControllerSpecification {
             )
     )
     ResponseEntity<ChatResponse> getChatMessages(@Parameter(hidden = true) CustomOAuth2User principal,
-                                                 @Valid @Parameter(description = "채팅방 ID", required = true) Long roomId,
-                                                 @Valid @Parameter(description = "페이지 번호", required = true) int pageNumber,
-                                                 @Valid @Parameter(description = "페이지 크기", required = true) int pageSize,
-                                                 @Valid @Parameter(description = "마지막 메시지 타임스탬프") LocalDateTime lastMessageTimeStamp);
+                                                 @Parameter(description = "채팅방 ID", required = true) Long roomId,
+                                                 @Parameter(description = "페이지 번호", required = true) int pageNumber,
+                                                 @Parameter(description = "페이지 크기", required = true) int pageSize,
+                                                 @Parameter(description = "마지막 메시지 타임스탬프") LocalDateTime lastMessageTimeStamp);
 
     @Tag(name = "Chat Get", description = "채팅방 참여자 정보 조회 API")
     @Operation(
@@ -225,7 +225,7 @@ public interface ChatControllerSpecification {
             )
     )
     ResponseEntity<ChatUserInfoResponse> getChatParticipants(@Parameter(hidden = true) CustomOAuth2User principal,
-                                                             @Valid @Parameter(description = "채팅방 ID", required = true) Long roomId);
+                                                             @Parameter(description = "채팅방 ID", required = true) Long roomId);
 
     @Tag(name = "Chat Delete", description = "채팅방 퇴장 API")
     @Operation(
@@ -298,7 +298,7 @@ public interface ChatControllerSpecification {
             )
     )
     ResponseEntity<Void> exitChatRoom(@Parameter(hidden = true) CustomOAuth2User principal,
-                                      @Valid @Parameter(description = "채팅방 ID", required = true) Long roomId);
+                                      @Parameter(description = "채팅방 ID", required = true) Long roomId);
 
-    void message(@Valid ChatMessageRequest request, SimpMessageHeaderAccessor headerAccessor);
+    void message(ChatMessageRequest request, SimpMessageHeaderAccessor headerAccessor);
 } 

--- a/src/main/java/com/playus/twpservice/domain/common/feign/client/UserFeignClient.java
+++ b/src/main/java/com/playus/twpservice/domain/common/feign/client/UserFeignClient.java
@@ -1,12 +1,11 @@
 package com.playus.twpservice.domain.common.feign.client;
 
 import com.playus.twpservice.domain.common.feign.fallback.UserFeignFallback;
-import com.playus.twpservice.domain.common.feign.response.PartyParticipantsInfoFeignResponse;
-import com.playus.twpservice.domain.common.feign.response.PartyUserThumbnailUrlListResponse;
-import com.playus.twpservice.domain.common.feign.response.PartyWriterInfoFeignResponse;
-import com.playus.twpservice.domain.common.feign.response.UserInfoResponse;
+import com.playus.twpservice.domain.common.feign.request.TokenValidationRequest;
+import com.playus.twpservice.domain.common.feign.response.*;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -29,4 +28,7 @@ public interface UserFeignClient {
 
      @PostMapping("/info")
      List<PartyParticipantsInfoFeignResponse> getPartyApplicantsInfo(@RequestBody List<Long> userIdList);
+
+     @PostMapping("/token/blacklist-check")
+     ResponseEntity<TokenValidationResponse> checkBlackList(@RequestBody TokenValidationRequest req);
 }

--- a/src/main/java/com/playus/twpservice/domain/common/feign/fallback/UserFeignFallback.java
+++ b/src/main/java/com/playus/twpservice/domain/common/feign/fallback/UserFeignFallback.java
@@ -1,11 +1,10 @@
 package com.playus.twpservice.domain.common.feign.fallback;
 
 import com.playus.twpservice.domain.common.feign.client.UserFeignClient;
-import com.playus.twpservice.domain.common.feign.response.PartyParticipantsInfoFeignResponse;
-import com.playus.twpservice.domain.common.feign.response.PartyUserThumbnailUrlListResponse;
-import com.playus.twpservice.domain.common.feign.response.PartyWriterInfoFeignResponse;
-import com.playus.twpservice.domain.common.feign.response.UserInfoResponse;
+import com.playus.twpservice.domain.common.feign.request.TokenValidationRequest;
+import com.playus.twpservice.domain.common.feign.response.*;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -37,4 +36,12 @@ public class UserFeignFallback implements UserFeignClient {
         log.error("503 happened in UserFeignClient at fetching applicants data!!!");
         return List.of(PartyParticipantsInfoFeignResponse.withServiceUnavailable());
     }
+
+    @Override
+    public ResponseEntity<TokenValidationResponse> checkBlackList(TokenValidationRequest req) {
+        log.error("503 happened in UserFeignClient at validating token!!!");
+        return ResponseEntity.internalServerError().body(TokenValidationResponse.of(true));
+    }
+
+
 }

--- a/src/main/java/com/playus/twpservice/domain/common/feign/request/TokenValidationRequest.java
+++ b/src/main/java/com/playus/twpservice/domain/common/feign/request/TokenValidationRequest.java
@@ -1,0 +1,17 @@
+package com.playus.twpservice.domain.common.feign.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+@Builder
+public record TokenValidationRequest(
+        @NotBlank(message = "토큰은 필수 입력값입니다")
+        String token
+) {
+
+     public static TokenValidationRequest of (String token) {
+         return TokenValidationRequest.builder()
+                 .token(token)
+                 .build();
+     }
+}

--- a/src/main/java/com/playus/twpservice/domain/common/feign/response/TokenValidationResponse.java
+++ b/src/main/java/com/playus/twpservice/domain/common/feign/response/TokenValidationResponse.java
@@ -1,0 +1,14 @@
+package com.playus.twpservice.domain.common.feign.response;
+
+import lombok.Builder;
+
+@Builder
+public record TokenValidationResponse(
+        boolean blacklisted
+) {
+    public static TokenValidationResponse of (Boolean blacklisted) {
+        return TokenValidationResponse.builder()
+                .blacklisted(blacklisted)
+                .build();
+    }
+}

--- a/src/main/java/com/playus/twpservice/domain/party/dto/info/PartyInfoResponse.java
+++ b/src/main/java/com/playus/twpservice/domain/party/dto/info/PartyInfoResponse.java
@@ -56,8 +56,8 @@ public record PartyInfoResponse(
                 .availableGender(availableGender.getDescription())
                 .authorName(authorName)
                 .authorGender(authorGender)
-                .authorAge(PartyAgeGroup.getAgeDescriptionByAge((authorAge / 10) * 10))
-//                .authorAge(PartyAgeGroup.getAgeDescriptionByAge(10)) // 임시
+//                .authorAge(PartyAgeGroup.getAgeDescriptionByAge((authorAge / 10) * 10))
+                .authorAge(PartyAgeGroup.getAgeDescriptionByAge(10)) // 임시
                 .matchDate(matchDate)
                 .currentParticipantsCount(currentParticipantsCount)
                 .maximumParticipantsCount(maximumParticipantsCount)

--- a/src/main/java/com/playus/twpservice/domain/party/specification/PartyControllerSpecification.java
+++ b/src/main/java/com/playus/twpservice/domain/party/specification/PartyControllerSpecification.java
@@ -680,7 +680,7 @@ public interface PartyControllerSpecification {
                     )
             )
     })
-    List<PartyInfoResponse> getPartiesByMatchId(@Valid @Parameter(description = "직관팟 리스트 요청", required = true) PartyInfoRequest request);
+    List<PartyInfoResponse> getPartiesByMatchId(@Valid @Parameter(description = "직관팟 리스트 요청", hidden = true) PartyInfoRequest request);
 
     @Tag(name = "Party Get", description = "직관팟 상세정보 조회 API")
     @Operation(
@@ -800,7 +800,7 @@ public interface PartyControllerSpecification {
                     )
             )
     })
-    PartyDetailResponse getPartyDetail(@Valid @Parameter(description = "직관팟 상세정보 요청", required = true) PartyDetailRequest request);
+    PartyDetailResponse getPartyDetail(@Valid @Parameter(description = "직관팟 상세정보 요청", hidden = true) PartyDetailRequest request);
 
 
     @Tag(name = "Party Put", description = "직관팟 수정 API")
@@ -1233,7 +1233,7 @@ public interface PartyControllerSpecification {
             )
     })
     PartyUpdateResponse updateParty(@Parameter(hidden = true) CustomOAuth2User principal,
-                                    @Valid @Parameter(description = "API 경로로 들어오는 직관팟 ID 위해 작성", required = true) PartyIdRequest idRequest,
+                                    @Valid @Parameter(description = "API 경로로 들어오는 직관팟 ID 위해 작성", hidden = true) PartyIdRequest idRequest,
                                     @Valid @Parameter(description = "직관팟 수정 요청", required = true) PartyUpdateRequest request);
 
     @Tag(name = "Party Patch", description = "직관팟 삭제 API")
@@ -1350,7 +1350,7 @@ public interface PartyControllerSpecification {
             )
     })
     PartyDeleteResponse deleteParty(@Parameter(hidden = true) CustomOAuth2User principal,
-                                    @Valid @Parameter(description = "API 경로로 들어오는 직관팟 ID 위해 작성", required = true) PartyIdRequest idRequest);
+                                    @Valid @Parameter(description = "API 경로로 들어오는 직관팟 ID 위해 작성", hidden = true) PartyIdRequest idRequest);
 
 
     @Tag(name = "Party Post", description = "직관팟 선착순 신청 API")
@@ -1527,7 +1527,7 @@ public interface PartyControllerSpecification {
             )
     })
     PartyApplyResponse applyPartyFCFS(@Parameter(hidden = true) CustomOAuth2User principal,
-                                      @Valid @Parameter(description = "API 경로로 들어오는 직관팟 ID 위해 작성", required = true) PartyIdRequest idRequest);
+                                      @Valid @Parameter(description = "API 경로로 들어오는 직관팟 ID 위해 작성", hidden = true) PartyIdRequest idRequest);
 
 
     @Tag(name = "Party Post", description = "승인제 직관팟 신청 API")
@@ -1718,7 +1718,7 @@ public interface PartyControllerSpecification {
             )
     })
     PartyApplyResponse applyParty(@Parameter(hidden = true) CustomOAuth2User principal,
-                                  @Valid @Parameter(description = "API 경로로 들어오는 직관팟 ID 위해 작성", required = true) PartyIdRequest idRequest,
+                                  @Valid @Parameter(description = "API 경로로 들어오는 직관팟 ID 위해 작성", hidden = true) PartyIdRequest idRequest,
                                   @Valid @Parameter(description = "직관팟 신청 시 방장에게 보여줄 requireMessage 작성") PartyApproveApplyRequest request);
 
 
@@ -2020,7 +2020,7 @@ public interface PartyControllerSpecification {
             )
     })
     PartyApproveResponse approveParty(@Parameter(hidden = true) CustomOAuth2User principal,
-                                      @Valid @Parameter(description = "API 경로로 들어오는 직관팟 ID 위해 작성", required = true) PartyIdRequest idRequest,
+                                      @Valid @Parameter(description = "API 경로로 들어오는 직관팟 ID 위해 작성", hidden = true) PartyIdRequest idRequest,
                                       @Valid @Parameter(description = "방장이 승인할 userId와 승인 여부 작성") PartyApproveRequest request);
 
 
@@ -2315,7 +2315,7 @@ public interface PartyControllerSpecification {
             )
     })
     PartyLeaveResponse leaveParty(@Parameter(hidden = true) CustomOAuth2User principal,
-                                  @Valid @Parameter(description = "API 경로로 들어오는 직관팟 ID 위해 작성", required = true) PartyIdRequest idRequest);
+                                  @Valid @Parameter(description = "API 경로로 들어오는 직관팟 ID 위해 작성", hidden = true) PartyIdRequest idRequest);
 
 
 
@@ -2494,7 +2494,7 @@ public interface PartyControllerSpecification {
             )
     })
     PartyCancelResponse cancelParty(@Parameter(hidden = true) CustomOAuth2User principal,
-                                    @Valid @Parameter(description = "API 경로로 들어오는 직관팟 ID 위해 작성", required = true) PartyIdRequest idRequest);
+                                    @Valid @Parameter(description = "API 경로로 들어오는 직관팟 ID 위해 작성", hidden = true) PartyIdRequest idRequest);
 
 
     @Tag(name = "Party Get", description = "신청한 직관팟 현황 조회 API")

--- a/src/main/java/com/playus/twpservice/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/playus/twpservice/global/config/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.playus.twpservice.global.config.security;
 
+import com.playus.twpservice.domain.common.feign.client.UserFeignClient;
 import com.playus.twpservice.global.jwt.JwtFilter;
 import com.playus.twpservice.global.jwt.JwtUtil;
 
@@ -7,7 +8,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 
@@ -24,6 +24,7 @@ import org.springframework.web.cors.CorsConfigurationSource;
 public class SecurityConfig {
 
     private final JwtUtil jwtUtil;
+    private final UserFeignClient userFeignClient;
     private final CorsConfigurationSource corsConfigurationSource;
 
     private String [] getWhiteList() {
@@ -48,7 +49,7 @@ public class SecurityConfig {
 
                 // JWT 필터를 UsernamePasswordAuthenticationFilter 앞에 등록
                 .addFilterBefore(
-                        new JwtFilter(jwtUtil),
+                        new JwtFilter(jwtUtil, userFeignClient),
                         UsernamePasswordAuthenticationFilter.class
                 )
 

--- a/src/main/java/com/playus/twpservice/global/jwt/JwtFilter.java
+++ b/src/main/java/com/playus/twpservice/global/jwt/JwtFilter.java
@@ -1,5 +1,8 @@
 package com.playus.twpservice.global.jwt;
 
+import com.playus.twpservice.domain.common.feign.client.UserFeignClient;
+import com.playus.twpservice.domain.common.feign.request.TokenValidationRequest;
+import com.playus.twpservice.domain.common.feign.response.TokenValidationResponse;
 import com.playus.twpservice.domain.common.security.CustomOAuth2User;
 import com.playus.twpservice.domain.common.security.Gender;
 import com.playus.twpservice.domain.common.security.Role;
@@ -13,8 +16,8 @@ import jakarta.servlet.http.HttpServletResponse;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -23,6 +26,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.io.IOException;
+import java.util.Objects;
 
 @Slf4j
 @Component
@@ -30,6 +34,7 @@ import java.io.IOException;
 public class JwtFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
+    private final UserFeignClient userFeignClient;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -51,7 +56,9 @@ public class JwtFilter extends OncePerRequestFilter {
         if (token != null) {
             try {
                 String jti = jwtUtil.getJti(token);
-//                if (redisTemplate.hasKey("blacklist:" + jti)) {
+
+//                ResponseEntity<TokenValidationResponse> tokenResponse = userFeignClient.checkBlackList(TokenValidationRequest.of(jti));
+//                if (Objects.requireNonNull(tokenResponse.getBody()).blacklisted()) {
 //                    throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "BLACKLISTED_TOKEN");
 //                }
 

--- a/src/main/java/com/playus/twpservice/global/jwt/JwtFilter.java
+++ b/src/main/java/com/playus/twpservice/global/jwt/JwtFilter.java
@@ -57,10 +57,10 @@ public class JwtFilter extends OncePerRequestFilter {
             try {
                 String jti = jwtUtil.getJti(token);
 
-//                ResponseEntity<TokenValidationResponse> tokenResponse = userFeignClient.checkBlackList(TokenValidationRequest.of(jti));
-//                if (Objects.requireNonNull(tokenResponse.getBody()).blacklisted()) {
-//                    throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "BLACKLISTED_TOKEN");
-//                }
+                ResponseEntity<TokenValidationResponse> tokenResponse = userFeignClient.checkBlackList(TokenValidationRequest.of(jti));
+                if (Objects.requireNonNull(tokenResponse.getBody()).blacklisted()) {
+                    throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "BLACKLISTED_TOKEN");
+                }
 
                 if (!jwtUtil.isExpired(token)) {
                     String userId = jwtUtil.getUserId(token);

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -125,6 +125,3 @@ logging:
 
 websocket:
   allowed-origin: "http://localhost:3000"
-
-server:
-  port: 8081

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -126,3 +126,5 @@ logging:
 websocket:
   allowed-origin: "http://localhost:3000"
 
+server:
+  port: 8081

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -51,22 +51,6 @@ logging:
     com:
       mongodb : DEBUG
 
-resilience4j:
-  circuitbreaker:
-    configs:
-      default:
-        failure-rate-threshold: 50
-        slow-call-rate-threshold: 80
-        slow-call-duration-threshold: 10s
-        permitted-number-of-calls-in-half-open-state: 3
-        max-wait-duration-in-half-open-state: 0s
-        sliding-window-type: COUNT_BASED
-        sliding-window-size: 10
-        minimum-number-of-calls: 10
-        wait-duration-in-open-state: 10s
-    instances:
-      circuit:
-        base-config: default
 
 websocket:
   allowed-origin: "http://localhost:3000"

--- a/src/test/java/com/playus/twpservice/ControllerTestSupport.java
+++ b/src/test/java/com/playus/twpservice/ControllerTestSupport.java
@@ -1,6 +1,7 @@
 package com.playus.twpservice;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.playus.twpservice.domain.common.feign.client.UserFeignClient;
 import com.playus.twpservice.domain.party.controller.PartyController;
 import com.playus.twpservice.domain.party.facade.PartyApplyFacade;
 import com.playus.twpservice.domain.party.service.PartyReadOnlyService;
@@ -11,7 +12,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -49,7 +49,7 @@ public abstract class ControllerTestSupport {
     protected JwtUtil jwtUtil;
 
     @MockitoBean
-    protected RedisTemplate<String, String> redisTemplate;
+    protected UserFeignClient userFeignClient;
 
     @TestConfiguration
     static class TestSecurityConfig {
@@ -69,7 +69,6 @@ public abstract class ControllerTestSupport {
             );
 
             return http.build();
-
         }
     }
 }

--- a/src/test/java/com/playus/twpservice/domain/common/feign/client/UserFeignClientTest.java
+++ b/src/test/java/com/playus/twpservice/domain/common/feign/client/UserFeignClientTest.java
@@ -2,9 +2,11 @@ package com.playus.twpservice.domain.common.feign.client;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.playus.twpservice.IntegrationTestSupport;
+import com.playus.twpservice.domain.common.feign.request.TokenValidationRequest;
 import com.playus.twpservice.domain.common.feign.response.PartyParticipantsInfoFeignResponse;
 import com.playus.twpservice.domain.common.feign.response.PartyUserThumbnailUrlListResponse;
 import com.playus.twpservice.domain.common.feign.response.PartyWriterInfoFeignResponse;
+import com.playus.twpservice.domain.common.feign.response.TokenValidationResponse;
 import com.playus.twpservice.global.response.ErrorResponse;
 import feign.FeignException;
 import org.junit.jupiter.api.DisplayName;
@@ -12,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 
 import java.util.List;
 
@@ -31,7 +34,7 @@ class UserFeignClientTest extends IntegrationTestSupport {
         PartyUserThumbnailUrlListResponse expectedResponse = PartyUserThumbnailUrlListResponse.of(List.of(
                 "http://user-thumb",
                 "http://user2-thumb"
-                ));
+        ));
         stubFor(post(urlEqualTo("/user/api/thumbnails"))
                 .withRequestBody(equalToJson(objectMapper.writeValueAsString(userIdList)))
                 .willReturn(aResponse()
@@ -147,7 +150,7 @@ class UserFeignClientTest extends IntegrationTestSupport {
         List<Long> userIdList = List.of(1L, 2L);
         List<PartyParticipantsInfoFeignResponse> expectedResponse = List.of(
                 PartyParticipantsInfoFeignResponse.of(1L, "kim", 14, "http://user1-thumb"),
-                PartyParticipantsInfoFeignResponse.of(2L, "jung", 27,  "http://user2-thumb")
+                PartyParticipantsInfoFeignResponse.of(2L, "jung", 27, "http://user2-thumb")
         );
 
         stubFor(post(urlEqualTo("/user/api/info"))
@@ -211,4 +214,26 @@ class UserFeignClientTest extends IntegrationTestSupport {
                 .hasMessageContaining("사용자가 존재하지 않습니다!");
     }
 
+    @DisplayName("토큰이 블랙리스트에 속해있는지 확인할 수 있다.")
+    @Test
+    void checkBlackList() throws JsonProcessingException {
+        // given
+        String token = "token";
+        TokenValidationRequest request = TokenValidationRequest.of(token);
+        TokenValidationResponse expectedResponse = TokenValidationResponse.of(false);
+
+        stubFor(post(urlEqualTo("/user/api/token/blacklist-check"))
+                .withRequestBody(equalToJson(objectMapper.writeValueAsString(request)))
+                .willReturn(aResponse()
+                        .withStatus(HttpStatus.OK.value())
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                        .withBody(objectMapper.writeValueAsString(expectedResponse))
+                ));
+
+        // when
+        ResponseEntity<TokenValidationResponse> actualResponse = userFeignClient.checkBlackList(request);
+
+        // then
+        assertThat(actualResponse.getBody().blacklisted()).isFalse();
+    }
 }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
`JwtFilter` 에서 토큰 블랙리스트 확인할 때 `user-service` 에 대해 API를 호출해 확인하도록 변경했습니다. 

---

## 🔗 관련 이슈
- closes #53 

---

## 💡 추가 사항
채팅 관련 `Speicification` 내 `@Valid` 를 제거했습니다.
직관팟 관련 `Specification` 에서 paht 나 param 의 값을 가져오기 위한 dto 에 대해 `hidden = true` 를 적용햇습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 토큰이 블랙리스트에 포함되어 있는지 확인하는 기능이 추가되었습니다.

- **버그 수정**
  - 일부 파라미터의 유효성 검사 어노테이션이 제거되어 입력값 처리 방식이 변경되었습니다.

- **문서**
  - 파티 관련 API 문서에서 일부 파라미터가 숨김 처리되어 API 문서 가독성이 향상되었습니다.

- **설정**
  - 테스트 환경에서 회로 차단기 관련 설정이 제거되었습니다.

- **테스트**
  - 토큰 블랙리스트 확인 기능에 대한 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->