### PR TITLE
CS-348 Fix/MongoDB 쿼리에서 Soft Delete가 포함되지 않는 오류 수정

### DIFF
--- a/src/main/java/com/playus/twpservice/domain/chat/repository/read/ChatParticipantReadOnlyRepository.java
+++ b/src/main/java/com/playus/twpservice/domain/chat/repository/read/ChatParticipantReadOnlyRepository.java
@@ -2,11 +2,13 @@ package com.playus.twpservice.domain.chat.repository.read;
 
 import com.playus.twpservice.domain.chat.document.ChatParticipantDocument;
 import com.playus.twpservice.domain.common.data.BaseMongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 
 import java.util.List;
 
 public interface ChatParticipantReadOnlyRepository extends BaseMongoRepository<ChatParticipantDocument, Long> {
 
+    @Query(value = "{'chat_room_id' : ?0, 'is_deleted' : false}")
     List<ChatParticipantDocument> findAllByChatRoomId(long chatRoomId);
 
     long countByChatRoomId(long chatRoomId);

--- a/src/main/java/com/playus/twpservice/global/jwt/JwtFilter.java
+++ b/src/main/java/com/playus/twpservice/global/jwt/JwtFilter.java
@@ -55,9 +55,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
         if (token != null) {
             try {
-                String jti = jwtUtil.getJti(token);
-
-                ResponseEntity<TokenValidationResponse> tokenResponse = userFeignClient.checkBlackList(TokenValidationRequest.of(jti));
+                ResponseEntity<TokenValidationResponse> tokenResponse = userFeignClient.checkBlackList(TokenValidationRequest.of(token));
                 if (Objects.requireNonNull(tokenResponse.getBody()).blacklisted()) {
                     throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "BLACKLISTED_TOKEN");
                 }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
-[x] soft delete 적용
<img width="1401" alt="image" src="https://github.com/user-attachments/assets/c3f44323-35b1-4d37-905f-a67864685b13" />

- [x] [토큰 검증 API에 JTI를 넘기는 오류 수정

---

## 🔗 관련 이슈
- closes #55

---

## 💡 추가 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 삭제되지 않은 채팅 참가자만 조회되도록 채팅 참가자 목록 조회 기능이 개선되었습니다.
  - JWT 토큰의 블랙리스트 확인 방식이 개선되어 인증 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->