### PR TITLE
CS-392 feat/직관팟 내부 인원 조회

### DIFF
--- a/src/main/java/com/playus/twpservice/domain/party/controller/PartyController.java
+++ b/src/main/java/com/playus/twpservice/domain/party/controller/PartyController.java
@@ -17,6 +17,7 @@ import com.playus.twpservice.domain.party.dto.create.PartyCreateRequest;
 import com.playus.twpservice.domain.party.dto.create.PartyCreateResponse;
 import com.playus.twpservice.domain.common.request.PartyIdRequest;
 import com.playus.twpservice.domain.party.dto.leave.PartyLeaveResponse;
+import com.playus.twpservice.domain.party.dto.participants.PartyParticipantsInfoResponse;
 import com.playus.twpservice.domain.party.dto.update.PartyUpdateRequest;
 import com.playus.twpservice.domain.party.dto.update.PartyUpdateResponse;
 import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageRequest;
@@ -96,6 +97,15 @@ public class PartyController implements PartyControllerSpecification {
             @PathVariable Long partyId) {
         return partyReadOnlyService.getAppliedUsers(principal.getId(), partyId);
     }
+
+    @GetMapping("/{partyId}/participants")
+    public List<PartyParticipantsInfoResponse> getParticipants(
+            @AuthenticationPrincipal CustomOAuth2User principal,
+            @Valid PartyIdRequest idRequest
+    ) {
+        return partyReadOnlyService.getParticipants(principal, idRequest.partyId());
+    }
+
 
     @PostMapping("/{partyId}/leave")
     public PartyLeaveResponse leaveParty(@AuthenticationPrincipal CustomOAuth2User principal,

--- a/src/main/java/com/playus/twpservice/domain/party/dto/participants/PartyParticipantsInfoResponse.java
+++ b/src/main/java/com/playus/twpservice/domain/party/dto/participants/PartyParticipantsInfoResponse.java
@@ -1,0 +1,17 @@
+package com.playus.twpservice.domain.party.dto.participants;
+
+import lombok.Builder;
+
+@Builder
+public record PartyParticipantsInfoResponse(
+        Long userId,
+        String name
+) {
+
+    public static PartyParticipantsInfoResponse of (Long userId, String name) {
+        return PartyParticipantsInfoResponse.builder()
+                .userId(userId)
+                .name(name)
+                .build();
+    }
+}

--- a/src/main/java/com/playus/twpservice/domain/party/exception/entity/PartyException.java
+++ b/src/main/java/com/playus/twpservice/domain/party/exception/entity/PartyException.java
@@ -3,71 +3,67 @@ package com.playus.twpservice.domain.party.exception.entity;
 public abstract class PartyException {
 
     public static class NotPartyWriterException extends RuntimeException {
-
         public NotPartyWriterException(String message) {
             super(message);
         }
     }
 
     public static class AlreadyCreatedPartyForPerMatchException extends RuntimeException {
-
         public AlreadyCreatedPartyForPerMatchException(String message) {
             super(message);
         }
     }
 
     public static class NotFoundException extends RuntimeException {
-
         public NotFoundException(String message) {
             super(message);
         }
+    }
 
+    public static class ParticipantsNotFoundException extends RuntimeException {
+        public ParticipantsNotFoundException(String message) {
+            super(message);
+        }
     }
 
     public static class ApplicantNotFoundException extends RuntimeException {
-
         public ApplicantNotFoundException(String message) {
             super(message);
         }
     }
 
     public static class ExceedPartyParticipantsException extends RuntimeException {
-
         public ExceedPartyParticipantsException(String message) {
             super(message);
         }
     }
 
     public static class InsufficientPartyParticipantsException extends RuntimeException {
-
         public InsufficientPartyParticipantsException(String message) {
             super(message);
         }
     }
 
     public static class InvalidApproveRequestToPartyException extends RuntimeException {
-
         public InvalidApproveRequestToPartyException(String message) {
             super(message);
         }
     }
 
-    public static class NotAllowedPartyConditionException extends RuntimeException {
 
+    public static class NotAllowedPartyConditionException extends RuntimeException {
         public NotAllowedPartyConditionException(String message) {
             super(message);
         }
     }
 
     public static class NotAllowedPartyJoinRequestStatusException extends RuntimeException {
-
         public NotAllowedPartyJoinRequestStatusException(String message) {
             super(message);
         }
     }
 
     public static class NotAllowedToFirstComePartyException extends RuntimeException {
-
         public NotAllowedToFirstComePartyException(String message) {
             super(message);
         }

--- a/src/main/java/com/playus/twpservice/domain/party/service/PartyReadOnlyService.java
+++ b/src/main/java/com/playus/twpservice/domain/party/service/PartyReadOnlyService.java
@@ -8,6 +8,7 @@ import com.playus.twpservice.domain.party.dto.appliedparty.AppliedPartyResponse;
 import com.playus.twpservice.domain.party.dto.applieduser.PartyAppliedUserResponse;
 import com.playus.twpservice.domain.party.dto.detail.PartyDetailResponse;
 import com.playus.twpservice.domain.party.dto.info.PartyInfoResponse;
+import com.playus.twpservice.domain.party.dto.participants.PartyParticipantsInfoResponse;
 import com.playus.twpservice.domain.party.enums.PartyAgeGroup;
 import com.playus.twpservice.domain.party.enums.PartyJoinRequestStatus;
 import com.playus.twpservice.domain.party.exception.document.PartyDocumentException;
@@ -15,6 +16,7 @@ import com.playus.twpservice.domain.common.feign.client.UserFeignClient;
 import com.playus.twpservice.domain.common.feign.response.PartyParticipantsInfoFeignResponse;
 import com.playus.twpservice.domain.common.feign.response.PartyUserThumbnailUrlListResponse;
 import com.playus.twpservice.domain.common.feign.response.PartyWriterInfoFeignResponse;
+import com.playus.twpservice.domain.party.exception.entity.PartyException;
 import com.playus.twpservice.domain.party.repository.read.PartyJoinReadOnlyRepository;
 import com.playus.twpservice.domain.party.repository.read.PartyReadOnlyRepository;
 import com.playus.twpservice.domain.party.vo.PartyInfo;
@@ -43,8 +45,8 @@ public class PartyReadOnlyService {
 
         List<PartyInfo> partyInfoList = partyRepository.findPartyInfoList(matchId);
 
-//        updateUserThumbnailUrls(partyInfoList);
-//        updateWriterInfo(partyInfoList);
+        updateUserThumbnailUrls(partyInfoList);
+        updateWriterInfo(partyInfoList);
 
         return partyInfoList.stream()
                 .map(PartyInfo::toResponse)
@@ -56,8 +58,8 @@ public class PartyReadOnlyService {
         PartyInfo partyDetail = partyRepository.findPartyDetail(partyId)
                 .orElseThrow(() -> new PartyDocumentException.NotFoundException("직관팟이 존재하지 않습니다!"));
 
-//        updateUserThumbnailUrls(List.of(partyDetail));
-//        updateWriterInfo(List.of(partyDetail));
+        updateUserThumbnailUrls(List.of(partyDetail));
+        updateWriterInfo(List.of(partyDetail));
 
         return partyDetail.toPartyDetailResponse();
     }
@@ -101,6 +103,47 @@ public class PartyReadOnlyService {
 
         // 주의: Feign 클라이언트가 요청 순서를 보존한다고 가정합니다
         return returnPartyApplicantInfoList(orderedUserIds, orderedUserInfos, userRequireMessageMap);
+    }
+
+    public List<PartyParticipantsInfoResponse> getParticipants(CustomOAuth2User principal, Long partyId) {
+
+        Long userId = principal.getId();
+
+        PartyDocument partyDocument = partyRepository.findById(partyId)
+                .orElseThrow(() -> new PartyDocumentException.NotFoundException("직관팟이 존재하지 않습니다!"));
+
+        List<Long> participantIds = getParticipantsIdWithoutLoginUser(partyDocument, userId);
+
+        List<PartyParticipantsInfoFeignResponse> partyParticipantsInfoFeignResponses = userFeignClient.getPartyApplicantsInfo(participantIds);
+
+        return getParticipantsInfoList(participantIds, partyParticipantsInfoFeignResponses);
+    }
+
+    private List<PartyParticipantsInfoResponse> getParticipantsInfoList(List<Long> participantIds, List<PartyParticipantsInfoFeignResponse> partyParticipantsInfoFeignResponses) {
+        return IntStream.range(0, participantIds.size())
+                .mapToObj(i -> {
+                    Long userId = participantIds.get(i);
+                    PartyParticipantsInfoFeignResponse userInfo = partyParticipantsInfoFeignResponses.get(i);
+
+                    return PartyParticipantsInfoResponse.of(
+                            userId,
+                            userInfo.name()
+                    );
+                })
+                .toList();
+    }
+
+    private List<Long> getParticipantsIdWithoutLoginUser(PartyDocument partyDocument, Long userId) {
+        List<Long> participantIds = partyJoinReadOnlyRepository.findByPartyIdAndStatus(partyDocument.getId(), PartyJoinRequestStatus.ACCEPT).stream()
+                .map(PartyJoinDocument::getUserId)
+                .collect(Collectors.toList());
+
+        participantIds.add(partyDocument.getWriterId());
+        if (!participantIds.contains(userId)) {
+            throw new PartyException.ParticipantsNotFoundException("이 직관팟에 참여하지 않은 인원입니다!");
+        }
+        participantIds.remove(userId);
+        return participantIds;
     }
 
     private static List<PartyAppliedUserResponse> returnPartyApplicantInfoList(

--- a/src/main/java/com/playus/twpservice/domain/party/service/PartyReadOnlyService.java
+++ b/src/main/java/com/playus/twpservice/domain/party/service/PartyReadOnlyService.java
@@ -120,18 +120,29 @@ public class PartyReadOnlyService {
     }
 
     private List<PartyParticipantsInfoResponse> getParticipantsInfoList(List<Long> participantIds, List<PartyParticipantsInfoFeignResponse> partyParticipantsInfoFeignResponses) {
-        return IntStream.range(0, participantIds.size())
-                .mapToObj(i -> {
-                    Long userId = participantIds.get(i);
-                    PartyParticipantsInfoFeignResponse userInfo = partyParticipantsInfoFeignResponses.get(i);
+        // Feign 응답을 userId 기준으로 Map으로 변환
+        Map<Long, PartyParticipantsInfoFeignResponse> userInfoMap = partyParticipantsInfoFeignResponses.stream()
+                .collect(Collectors.toMap(
+                        PartyParticipantsInfoFeignResponse::userId,
+                        response -> response
+                ));
+
+        // participantIds를 순회하면서 해당하는 userInfo 매핑
+        return participantIds.stream()
+                .map(participantId -> {
+                    PartyParticipantsInfoFeignResponse userInfo = userInfoMap.get(participantId);
+                    if (userInfo == null) {
+                        throw new IllegalStateException("참가자 ID " + participantId + "에 대한 사용자 정보를 찾을 수 없습니다.");
+                    }
 
                     return PartyParticipantsInfoResponse.of(
-                            userId,
+                            participantId,
                             userInfo.name()
                     );
                 })
                 .toList();
     }
+
 
     private List<Long> getParticipantsIdWithoutLoginUser(PartyDocument partyDocument, Long userId) {
         List<Long> participantIds = partyJoinReadOnlyRepository.findByPartyIdAndStatus(partyDocument.getId(), PartyJoinRequestStatus.ACCEPT).stream()

--- a/src/main/java/com/playus/twpservice/domain/party/specification/PartyControllerSpecification.java
+++ b/src/main/java/com/playus/twpservice/domain/party/specification/PartyControllerSpecification.java
@@ -17,6 +17,7 @@ import com.playus.twpservice.domain.party.dto.info.PartyInfoRequest;
 import com.playus.twpservice.domain.party.dto.info.PartyInfoResponse;
 import com.playus.twpservice.domain.common.request.PartyIdRequest;
 import com.playus.twpservice.domain.party.dto.leave.PartyLeaveResponse;
+import com.playus.twpservice.domain.party.dto.participants.PartyParticipantsInfoResponse;
 import com.playus.twpservice.domain.party.dto.update.PartyUpdateRequest;
 import com.playus.twpservice.domain.party.dto.update.PartyUpdateResponse;
 import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageRequest;
@@ -2153,6 +2154,132 @@ public interface PartyControllerSpecification {
             @Parameter(description = "직관팟 ID", required = true) @PathVariable Long partyId);
 
 
+    @Tag(name = "Party Get", description = "유저 평가 위한 직관팟 참가자 조회 API")
+    @Operation(
+            summary = "유저 평가 위한 직관팟 참가자 조회 API",
+            description = "직관팟 종료 후 유저 평가 위해 로그인 유저를 제외한 직관팟 참가자를 조회합니다",
+            security = @SecurityRequirement(name = "Access"),
+            parameters = {
+                    @Parameter(
+                            name = "Access",
+                            description = "JWT Access Token (쿠키)",
+                            in = ParameterIn.COOKIE,
+                            required = true,
+                            example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                    ),
+                    @Parameter(
+                            name = "partyId",
+                            in = ParameterIn.PATH,
+                            description = "직관팟 ID",
+                            required = true,
+                            example = "1"
+                    )
+            }
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "조회 성공",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    name = "직관팟 참가자 조회 응답 예시",
+                                    value = """
+                                                                    [
+                                                                       {
+                                                                         "userId": 1,
+                                                                         "name": "ZSJ"
+                                                                       },
+                                            
+                                                                       {
+                                                                         "userId": 2,
+                                                                         "name": "KIM"
+                                                                       },
+                                                                     ]
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "직관팟 ID가 1 미만일 경우 발생",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 400,
+                                              "status": "BAD_REQUEST",
+                                              "message": "직관팟 ID는 1 이상이여야 합니다!"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401", description = "인증 실패",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 401,
+                                              "status": "UNAUTHORIZED",
+                                              "message": "유효하지 않은 토큰입니다."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404", description = "직관팟 ID로 직관팟을 찾을 수 없는 경우 발생",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 404,
+                                              "status": "NOT_FOUND",
+                                              "message": "직관팟이 존재하지 않습니다!"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404", description = "로그인 유저가 직관팟 참가자가 아닐 경우 발생",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 404,
+                                              "status": "NOT_FOUND",
+                                              "message": "이 직관팟에 참여하지 않은 인원입니다!"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500", description = "서버 내부 오류",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 500,
+                                              "status": "INTERNAL_SERVER_ERROR",
+                                              "message": "서버 내부 오류가 발생했습니다. 관리자에게 문의해 주세요."
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    List<PartyParticipantsInfoResponse> getParticipants(
+            @Parameter(hidden = true) CustomOAuth2User principal,
+            @Parameter(description = "직관팟 ID", hidden = true) PartyIdRequest idRequest);
+
+
     @Tag(name = "Party Post", description = "직관팟 탈퇴 API")
     @Operation(
             summary = "직관팟 탈퇴 API",
@@ -2313,8 +2440,6 @@ public interface PartyControllerSpecification {
     })
     PartyLeaveResponse leaveParty(@Parameter(hidden = true) CustomOAuth2User principal,
                                   @Valid @Parameter(description = "API 경로로 들어오는 직관팟 ID 위해 작성", hidden = true) PartyIdRequest idRequest);
-
-
 
 
     @Tag(name = "Party Patch", description = "직관팟 신청 취소 API")

--- a/src/main/java/com/playus/twpservice/global/config/data/redis/RedisClusterConfig.java
+++ b/src/main/java/com/playus/twpservice/global/config/data/redis/RedisClusterConfig.java
@@ -1,5 +1,9 @@
 package com.playus.twpservice.global.config.data.redis;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.playus.twpservice.domain.chat.dto.request.ChattingMessage;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -7,6 +11,12 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.connection.RedisClusterConfiguration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.text.SimpleDateFormat;
 
 @Configuration
 @Profile({"dev", "prod"})  // dev, prod 프로필에서만 사용
@@ -32,5 +42,34 @@ public class RedisClusterConfig {
         clusterConfig.setMaxRedirects(maxRedirects);
 
         return new LettuceConnectionFactory(clusterConfig);
+    }
+
+    @Bean
+    @Qualifier("chatRedisTemplate")
+    public RedisTemplate<String, ChattingMessage> chatRedisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, ChattingMessage> redisTemplate = new RedisTemplate<>();
+
+        ObjectMapper objectMapper = new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .setDateFormat(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss"));
+
+        Jackson2JsonRedisSerializer<ChattingMessage> serializer =
+                new Jackson2JsonRedisSerializer<>(objectMapper, ChattingMessage.class);
+
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(serializer);
+
+        return redisTemplate;
+    }
+
+    @Bean
+    @Qualifier("chatRoomRedisTemplate")
+    public RedisTemplate<String, Object> chatRoomRedisTemplate(RedisConnectionFactory factory) {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(factory);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return redisTemplate;
     }
 }

--- a/src/main/java/com/playus/twpservice/global/config/data/redis/RedisClusterConfig.java
+++ b/src/main/java/com/playus/twpservice/global/config/data/redis/RedisClusterConfig.java
@@ -1,0 +1,36 @@
+package com.playus.twpservice.global.config.data.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.connection.RedisClusterConfiguration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+@Configuration
+@Profile({"dev", "prod"})  // dev, prod 프로필에서만 사용
+public class RedisClusterConfig {
+
+    @Value("${spring.data.redis.cluster.nodes}")
+    private String redisClusterNodes;
+
+    @Value("${spring.data.redis.cluster.max-redirects}")
+    private int maxRedirects;
+
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisClusterConfiguration clusterConfig = new RedisClusterConfiguration();
+
+        String[] nodes = redisClusterNodes.split(",");
+        for (String node : nodes) {
+            String[] hostPort = node.trim().split(":");
+            clusterConfig.clusterNode(hostPort[0], Integer.parseInt(hostPort[1]));
+        }
+
+        clusterConfig.setMaxRedirects(maxRedirects);
+
+        return new LettuceConnectionFactory(clusterConfig);
+    }
+}

--- a/src/main/java/com/playus/twpservice/global/config/data/redis/RedisConfig.java
+++ b/src/main/java/com/playus/twpservice/global/config/data/redis/RedisConfig.java
@@ -5,8 +5,10 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.playus.twpservice.domain.chat.dto.request.ChattingMessage;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -17,6 +19,8 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 import java.text.SimpleDateFormat;
 
 @Configuration
+@Profile("local")
+@ConditionalOnProperty(prefix = "spring.data.redis", name = "host")
 public class RedisConfig {
 
     @Value("${spring.data.redis.host}")

--- a/src/main/java/com/playus/twpservice/global/config/data/redis/RedisConfig.java
+++ b/src/main/java/com/playus/twpservice/global/config/data/redis/RedisConfig.java
@@ -19,7 +19,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 import java.text.SimpleDateFormat;
 
 @Configuration
-@Profile("local")
+@Profile({"local", "test"})
 @ConditionalOnProperty(prefix = "spring.data.redis", name = "host")
 public class RedisConfig {
 

--- a/src/main/java/com/playus/twpservice/global/config/security/CorsConfig.java
+++ b/src/main/java/com/playus/twpservice/global/config/security/CorsConfig.java
@@ -3,12 +3,10 @@ package com.playus.twpservice.global.config.security;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import org.springframework.http.HttpMethod;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import java.util.Collections;
 import java.util.List;
 
 @Configuration
@@ -16,7 +14,6 @@ public class CorsConfig {
 
     private static final List<String> ALLOWED_ORIGINS = List.of(
             "https://web.playus.o-r.kr",
-            "https://api.playus.o-r.kr",
             "http://localhost:3000"
     );
 
@@ -26,15 +23,10 @@ public class CorsConfig {
         CorsConfiguration configuration = new CorsConfiguration();
 
         configuration.setAllowedOrigins(ALLOWED_ORIGINS);
-        configuration.setAllowedHeaders(Collections.singletonList("*"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowedMethods(List.of("*"));
         configuration.setAllowCredentials(true);
-        configuration.setExposedHeaders(Collections.singletonList("Authorization"));
-
-        configuration.addAllowedMethod(HttpMethod.GET.name());
-        configuration.addAllowedMethod(HttpMethod.POST.name());
-        configuration.addAllowedMethod(HttpMethod.PUT.name());
-        configuration.addAllowedMethod(HttpMethod.DELETE.name());
-        configuration.addAllowedMethod(HttpMethod.OPTIONS.name());
+        configuration.setExposedHeaders(List.of("Authorization"));
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);

--- a/src/main/java/com/playus/twpservice/global/exception/ExceptionAdvice.java
+++ b/src/main/java/com/playus/twpservice/global/exception/ExceptionAdvice.java
@@ -77,6 +77,7 @@ public class ExceptionAdvice {
     @ResponseStatus(NOT_FOUND)
     @ExceptionHandler({
             PartyException.NotFoundException.class,
+            PartyException.ParticipantsNotFoundException.class,
             PartyDocumentException.NotFoundException.class,
             ChatRoomException.NotFoundException.class,
             ChatMessageException.NotFoundException.class,

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -1,37 +1,69 @@
+server:
+  forward-headers-strategy: framework  # ALB HTTPS 헤더 인식
+
 spring:
   application:
     name: twp-service
 
   datasource:
-    url: ${SPRING_DATASOURCE_URL}
+    url: ${SPRING_DATASOURCE_URL}?useSSL=false&autoReconnect=true&failOverReadOnly=false&maxReconnects=10&socketTimeout=60000&connectTimeout=60000
     username: ${SPRING_DATASOURCE_USERNAME}
     password: ${SPRING_DATASOURCE_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+    # OCI 프록시 환경 최적화 HikariCP 설정
+    hikari:
+      connection-timeout: 60000          # OCI 네트워크 지연 고려 60초
+      idle-timeout: 60000                # OCI 프록시가 빨리 끊으므로 1분
+      max-lifetime: 180000               # OCI 프록시 정책 고려 3분
+      keepalive-time: 30000
+      maximum-pool-size: 5               # 작은 풀 크기 (OCI 동시 연결 제한)
+      minimum-idle: 1                    # 최소한만 유지
+      validation-timeout: 10000          # 네트워크 지연 고려 10초
+      leak-detection-threshold: 30000    # 30초로 단축
+      connection-test-query: "SELECT 1"  # 연결 검증 쿼리
+      auto-commit: false
 
   data:
     mongodb:
       read:
-        uri: ${SPRING_DATA_MONGODB_READ_URI}
+        uri: ${SPRING_DATA_MONGODB_READ_URI}&connectTimeoutMS=30000&socketTimeoutMS=30000&serverSelectionTimeoutMS=10000&maxIdleTimeMS=60000
       chat:
-        uri: ${SPRING_DATA_MONGODB_CHAT_URI}
+        uri: ${SPRING_DATA_MONGODB_CHAT_URI}&connectTimeoutMS=30000&socketTimeoutMS=30000&serverSelectionTimeoutMS=10000&maxIdleTimeMS=60000
 
       auto-index-creation: true
 
     redis:
-      host: ${REDIS_HOST}
-      port: ${REDIS_PORT}
+      cluster:
+        nodes: ${REDIS_CLUSTER_NODES}
+        max-redirects: 3  # 여기가 맞는 위치
+      timeout: 5s
+      lettuce:
+        pool:
+          max-active: 10
+          max-idle: 10
+          min-idle: 1
+      repositories:
+        enabled: false
 
   jpa:
-    show-sql: true
+    database: mysql
     hibernate:
       ddl-auto: update
-    database: mysql
+    show-sql: true
+    open-in-view: false
     properties:
-      hibernate:
-        format_sql: true
-        jdbc:
-          time_zone: Asia/Seoul
-        show_sql: true
+      hibernate.format_sql: true
+      hibernate.show_sql: true
+      hibernate.jdbc.time_zone: Asia/Seoul
+
+      # OCI 환경에서 안정성 우선 설정
+      hibernate.jdbc.batch_size: 1     # 배치 비활성화 (안정성 우선)
+      hibernate.order_inserts: false   # OCI 환경에서 순서 보장 비활성화
+      hibernate.order_updates: false
+
+      # OCI 프록시 연결 관리
+      hibernate.connection.acquisition_timeout: 60000
+      hibernate.connection.validation_timeout: 10000
 
   jwt:
     secret: ${JWT_SECRET}
@@ -82,23 +114,38 @@ resilience4j:
   circuitbreaker:
     configs:
       default:
-        failure-rate-threshold: 50
+        failure-rate-threshold: 60
         slow-call-rate-threshold: 80
-        slow-call-duration-threshold: 10s
+        slow-call-duration-threshold: 15s
         permitted-number-of-calls-in-half-open-state: 3
         max-wait-duration-in-half-open-state: 0s
         sliding-window-type: COUNT_BASED
         sliding-window-size: 10
         minimum-number-of-calls: 10
-        wait-duration-in-open-state: 10s
+        wait-duration-in-open-state: 15s
     instances:
       circuit:
+        base-config: default
+
+  # OCI 환경 Retry 설정 추가 x
+  retry:
+    configs:
+      default:
+        max-attempts: 5    # OCI 환경에서 재시도 증가
+        wait-duration: 2s
+        retry-exceptions:
+          - java.sql.SQLException
+          - com.mysql.cj.jdbc.exceptions.CommunicationsException
+          - java.net.SocketTimeoutException
+    instances:
+      database:
         base-config: default
 
 feign:
   user:
     url: ${USER_SERVICE_URL}
 
+management:
   endpoints:
     web:
       exposure:

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -16,8 +16,8 @@ spring:
       idle-timeout: 60000                # OCI 프록시가 빨리 끊으므로 1분
       max-lifetime: 180000               # OCI 프록시 정책 고려 3분
       keepalive-time: 30000
-      maximum-pool-size: 5               # 작은 풀 크기 (OCI 동시 연결 제한)
-      minimum-idle: 1                    # 최소한만 유지
+      maximum-pool-size: 8               # 채팅/실시간 서비스라 조금 더 큰 풀
+      minimum-idle: 2                    # 최소 연결 수 증가
       validation-timeout: 10000          # 네트워크 지연 고려 10초
       leak-detection-threshold: 30000    # 30초로 단축
       connection-test-query: "SELECT 1"  # 연결 검증 쿼리
@@ -29,7 +29,6 @@ spring:
         uri: ${SPRING_DATA_MONGODB_READ_URI}&connectTimeoutMS=30000&socketTimeoutMS=30000&serverSelectionTimeoutMS=10000&maxIdleTimeMS=60000
       chat:
         uri: ${SPRING_DATA_MONGODB_CHAT_URI}&connectTimeoutMS=30000&socketTimeoutMS=30000&serverSelectionTimeoutMS=10000&maxIdleTimeMS=60000
-
       auto-index-creation: true
 
     redis:
@@ -50,10 +49,10 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: true
-    open-in-view: false
+    open-in-view: false  # 성능 개선을 위해 추가
     properties:
-      hibernate.format_sql: true
-      hibernate.show_sql: true
+      hibernate.format_sql:    true
+      hibernate.show_sql:      true
       hibernate.jdbc.time_zone: Asia/Seoul
 
       # OCI 환경에서 안정성 우선 설정
@@ -95,8 +94,21 @@ cloud:
       access-key: ${STORAGE_ACCESS_KEY}
       secret-key: ${STORAGE_SECRET_KEY}
     s3:
-      bucket : ${BUCKET_NAME}
-      endpoint : ${BUCKET_ENDPOINT}
+      bucket: ${BUCKET_NAME}
+      endpoint: ${BUCKET_ENDPOINT}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include:
+          - health           # 애플리케이션 상태 확인
+          - info             # 애플리케이션 정보
+          - prometheus       # 메트릭 데이터 노출
+
+  endpoint:
+    health:
+      show-details: never
 
 sentry:
   dsn: ${SENTRY_REPOSITORY_DSN}
@@ -127,7 +139,7 @@ resilience4j:
       circuit:
         base-config: default
 
-  # OCI 환경 Retry 설정 추가 x
+  # OCI 환경 Retry 설정 추가
   retry:
     configs:
       default:
@@ -137,26 +149,16 @@ resilience4j:
           - java.sql.SQLException
           - com.mysql.cj.jdbc.exceptions.CommunicationsException
           - java.net.SocketTimeoutException
+          - org.springframework.kafka.KafkaException
     instances:
       database:
+        base-config: default
+      kafka:
         base-config: default
 
 feign:
   user:
     url: ${USER_SERVICE_URL}
-
-management:
-  endpoints:
-    web:
-      exposure:
-        include:
-          - health           # 애플리케이션 상태 확인
-          - info             # 애플리케이션 정보
-          - prometheus       # 메트릭 데이터 노출
-
-  endpoint:
-    health:
-      show-details: never
 
 springdoc:
   swagger-ui:

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -1,35 +1,69 @@
+server:
+  forward-headers-strategy: framework  # ALB HTTPS 헤더 인식
+
 spring:
   application:
     name: twp-service
 
   datasource:
-    url: ${SPRING_DATASOURCE_URL}
+    url: ${SPRING_DATASOURCE_URL}?useSSL=false&autoReconnect=true&failOverReadOnly=false&maxReconnects=10&socketTimeout=60000&connectTimeout=60000
     username: ${SPRING_DATASOURCE_USERNAME}
     password: ${SPRING_DATASOURCE_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+    # OCI 프록시 환경 최적화 HikariCP 설정
+    hikari:
+      connection-timeout: 60000          # OCI 네트워크 지연 고려 60초
+      idle-timeout: 60000                # OCI 프록시가 빨리 끊으므로 1분
+      max-lifetime: 180000               # OCI 프록시 정책 고려 3분
+      keepalive-time: 30000
+      maximum-pool-size: 5               # 작은 풀 크기 (OCI 동시 연결 제한)
+      minimum-idle: 1                    # 최소한만 유지
+      validation-timeout: 10000          # 네트워크 지연 고려 10초
+      leak-detection-threshold: 30000    # 30초로 단축
+      connection-test-query: "SELECT 1"  # 연결 검증 쿼리
+      auto-commit: false
 
   data:
     mongodb:
       read:
-        uri: ${SPRING_DATA_MONGODB_READ_URI}
+        uri: ${SPRING_DATA_MONGODB_READ_URI}&connectTimeoutMS=30000&socketTimeoutMS=30000&serverSelectionTimeoutMS=10000&maxIdleTimeMS=60000
       chat:
-        uri: ${SPRING_DATA_MONGODB_CHAT_URI}
+        uri: ${SPRING_DATA_MONGODB_CHAT_URI}&connectTimeoutMS=30000&socketTimeoutMS=30000&serverSelectionTimeoutMS=10000&maxIdleTimeMS=60000
+
       auto-index-creation: true
 
     redis:
-      host: ${REDIS_HOST}
-      port: ${REDIS_PORT}
+      cluster:
+        nodes: ${REDIS_CLUSTER_NODES}
+        max-redirects: 3  # 여기가 맞는 위치
+      timeout: 5s
+      lettuce:
+        pool:
+          max-active: 10
+          max-idle: 10
+          min-idle: 1
+      repositories:
+        enabled: false
 
   jpa:
-    show-sql: false
+    database: mysql
     hibernate:
       ddl-auto: update
-    database: mysql
+    show-sql: true
+    open-in-view: false
     properties:
-      hibernate:
-        jdbc:
-          time_zone: Asia/Seoul
-        show_sql: false
+      hibernate.format_sql: true
+      hibernate.show_sql: true
+      hibernate.jdbc.time_zone: Asia/Seoul
+
+      # OCI 환경에서 안정성 우선 설정
+      hibernate.jdbc.batch_size: 1     # 배치 비활성화 (안정성 우선)
+      hibernate.order_inserts: false   # OCI 환경에서 순서 보장 비활성화
+      hibernate.order_updates: false
+
+      # OCI 프록시 연결 관리
+      hibernate.connection.acquisition_timeout: 60000
+      hibernate.connection.validation_timeout: 10000
 
   jwt:
     secret: ${JWT_SECRET}
@@ -80,17 +114,31 @@ resilience4j:
   circuitbreaker:
     configs:
       default:
-        failure-rate-threshold: 50
+        failure-rate-threshold: 60
         slow-call-rate-threshold: 80
-        slow-call-duration-threshold: 10s
+        slow-call-duration-threshold: 15s
         permitted-number-of-calls-in-half-open-state: 3
         max-wait-duration-in-half-open-state: 0s
         sliding-window-type: COUNT_BASED
         sliding-window-size: 10
         minimum-number-of-calls: 10
-        wait-duration-in-open-state: 10s
+        wait-duration-in-open-state: 15s
     instances:
       circuit:
+        base-config: default
+
+  # OCI 환경 Retry 설정 추가 x
+  retry:
+    configs:
+      default:
+        max-attempts: 5    # OCI 환경에서 재시도 증가
+        wait-duration: 2s
+        retry-exceptions:
+          - java.sql.SQLException
+          - com.mysql.cj.jdbc.exceptions.CommunicationsException
+          - java.net.SocketTimeoutException
+    instances:
+      database:
         base-config: default
 
 feign:
@@ -103,6 +151,7 @@ management:
       exposure:
         include:
           - health           # 애플리케이션 상태 확인
+          - info             # 애플리케이션 정보
           - prometheus       # 메트릭 데이터 노출
 
   endpoint:
@@ -115,4 +164,3 @@ springdoc:
 
 websocket:
   allowed-origin: ${WEBSOCKET_ALLOWED_ORIGIN}
-

--- a/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/controller/PartyControllerTest.java
@@ -16,6 +16,7 @@ import com.playus.twpservice.domain.party.dto.create.PartyCreateRequest;
 import com.playus.twpservice.domain.party.dto.create.PartyCreateResponse;
 import com.playus.twpservice.domain.common.request.PartyIdRequest;
 import com.playus.twpservice.domain.party.dto.leave.PartyLeaveResponse;
+import com.playus.twpservice.domain.party.dto.participants.PartyParticipantsInfoResponse;
 import com.playus.twpservice.domain.party.dto.update.PartyUpdateRequest;
 import com.playus.twpservice.domain.party.dto.update.PartyUpdateResponse;
 import com.playus.twpservice.domain.party.dto.presigned.PresignedUrlForSaveImageRequest;
@@ -45,7 +46,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 class PartyControllerTest extends ControllerTestSupport {
 
-//    Long userId = 1L;
+    //    Long userId = 1L;
     List<String> thumbnailUrl = List.of("http://image.com");
 //    UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(applicantUserId, null, List.of(new SimpleGrantedAuthority("USER")));
 
@@ -1143,7 +1144,7 @@ class PartyControllerTest extends ControllerTestSupport {
 
     @DisplayName("직관팟을 승인할 때 지원자의 ID는 1 이상이여야 한다.")
     @Test
-    void approveParty_NEGATIVE_APPLICANT() throws Exception {
+    void approveParty_NEGATIVE_APPLICANT_ID() throws Exception {
         // given
         long partyId = 1L;
         PartyApproveRequest request = PartyApproveRequest.of(null, Boolean.TRUE);
@@ -1204,6 +1205,46 @@ class PartyControllerTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$[0].ageGroup").value("10대"))
                 .andExpect(jsonPath("$[0].thumbnailUrl").value("http://image.jpg"))
                 .andExpect(jsonPath("$[0].requireMessage").value("참여 희망합니다!"));
+    }
+
+    @DisplayName("직관팟 참여자를 조회할 수 있다.")
+    @Test
+    void getParticipants() throws Exception {
+        // given
+        long partyId = 1L;
+        given(partyReadOnlyService.getParticipants(any(), any()))
+                .willReturn(List.of(
+                        PartyParticipantsInfoResponse.of(1L, "name"),
+                        PartyParticipantsInfoResponse.of(2L, "name2")
+                ));
+
+        // when // then
+        mockMvc.perform(get("/party/" + partyId + "/participants")
+                        .contentType(APPLICATION_JSON)
+                        .with(authentication(token)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].userId").value(1L))
+                .andExpect(jsonPath("$[0].name").value("name"))
+                .andExpect(jsonPath("$[1].userId").value(2L))
+                .andExpect(jsonPath("$[1].name").value("name2"));
+    }
+
+    @DisplayName("직관팟 참가자를 불러올 때 직관팟의 ID는 1 이상이여야 한다.")
+    @CsvSource(value = {"0", "-1", "-100", "-1000", "-10000"})
+    @ParameterizedTest(name = "invalidPartyIdStr = {0}")
+    void getParticipants_INVALID_PARTYID(String invalidPartyStr) throws Exception {
+        // given
+
+        // when // then
+        mockMvc.perform(get("/party/" + invalidPartyStr + "/participants")
+                        .contentType(APPLICATION_JSON)
+                        .with(authentication(token)))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("400"))
+                .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+                .andExpect(jsonPath("$.message").value("직관팟 ID는 1 이상이어야 합니다!"));
     }
 
 //    @DisplayName("직관팟을 승인할 때 직관팟의 ID는 1 이상이여야 한다.")
@@ -1307,7 +1348,7 @@ class PartyControllerTest extends ControllerTestSupport {
                         AppliedPartyResponse.of(3L, "title3", List.of("50대", "60대 이상"), "상관없음",
                                 "승인 거부됨", 3L, "JUNG", "남성", "40대", "http://image3.jpg", 1L)
 
-                        ));
+                ));
 
         // when // then
         mockMvc.perform(get("/party/applied-parties")

--- a/src/test/java/com/playus/twpservice/domain/party/service/PartyReadOnlyServiceTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/service/PartyReadOnlyServiceTest.java
@@ -1,10 +1,17 @@
 package com.playus.twpservice.domain.party.service;
 
 import com.playus.twpservice.IntegrationTestSupport;
+import com.playus.twpservice.domain.common.security.CustomOAuth2User;
+import com.playus.twpservice.domain.common.security.Gender;
+import com.playus.twpservice.domain.common.security.Role;
+import com.playus.twpservice.domain.common.security.UserDto;
+import com.playus.twpservice.domain.party.document.PartyAgeDocument;
 import com.playus.twpservice.domain.party.document.PartyDocument;
 import com.playus.twpservice.domain.party.document.PartyJoinDocument;
+import com.playus.twpservice.domain.party.document.PartyThumbnailUrlDocument;
 import com.playus.twpservice.domain.party.dto.applieduser.PartyAppliedUserResponse;
 import com.playus.twpservice.domain.party.dto.info.PartyInfoResponse;
+import com.playus.twpservice.domain.party.dto.participants.PartyParticipantsInfoResponse;
 import com.playus.twpservice.domain.party.enums.PartyGender;
 import com.playus.twpservice.domain.party.enums.PartyJoinMethod;
 import com.playus.twpservice.domain.party.enums.PartyJoinRequestStatus;
@@ -320,7 +327,7 @@ class PartyReadOnlyServiceTest extends IntegrationTestSupport {
         List<PartyAppliedUserResponse> response = partyReadOnlyService.getAppliedUsers(userId, p1.getId());
 
         // then
-        assertThat(response).hasSize(0);
+        assertThat(response).isEmpty();
     }
 
 //    @DisplayName("자신이 지원한 직관팟 정보를 가져올 수 있다.")
@@ -381,4 +388,129 @@ class PartyReadOnlyServiceTest extends IntegrationTestSupport {
 //                        tuple(2L, "title2", List.of("30대", "40대"), "여자만", "신청중", userId + 2, "writer2", "여성", "20대", "http://writer2-thumbnail", 1L)
 //                );
 //    }
+
+    @DisplayName("직관팟 참가자를 조회할 수 있다.")
+    @Test
+    void getParticipants() {
+        // given
+        Long userId = 1L;
+        Long matchId = 1L;
+
+        UserDto userDto = UserDto.createForTest(userId, "nickname", Gender.FEMALE, Role.USER, "http://image.com", 20);
+        CustomOAuth2User customOAuth2User = new CustomOAuth2User(userDto, "accesstoken");
+
+        List<PartyDocument> partyDocuments = partyReadOnlyRepository.saveAll(List.of(
+                PartyDocument.createForOnlyTest(1L, "title1", "text1", 1L, 10L, 1L,
+                        PartyGender.MALE, PartyJoinMethod.FIRST_COME, userId, matchId, 1L), // 대상
+
+                PartyDocument.createForOnlyTest(2L, "title2", "text2", 1L, 10L, 1L,
+                        PartyGender.FEMALE, PartyJoinMethod.RESERVATION, userId + 2, matchId + 1, 2L)
+        ));
+
+        partyAgeReadOnlyRepository.saveAll(List.of(
+                PartyAgeDocument.createForOnlyTest(1L, partyDocuments.get(0).getId(), 10),
+                PartyAgeDocument.createForOnlyTest(2L, partyDocuments.get(0).getId(), 20),
+                PartyAgeDocument.createForOnlyTest(3L, partyDocuments.get(1).getId(), 30),
+                PartyAgeDocument.createForOnlyTest(4L, partyDocuments.get(1).getId(), 40)
+        ));
+
+        partyJoinReadOnlyRepository.saveAll(List.of(
+
+                // 대상
+                PartyJoinDocument.createForOnlyTest(1L, userId + 1, partyDocuments.get(0).getId(), PartyJoinRequestStatus.ACCEPT, null),
+
+                // 대상
+                PartyJoinDocument.createForOnlyTest(2L, userId + 2, partyDocuments.get(0).getId(), PartyJoinRequestStatus.ACCEPT, "가입 원합니다!"),
+
+                PartyJoinDocument.createForOnlyTest(3L, userId + 3, partyDocuments.get(0).getId(), PartyJoinRequestStatus.WAIT, "가입 원합니다!")
+        ));
+
+        given(userFeignClient.getPartyApplicantsInfo(List.of(userId + 1, userId + 2))).willReturn(List.of(
+                PartyParticipantsInfoFeignResponse.of(userId + 1, "writer1",   17,"http://writer1-thumbnail"),
+                PartyParticipantsInfoFeignResponse.of(userId + 2, "writer2", 26, "http://writer2-thumbnail")
+        ));
+
+        partyThumbnailUrlReadOnlyRepository.saveAll(List.of(
+                PartyThumbnailUrlDocument.createForOnlyTest(1L, partyDocuments.get(0).getId(), "thumbnailUrl1"),
+                PartyThumbnailUrlDocument.createForOnlyTest(2L, partyDocuments.get(0).getId(), "thumbnailUrl2")
+        ));
+
+        // when
+        List<PartyParticipantsInfoResponse> result = partyReadOnlyService.getParticipants(customOAuth2User, partyDocuments.get(0).getId());
+
+        // then
+        assertThat(result).hasSize(2)
+                .extracting("userId", "name")
+                .containsExactlyInAnyOrder(
+                        tuple(userId + 1, "writer1"),
+                        tuple(userId + 2, "writer2")
+                );
+    }
+
+    @DisplayName("존재하지 않는 직관팟에 대한 참가자를 조회할 수 없다")
+    @Test
+    void getParticipants_INVALID_PARTY() {
+        // given
+        Long userId = 1L;
+
+        UserDto userDto = UserDto.createForTest(userId, "nickname", Gender.FEMALE, Role.USER, "http://image.com", 20);
+        CustomOAuth2User customOAuth2User = new CustomOAuth2User(userDto, "accesstoken");
+
+        // when // then
+        assertThatThrownBy(() -> partyReadOnlyService.getParticipants(customOAuth2User, 1L))
+                .isInstanceOf(PartyDocumentException.NotFoundException.class)
+                .hasMessage("직관팟이 존재하지 않습니다!");
+    }
+
+    @DisplayName("직관팟 참가자를 조회할 때, 본인은 반드시 그 직관팟에 참여되어 있어야 한다.")
+    @Test
+    void getParticipants_MUST_PARTICIPATE() {
+        // given
+        Long userId = 1L;
+        Long matchId = 1L;
+
+        UserDto userDto = UserDto.createForTest(userId + 1000, "nickname", Gender.FEMALE, Role.USER, "http://image.com", 20);
+        CustomOAuth2User customOAuth2User = new CustomOAuth2User(userDto, "accesstoken");
+
+        List<PartyDocument> partyDocuments = partyReadOnlyRepository.saveAll(List.of(
+                PartyDocument.createForOnlyTest(1L, "title1", "text1", 1L, 10L, 1L,
+                        PartyGender.MALE, PartyJoinMethod.FIRST_COME, userId, matchId, 1L), // 대상
+
+                PartyDocument.createForOnlyTest(2L, "title2", "text2", 1L, 10L, 1L,
+                        PartyGender.FEMALE, PartyJoinMethod.RESERVATION, userId + 2, matchId + 1, 2L)
+        ));
+
+        partyAgeReadOnlyRepository.saveAll(List.of(
+                PartyAgeDocument.createForOnlyTest(1L, partyDocuments.get(0).getId(), 10),
+                PartyAgeDocument.createForOnlyTest(2L, partyDocuments.get(0).getId(), 20),
+                PartyAgeDocument.createForOnlyTest(3L, partyDocuments.get(1).getId(), 30),
+                PartyAgeDocument.createForOnlyTest(4L, partyDocuments.get(1).getId(), 40)
+        ));
+
+        partyJoinReadOnlyRepository.saveAll(List.of(
+
+                // 대상
+                PartyJoinDocument.createForOnlyTest(1L, userId + 1, partyDocuments.get(0).getId(), PartyJoinRequestStatus.ACCEPT, null),
+
+                // 대상
+                PartyJoinDocument.createForOnlyTest(2L, userId + 2, partyDocuments.get(0).getId(), PartyJoinRequestStatus.ACCEPT, "가입 원합니다!"),
+
+                PartyJoinDocument.createForOnlyTest(3L, userId + 3, partyDocuments.get(0).getId(), PartyJoinRequestStatus.WAIT, "가입 원합니다!")
+        ));
+
+        given(userFeignClient.getPartyApplicantsInfo(List.of(userId + 1, userId + 2))).willReturn(List.of(
+                PartyParticipantsInfoFeignResponse.of(userId + 1, "writer1",   17,"http://writer1-thumbnail"),
+                PartyParticipantsInfoFeignResponse.of(userId + 2, "writer2", 26, "http://writer2-thumbnail")
+        ));
+
+        partyThumbnailUrlReadOnlyRepository.saveAll(List.of(
+                PartyThumbnailUrlDocument.createForOnlyTest(1L, partyDocuments.get(0).getId(), "thumbnailUrl1"),
+                PartyThumbnailUrlDocument.createForOnlyTest(2L, partyDocuments.get(0).getId(), "thumbnailUrl2")
+        ));
+
+        // when // then
+        assertThatThrownBy(() -> partyReadOnlyService.getParticipants(customOAuth2User, 1L))
+                .isInstanceOf(PartyException.ParticipantsNotFoundException.class)
+                .hasMessage("이 직관팟에 참여하지 않은 인원입니다!");
+    }
 }

--- a/src/test/java/com/playus/twpservice/domain/party/service/PartyReadOnlyServiceTest.java
+++ b/src/test/java/com/playus/twpservice/domain/party/service/PartyReadOnlyServiceTest.java
@@ -426,8 +426,8 @@ class PartyReadOnlyServiceTest extends IntegrationTestSupport {
         ));
 
         given(userFeignClient.getPartyApplicantsInfo(List.of(userId + 1, userId + 2))).willReturn(List.of(
-                PartyParticipantsInfoFeignResponse.of(userId + 1, "writer1",   17,"http://writer1-thumbnail"),
-                PartyParticipantsInfoFeignResponse.of(userId + 2, "writer2", 26, "http://writer2-thumbnail")
+                PartyParticipantsInfoFeignResponse.of(userId + 2, "writer2", 26, "http://writer2-thumbnail"),
+                PartyParticipantsInfoFeignResponse.of(userId + 1, "writer1",   17,"http://writer1-thumbnail")
         ));
 
         partyThumbnailUrlReadOnlyRepository.saveAll(List.of(


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용

직관팟 종료 후 참가자 평가 위한 내부 인원 조회 API를 구현했습니다.
![image](https://github.com/user-attachments/assets/23dc7d46-b1b9-43b5-aed2-18f4b3ad98ba)

---

## 🔗 관련 이슈
- closes #67 

---

## 💡 추가 사항

dev, prod profile을 user-service 참고해서 최신화했고, `RedisClusterConfig` 랑 `CorsConfig` 를 최신화햇습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 특정 파티의 참가자 목록을 조회할 수 있는 엔드포인트가 추가되었습니다. (로그인 사용자는 제외)
- **버그 수정**
  - 참가자가 아닌 사용자가 참가자 목록을 조회할 경우 404 오류가 반환됩니다.
- **테스트**
  - 참가자 조회 엔드포인트 및 유효하지 않은 파티 ID에 대한 테스트가 추가되었습니다.
  - 참가자 조회 서비스의 정상 및 예외 처리 케이스에 대한 단위 테스트가 보강되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->