### PR TITLE
CS-435 refactor : dev 내 partyThumbnailUrl collection 구조에 맞게 document 및 조회 코드 변경

### DIFF
--- a/src/main/java/com/playus/twpservice/domain/party/document/PartyThumbnailUrlDocument.java
+++ b/src/main/java/com/playus/twpservice/domain/party/document/PartyThumbnailUrlDocument.java
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-@Document(collection = "party_thumbnailurl")
+@Document(collection = "party_thumbnail_url")
 public class PartyThumbnailUrlDocument {
 
     @Id
@@ -26,6 +26,7 @@ public class PartyThumbnailUrlDocument {
     private Long partyId;
 
     @NotNull
+    @Field(name = "thumbnail_url")
     private String thumbnailUrl;
 
     private LocalDateTime createdAt;

--- a/src/main/java/com/playus/twpservice/domain/party/repository/read/custom/PartyReadOnlyRepositoryCustomImpl.java
+++ b/src/main/java/com/playus/twpservice/domain/party/repository/read/custom/PartyReadOnlyRepositoryCustomImpl.java
@@ -61,7 +61,7 @@ public class PartyReadOnlyRepositoryCustomImpl implements PartyReadOnlyRepositor
 
         AggregationOperation partyThumbnailUrlLookupOperation = context -> new Document(
                 "$lookup",
-                new Document("from", "party_thumbnailurl")
+                new Document("from", "party_thumbnail_url")
                         .append("let", new Document("partyId", "$_id"))
                         .append("pipeline", Arrays.asList(
                                 new Document("$match", new Document("$expr", new Document("$and", Arrays.asList(
@@ -83,7 +83,7 @@ public class PartyReadOnlyRepositoryCustomImpl implements PartyReadOnlyRepositor
                 .and("party_gender").as("partyGender")
                 .and("maximum_participants").as("maximumParticipants")
                 .and("partyAge.age").as("ages")
-                .and("partyThumbnailUrl.thumbnailUrl").as("thumbnailUrls");
+                .and("partyThumbnailUrl.thumbnail_url").as("thumbnailUrls");
 
         Aggregation aggregation = newAggregation(
                 matchOperation,
@@ -132,7 +132,7 @@ public class PartyReadOnlyRepositoryCustomImpl implements PartyReadOnlyRepositor
 
         AggregationOperation partyThumbnailUrlLookupOperation = context -> new Document(
                 "$lookup",
-                new Document("from", "party_thumbnailurl")
+                new Document("from", "party_thumbnail_url")
                         .append("let", new Document("partyId", "$_id"))
                         .append("pipeline", Arrays.asList(
                                 new Document("$match", new Document("$expr", new Document("$and", Arrays.asList(
@@ -156,7 +156,7 @@ public class PartyReadOnlyRepositoryCustomImpl implements PartyReadOnlyRepositor
                 .and("party_gender").as("partyGender")
                 .and("maximum_participants").as("maximumParticipants")
                 .and("partyAge.age").as("ages")
-                .and("partyThumbnailUrl.thumbnailUrl").as("thumbnailUrls");
+                .and("partyThumbnailUrl.thumbnail_url").as("thumbnailUrls");
 
         Aggregation aggregation = Aggregation.newAggregation(
                 matchOperation,


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
16시경 CDC 에러 해결로 재생성된 `party_thumbnail_url` 컬렉션 대해 관련 코드를 수정했고 직관팟 조회 API 대한 테스트를 재진행했습니다

![image](https://github.com/user-attachments/assets/61dd7ccb-3abd-4717-b901-c2b679ad8d57)

![image](https://github.com/user-attachments/assets/3afc6ce7-c38b-430e-94bd-767776169f85)


---

## 🔗 관련 이슈
- closes #75 

---

## 💡 추가 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 썸네일 관련 정보 조회 시 일관된 컬렉션 및 필드명이 적용되어 데이터 표시 오류가 해결되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->